### PR TITLE
Implement the create-device-wearer endpoint.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/DeviceWearer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/DeviceWearer.kt
@@ -1,0 +1,32 @@
+package uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.time.LocalDate
+import java.util.UUID
+
+@Entity
+@Table(name = "DEVICE_WEARER")
+data class DeviceWearer(
+
+  @Id
+  @Column(name = "ID", nullable = false, unique = true)
+  val id: UUID = UUID.randomUUID(),
+
+  @Column(name = "ORDER_ID", nullable = false, unique = true)
+  val orderId: UUID,
+
+  @Column(name = "FIRST_NAME", nullable = true)
+  var firstName: String? = null,
+
+  @Column(name = "LAST_NAME", nullable = true)
+  var lastName: String? = null,
+
+  @Column(name = "GENDER", nullable = true)
+  var gender: String? = null,
+
+  @Column(name = "DATE_OF_BIRTH", nullable = true)
+  var dateOfBirth: LocalDate? = null,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/repository/DeviceWearerRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/repository/DeviceWearerRepository.kt
@@ -1,0 +1,9 @@
+package uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.DeviceWearer
+import java.util.UUID
+
+@Repository
+interface DeviceWearerRepository : JpaRepository<DeviceWearer, UUID>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/resource/DeviceWearerController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/resource/DeviceWearerController.kt
@@ -15,7 +15,7 @@ import java.util.UUID
 
 @RestController
 // TODO: Replace with CEMO Role one created
-@PreAuthorize("hasRole('ROLE_COMMUNITY')")
+@PreAuthorize("hasRole('ROLE_EM_CEMO__CREATE_DEVICE_WEARER')")
 @RequestMapping("/api/")
 class DeviceWearerController(
   @Autowired val deviceWearerService: DeviceWearerService,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/resource/DeviceWearerController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/resource/DeviceWearerController.kt
@@ -1,0 +1,35 @@
+package uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.resource
+
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.DeviceWearer
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.service.DeviceWearerService
+import java.time.LocalDate
+import java.util.UUID
+
+@RestController
+// TODO: Replace with CEMO Role one created
+@PreAuthorize("hasRole('ROLE_COMMUNITY')")
+@RequestMapping("/api/")
+class DeviceWearerController(
+  @Autowired val deviceWearerService: DeviceWearerService,
+) {
+
+  @GetMapping("/CreateDeviceWearer")
+  fun createDeviceWearer(
+    @RequestParam("orderId") orderId: UUID,
+    @RequestParam("firstName") firstName: String? = null,
+    @RequestParam("lastName") lastName: String? = null,
+    @RequestParam("gender") gender: String? = null,
+    @RequestParam("dateOfBirth") dateOfBirth: LocalDate? = null,
+  ): ResponseEntity<DeviceWearer> {
+    val deviceWearer = deviceWearerService.createDeviceWearer(orderId, firstName, lastName, gender, dateOfBirth)
+    return ResponseEntity(deviceWearer, HttpStatus.OK)
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/DeviceWearerService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/DeviceWearerService.kt
@@ -1,0 +1,19 @@
+package uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.service
+
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.DeviceWearer
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.repository.DeviceWearerRepository
+import java.time.LocalDate
+import java.util.UUID
+
+@Service
+class DeviceWearerService(
+  val repo: DeviceWearerRepository,
+) {
+
+  fun createDeviceWearer(orderId: UUID, firstName: String? = null, lastName: String? = null, gender: String? = null, dateOfBirth: LocalDate? = null): DeviceWearer {
+    val deviceWearer = DeviceWearer(orderId = orderId, firstName = firstName, lastName = lastName, gender = gender, dateOfBirth = dateOfBirth)
+    repo.save(deviceWearer)
+    return deviceWearer
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/IntegrationTestBase.kt
@@ -24,12 +24,12 @@ abstract class IntegrationTestBase {
 
   internal fun setAuthorisation(
     username: String? = "AUTH_ADM",
-    roles: List<String> = listOf("ROLE_EM_CEMO__CREATE_ORDER"),
+    roles: List<String> = listOf("ROLE_EM_CEMO__CREATE_ORDER", "ROLE_EM_CEMO__CREATE_DEVICE_WEARER"),
     scopes: List<String> = listOf("read"),
   ): (HttpHeaders) -> Unit = jwtAuthHelper.setAuthorisationHeader(username = username, scope = scopes, roles = roles)
 
   internal fun setAuthorisationWithoutUsername(
-    roles: List<String> = listOf("ROLE_EM_CEMO__CREATE_ORDER"),
+    roles: List<String> = listOf("ROLE_EM_CEMO__CREATE_ORDER", "ROLE_EM_CEMO__CREATE_DEVICE_WEARER"),
     scopes: List<String> = listOf("read"),
   ): (HttpHeaders) -> Unit = jwtAuthHelper.setAuthorisationHeader(scope = scopes, roles = roles)
   protected fun stubPingWithResponse(status: Int) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/DeviceWearerControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/DeviceWearerControllerTest.kt
@@ -1,0 +1,71 @@
+package uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.integration.resource
+
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.DeviceWearer
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.repository.DeviceWearerRepository
+import java.time.LocalDate
+import java.util.*
+
+class DeviceWearerControllerTest : IntegrationTestBase() {
+  @Autowired
+  lateinit var repo: DeviceWearerRepository
+  private lateinit var mockOrderId: UUID
+  private val mockFirstName: String = "mockFirstName"
+  private val mockLastName: String = "mockLastName"
+  private val mockGender: String = "mockGender"
+  private val mockDateOfBirth: LocalDate = LocalDate.of(1970, 1, 1)
+  @BeforeEach
+  fun setup() {
+    repo.deleteAll()
+    mockOrderId = UUID.randomUUID()
+  }
+
+  @Test
+  fun `Device wearer created and saved in database without device wearer details`() {
+    val result = webTestClient.get()
+      .uri("/api/CreateDeviceWearer?orderId=$mockOrderId")
+      .headers(setAuthorisation())
+      .exchange()
+      .expectStatus()
+      .isOk
+      .expectBody(DeviceWearer::class.java)
+
+    val deviceWearers = repo.findAll()
+    Assertions.assertThat(deviceWearers).hasSize(1)
+    Assertions.assertThat(deviceWearers[0]).isEqualTo(result.returnResult().responseBody)
+    Assertions.assertThat(deviceWearers[0].id).isNotNull()
+    Assertions.assertThat(UUID.fromString(deviceWearers[0].id.toString())).isEqualTo(deviceWearers[0].id)
+    Assertions.assertThat(deviceWearers[0].orderId).isEqualTo(mockOrderId)
+    Assertions.assertThat(deviceWearers[0].firstName).isNull()
+    Assertions.assertThat(deviceWearers[0].lastName).isNull()
+    Assertions.assertThat(deviceWearers[0].gender).isNull()
+    Assertions.assertThat(deviceWearers[0].dateOfBirth).isNull()
+  }
+
+  @Test
+  fun `Device wearer created and saved in database with device wearer details`() {
+
+    val result = webTestClient.get()
+      .uri("/api/CreateDeviceWearer?orderId=$mockOrderId&firstName=$mockFirstName&lastName=$mockLastName&gender=$mockGender&dateOfBirth=$mockDateOfBirth")
+      .headers(setAuthorisation())
+      .exchange()
+      .expectStatus()
+      .isOk
+      .expectBody(DeviceWearer::class.java)
+
+    val deviceWearers = repo.findAll()
+    Assertions.assertThat(deviceWearers).hasSize(1)
+    Assertions.assertThat(deviceWearers[0]).isEqualTo(result.returnResult().responseBody)
+    Assertions.assertThat(deviceWearers[0].id).isNotNull()
+    Assertions.assertThat(UUID.fromString(deviceWearers[0].id.toString())).isEqualTo(deviceWearers[0].id)
+    Assertions.assertThat(deviceWearers[0].orderId).isEqualTo(mockOrderId)
+    Assertions.assertThat(deviceWearers[0].firstName).isEqualTo(mockFirstName)
+    Assertions.assertThat(deviceWearers[0].lastName).isEqualTo(mockLastName)
+    Assertions.assertThat(deviceWearers[0].gender).isEqualTo(mockGender)
+    Assertions.assertThat(deviceWearers[0].dateOfBirth).isEqualTo(mockDateOfBirth)
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/DeviceWearerControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/DeviceWearerControllerTest.kt
@@ -18,6 +18,7 @@ class DeviceWearerControllerTest : IntegrationTestBase() {
   private val mockLastName: String = "mockLastName"
   private val mockGender: String = "mockGender"
   private val mockDateOfBirth: LocalDate = LocalDate.of(1970, 1, 1)
+
   @BeforeEach
   fun setup() {
     repo.deleteAll()
@@ -48,7 +49,6 @@ class DeviceWearerControllerTest : IntegrationTestBase() {
 
   @Test
   fun `Device wearer created and saved in database with device wearer details`() {
-
     val result = webTestClient.get()
       .uri("/api/CreateDeviceWearer?orderId=$mockOrderId&firstName=$mockFirstName&lastName=$mockLastName&gender=$mockGender&dateOfBirth=$mockDateOfBirth")
       .headers(setAuthorisation())

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/resources/DeviceWearerControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/resources/DeviceWearerControllerTest.kt
@@ -1,0 +1,41 @@
+package uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.resources
+
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import org.springframework.boot.test.autoconfigure.json.JsonTest
+import org.springframework.security.core.Authentication
+import org.springframework.test.context.ActiveProfiles
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.DeviceWearer
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.resource.DeviceWearerController
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.service.DeviceWearerService
+import java.util.*
+
+@ActiveProfiles("test")
+@JsonTest
+class DeviceWearerControllerTest {
+  private val deviceWearerService: DeviceWearerService = mock()
+  private val controller = DeviceWearerController(deviceWearerService)
+  private lateinit var authentication: Authentication
+  private lateinit var mockOrderId: UUID
+
+  @BeforeEach
+  fun setup() {
+    authentication = mock(Authentication::class.java)
+    mockOrderId = UUID.randomUUID()
+  }
+
+  @Test
+  fun `create a new device wearer and return`() {
+    val mockDeviceWearer = DeviceWearer(orderId = mockOrderId)
+    `when`(deviceWearerService.createDeviceWearer(mockOrderId)).thenReturn(mockDeviceWearer)
+    `when`(authentication.name).thenReturn("mockUser")
+
+    val result = controller.createDeviceWearer(mockOrderId)
+
+    Assertions.assertThat(result.statusCode.is2xxSuccessful)
+    Assertions.assertThat(result.body).isEqualTo(mockDeviceWearer)
+  }
+}

--- a/src/test/resources/db/migration/V1_0_0__create_ORDER_FORM_table.sql
+++ b/src/test/resources/db/migration/V1_0_0__create_ORDER_FORM_table.sql
@@ -1,9 +1,7 @@
 
-
 CREATE TABLE IF NOT EXISTS ORDER_FORM(
     ID UUID primary key,
     TITLE varchar(200),
     USER_NAME varchar(240) NOT NULL,
     STATUS varchar(15)
 );
-

--- a/src/test/resources/db/migration/V1_1_0__create_DEVICE_WEARER_table.sql
+++ b/src/test/resources/db/migration/V1_1_0__create_DEVICE_WEARER_table.sql
@@ -1,0 +1,7 @@
+
+CREATE TABLE IF NOT EXISTS DEVICE_WEARER(
+    ID UUID primary key,
+    TITLE varchar(200),
+    USER_NAME varchar(240) NOT NULL,
+    STATUS varchar(15)
+);


### PR DESCRIPTION
- Adds a `create-device-wearer` endpoint to the CEMO API
- Adds unit & integration tests for this endpoint