### PR TITLE
Allow a Notifying Organisation to enter addresses

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/DeviceWearer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/DeviceWearer.kt
@@ -6,7 +6,6 @@ import jakarta.persistence.Entity
 import jakarta.persistence.FetchType
 import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
-import jakarta.persistence.OneToMany
 import jakarta.persistence.OneToOne
 import jakarta.persistence.Table
 import jakarta.validation.constraints.Past
@@ -70,7 +69,4 @@ data class DeviceWearer(
 
   @OneToOne(fetch = FetchType.LAZY, cascade = [ALL], mappedBy = "deviceWearer", orphanRemoval = true)
   var alternativeContactDetails: AlternativeContractDetails? = null,
-
-  @OneToMany(fetch = FetchType.LAZY, cascade = [ALL], mappedBy = "deviceWearer", orphanRemoval = true)
-  var deviceWearerAddresses: MutableList<DeviceWearerAddress> = mutableListOf(),
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/DeviceWearerAddress.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/DeviceWearerAddress.kt
@@ -20,8 +20,8 @@ data class DeviceWearerAddress(
   @Column(name = "ID", nullable = false, unique = true)
   val id: UUID = UUID.randomUUID(),
 
-  @Column(name = "DEVICE_WEARER_ID", nullable = false)
-  val deviceWearerId: UUID,
+  @Column(name = "ORDER_ID", nullable = false)
+  val orderId: UUID,
 
   @Column(name = "ADDRESS_LINE_1", nullable = true)
   var addressLine1: String? = null,
@@ -47,6 +47,6 @@ data class DeviceWearerAddress(
   var addressUsage: DeviceWearerAddressUsage? = DeviceWearerAddressUsage.NA,
 
   @ManyToOne
-  @JoinColumn(name = "DEVICE_WEARER_ID", updatable = false, insertable = false)
-  private val deviceWearer: DeviceWearer? = null,
+  @JoinColumn(name = "ORDER_ID", updatable = false, insertable = false)
+  private val order: OrderForm? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/OrderForm.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/OrderForm.kt
@@ -10,6 +10,7 @@ import jakarta.persistence.Id
 import jakarta.persistence.OneToMany
 import jakarta.persistence.OneToOne
 import jakarta.persistence.Table
+import jakarta.validation.constraints.Size
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.FormStatus
 import java.util.UUID
 
@@ -40,6 +41,10 @@ data class OrderForm(
   @OneToOne(fetch = FetchType.LAZY, cascade = [ALL], mappedBy = "order", orphanRemoval = true)
   var deviceWearerContactDetails: DeviceWearerContactDetails? = null,
 
+  @OneToMany(fetch = FetchType.LAZY, cascade = [ALL], mappedBy = "order", orphanRemoval = true)
+  @Size(min = 0, max = 3)
+  var deviceWearerAddresses: MutableList<DeviceWearerAddress> = mutableListOf(),
+
   @OneToOne(fetch = FetchType.LAZY, cascade = [ALL], mappedBy = "orderForm", orphanRemoval = true)
   var monitoringConditions: MonitoringConditions? = null,
 
@@ -48,5 +53,4 @@ data class OrderForm(
 
   @OneToMany(fetch = FetchType.LAZY, cascade = [ALL], mappedBy = "order", orphanRemoval = true)
   var additionalDocuments: MutableList<AdditionalDocument> = mutableListOf(),
-
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/enums/DeviceWearerAddressType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/enums/DeviceWearerAddressType.kt
@@ -2,6 +2,6 @@ package uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.m
 
 enum class DeviceWearerAddressType {
   PRIMARY,
-  SECOND,
-  THIRD,
+  SECONDARY,
+  TERTIARY,
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/fms/DeviceWearer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/fms/DeviceWearer.kt
@@ -130,7 +130,7 @@ data class DeviceWearer(
       if (!order.deviceWearer?.adultAtTimeOfInstallation!!) {
         adultChild = "child"
       }
-      val primaryAddress = order.deviceWearer?.deviceWearerAddresses?.find { address -> address.addressType == DeviceWearerAddressType.PRIMARY }!!
+      val primaryAddress = order.deviceWearerAddresses?.find { address -> address.addressType == DeviceWearerAddressType.PRIMARY }!!
       val disabilities = order.deviceWearer?.disabilities?.split(',')?.map { disability -> Disability(disability) }?.toList()
       val deviceWearer = DeviceWearer(
         firstName = order.deviceWearer?.firstName,
@@ -156,7 +156,7 @@ data class DeviceWearer(
         parent = "${order.deviceWearer?.responsibleAdult?.fullName}",
         parentPhoneNumber = order.deviceWearer?.responsibleAdult?.contactNumber,
       )
-      order.deviceWearer?.deviceWearerAddresses?.find { address -> address.addressType == DeviceWearerAddressType.SECOND }.let { address ->
+      order.deviceWearerAddresses?.find { address -> address.addressType == DeviceWearerAddressType.SECOND }.let { address ->
         {
           if (address != null) {
             deviceWearer.secondaryAddress1 = address.addressLine1

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/fms/DeviceWearer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/fms/DeviceWearer.kt
@@ -156,7 +156,7 @@ data class DeviceWearer(
         parent = "${order.deviceWearer?.responsibleAdult?.fullName}",
         parentPhoneNumber = order.deviceWearer?.responsibleAdult?.contactNumber,
       )
-      order.deviceWearerAddresses?.find { address -> address.addressType == DeviceWearerAddressType.SECOND }.let { address ->
+      order.deviceWearerAddresses?.find { address -> address.addressType == DeviceWearerAddressType.SECONDARY }.let { address ->
         {
           if (address != null) {
             deviceWearer.secondaryAddress1 = address.addressLine1

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/repository/DeviceWearerAddressRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/repository/DeviceWearerAddressRepository.kt
@@ -1,0 +1,18 @@
+package uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.DeviceWearerAddress
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.DeviceWearerAddressType
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.FormStatus
+import java.util.*
+
+@Repository
+interface DeviceWearerAddressRepository : JpaRepository<DeviceWearerAddress, UUID> {
+  fun findByOrderIdAndOrderUsernameAndOrderStatusAndAddressType(
+    id: UUID,
+    username: String,
+    status: FormStatus,
+    addressType: DeviceWearerAddressType,
+  ): Optional<DeviceWearerAddress>
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/repository/OrderFormRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/repository/OrderFormRepository.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.r
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.OrderForm
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.FormStatus
 import java.util.*
 
 @Repository
@@ -14,5 +15,11 @@ interface OrderFormRepository : JpaRepository<OrderForm, UUID> {
   fun findByUsernameAndId(
     username: String,
     id: UUID,
+  ): Optional<OrderForm>
+
+  fun findByIdAndUsernameAndStatus(
+    id: UUID,
+    username: String,
+    status: FormStatus,
   ): Optional<OrderForm>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/resource/DeviceWearerAddressController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/resource/DeviceWearerAddressController.kt
@@ -1,0 +1,75 @@
+package uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.resource
+
+import jakarta.validation.Valid
+import jakarta.validation.constraints.AssertTrue
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.security.core.Authentication
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.DeviceWearerAddress
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.DeviceWearerAddressType
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.service.DeviceWearerAddressService
+import java.util.*
+
+@RestController
+@PreAuthorize("hasRole('ROLE_EM_CEMO__CREATE_ORDER')")
+@RequestMapping("/api/")
+class DeviceWearerAddressController(
+  @Autowired val deviceWearerAddressService: DeviceWearerAddressService,
+) {
+
+  @PostMapping("/order/{orderId}/address")
+  fun updateContactDetails(
+    @PathVariable orderId: UUID,
+    @RequestBody @Valid deviceWearerAddressUpdateRecord: UpdateDeviceWearerAddressDto,
+    authentication: Authentication,
+  ): ResponseEntity<DeviceWearerAddress> {
+    val username = authentication.name
+    val address = deviceWearerAddressService.createOrUpdateAddress(
+      orderId,
+      username,
+      deviceWearerAddressUpdateRecord,
+    )
+
+    return ResponseEntity(address, HttpStatus.OK)
+  }
+}
+
+data class UpdateDeviceWearerAddressDto(
+  val addressType: DeviceWearerAddressType,
+  val addressLine1: String,
+  val addressLine2: String,
+  val addressLine3: String,
+  val addressLine4: String,
+  val postCode: String,
+) {
+  @AssertTrue(message = "Address line 1 is required")
+  fun isAddressLine1(): Boolean {
+    if (this.addressType === DeviceWearerAddressType.PRIMARY) {
+      return this.addressLine1.isNotBlank()
+    }
+    return true
+  }
+
+  @AssertTrue(message = "Address line 2 is required")
+  fun isAddressLine2(): Boolean {
+    if (this.addressType === DeviceWearerAddressType.PRIMARY) {
+      return this.addressLine2.isNotBlank()
+    }
+    return true
+  }
+
+  @AssertTrue(message = "Post code is required")
+  fun isPostCode(): Boolean {
+    if (this.addressType === DeviceWearerAddressType.PRIMARY) {
+      return this.postCode.isNotBlank()
+    }
+    return true
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/DeviceWearerAddressService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/DeviceWearerAddressService.kt
@@ -1,0 +1,42 @@
+package uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.service
+
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.DeviceWearerAddress
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.FormStatus
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.repository.DeviceWearerAddressRepository
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.resource.UpdateDeviceWearerAddressDto
+import java.util.UUID
+
+@Service
+class DeviceWearerAddressService(
+  val repo: DeviceWearerAddressRepository,
+) {
+  fun createOrUpdateAddress(
+    orderId: UUID,
+    username: String,
+    deviceWearerAddressUpdateRecord: UpdateDeviceWearerAddressDto,
+  ): DeviceWearerAddress {
+    // BAD LOGIC - will allow creation of address against submitted order or another user's order
+    val address = repo.findByOrderIdAndOrderUsernameAndOrderStatusAndAddressType(
+      orderId,
+      username,
+      FormStatus.IN_PROGRESS,
+      deviceWearerAddressUpdateRecord.addressType,
+    ).orElse(
+      DeviceWearerAddress(
+        orderId = orderId,
+        addressType = deviceWearerAddressUpdateRecord.addressType,
+      ),
+    )
+
+    with(deviceWearerAddressUpdateRecord) {
+      address.addressLine1 = addressLine1
+      address.addressLine2 = addressLine2
+      address.addressLine3 = addressLine3
+      address.addressLine4 = addressLine4
+      address.postcode = postCode
+    }
+
+    return repo.save(address)
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/DeviceWearerAddressService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/DeviceWearerAddressService.kt
@@ -20,6 +20,7 @@ class DeviceWearerAddressService(
     username: String,
     addressType: DeviceWearerAddressType,
   ): DeviceWearerAddress {
+    // Verify the order belongs to the user and is in draft state
     val order = orderRepo.findByIdAndUsernameAndStatus(
       orderId,
       username,
@@ -28,6 +29,7 @@ class DeviceWearerAddressService(
       EntityNotFoundException("Order with id $orderId does not exist")
     }
 
+    // Find an existing address or create a new address
     return addressRepo.findByOrderIdAndOrderUsernameAndOrderStatusAndAddressType(
       order.id,
       order.username,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/OrderFormService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/OrderFormService.kt
@@ -24,6 +24,7 @@ class OrderFormService(
       status = FormStatus.IN_PROGRESS,
     )
     orderForm.deviceWearer = DeviceWearer(orderId = orderForm.id)
+    orderForm.deviceWearerAddresses = mutableListOf()
     orderForm.deviceWearerContactDetails = DeviceWearerContactDetails(orderId = orderForm.id)
     orderForm.monitoringConditions = MonitoringConditions(orderId = orderForm.id)
     orderForm.additionalDocuments = mutableListOf()

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -10,8 +10,8 @@ spring:
 
 services:
   hmppsauth:
-    #url: http://localhost:9090/auth
-    url: https://sign-in-dev.hmpps.service.justice.gov.uk/auth
+    url: http://localhost:9090/auth
+    #url: https://sign-in-dev.hmpps.service.justice.gov.uk/auth
 
 DOCUMENT_MANAGEMENT_URL:  http://localhost:8081/
 #DOCUMENT_MANAGEMENT_URL:  https://document-api-dev.hmpps.service.justice.gov.uk/

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -10,8 +10,8 @@ spring:
 
 services:
   hmppsauth:
-    url: http://localhost:9090/auth
-    #url: https://sign-in-dev.hmpps.service.justice.gov.uk/auth
+    #url: http://localhost:9090/auth
+    url: https://sign-in-dev.hmpps.service.justice.gov.uk/auth
 
 DOCUMENT_MANAGEMENT_URL:  http://localhost:8081/
 #DOCUMENT_MANAGEMENT_URL:  https://document-api-dev.hmpps.service.justice.gov.uk/

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/DeviceWearerAddressControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/DeviceWearerAddressControllerTest.kt
@@ -8,11 +8,8 @@ import org.springframework.http.MediaType
 import org.springframework.web.reactive.function.BodyInserters
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.DeviceWearerAddress
-import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.DeviceWearerContactDetails
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.DeviceWearerAddressType
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.DeviceWearerAddressUsage
-import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.FormStatus
-import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.repository.DeviceWearerContactDetailsRepository
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.repository.DeviceWearerAddressRepository
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.repository.OrderFormRepository
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.resource.validator.ValidationError
@@ -56,8 +53,8 @@ class DeviceWearerAddressControllerTest : IntegrationTestBase() {
               "addressLine4": "$mockAddressLine4",
               "postCode": "$mockPostCode"
             }
-          """.trimIndent()
-        )
+          """.trimIndent(),
+        ),
       )
       .headers(setAuthorisation("AUTH_ADM"))
       .exchange()
@@ -96,8 +93,8 @@ class DeviceWearerAddressControllerTest : IntegrationTestBase() {
               "postCode": "$mockPostCode",
               "addressUsage": "$mockAddressUsage"
             }
-          """.trimIndent()
-        )
+          """.trimIndent(),
+        ),
       )
       .headers(setAuthorisation("AUTH_ADM"))
       .exchange()
@@ -135,8 +132,8 @@ class DeviceWearerAddressControllerTest : IntegrationTestBase() {
               "addressLine4": "",
               "postCode": ""
             }
-          """.trimIndent()
-        )
+          """.trimIndent(),
+        ),
       )
       .headers(setAuthorisation("AUTH_ADM"))
       .exchange()
@@ -176,8 +173,8 @@ class DeviceWearerAddressControllerTest : IntegrationTestBase() {
               "addressLine4": "",
               "postCode": ""
             }
-          """.trimIndent()
-        )
+          """.trimIndent(),
+        ),
       )
       .headers(setAuthorisation("AUTH_ADM"))
       .exchange()
@@ -203,8 +200,8 @@ class DeviceWearerAddressControllerTest : IntegrationTestBase() {
               "addressLine4": "",
               "postCode": ""
             }
-          """.trimIndent()
-        )
+          """.trimIndent(),
+        ),
       )
       .headers(setAuthorisation("AUTH_ADM"))
       .exchange()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/DeviceWearerAddressControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/DeviceWearerAddressControllerTest.kt
@@ -40,7 +40,7 @@ class DeviceWearerAddressControllerTest : IntegrationTestBase() {
     val order = createOrder()
 
     val result = webTestClient.post()
-      .uri("/api/order/${order.id}/address/")
+      .uri("/api/order/${order.id}/address")
       .contentType(MediaType.APPLICATION_JSON)
       .body(
         BodyInserters.fromValue(
@@ -75,51 +75,11 @@ class DeviceWearerAddressControllerTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `Address details can be updated with a usage type`() {
-    val order = createOrder()
-
-    val result = webTestClient.post()
-      .uri("/api/order/${order.id}/address/")
-      .contentType(MediaType.APPLICATION_JSON)
-      .body(
-        BodyInserters.fromValue(
-          """
-            {
-              "addressType": "PRIMARY",
-              "addressLine1": "$mockAddressLine1",
-              "addressLine2": "$mockAddressLine2",
-              "addressLine3": "$mockAddressLine3",
-              "addressLine4": "$mockAddressLine4",
-              "postCode": "$mockPostCode",
-              "addressUsage": "$mockAddressUsage"
-            }
-          """.trimIndent(),
-        ),
-      )
-      .headers(setAuthorisation("AUTH_ADM"))
-      .exchange()
-      .expectStatus()
-      .isOk
-      .expectBody(DeviceWearerAddress::class.java)
-      .returnResult()
-
-    val address = result.responseBody!!
-
-    Assertions.assertThat(address.addressType).isEqualTo(DeviceWearerAddressType.PRIMARY)
-    Assertions.assertThat(address.addressLine1).isEqualTo(mockAddressLine1)
-    Assertions.assertThat(address.addressLine2).isEqualTo(mockAddressLine2)
-    Assertions.assertThat(address.addressLine3).isEqualTo(mockAddressLine3)
-    Assertions.assertThat(address.addressLine4).isEqualTo(mockAddressLine4)
-    Assertions.assertThat(address.postcode).isEqualTo(mockPostCode)
-    Assertions.assertThat(address.addressUsage).isEqualTo(DeviceWearerAddressUsage.WORK)
-  }
-
-  @Test
   fun `Primary address details are mandatory`() {
     val order = createOrder()
 
     val result = webTestClient.post()
-      .uri("/api/order/${order.id}/address/")
+      .uri("/api/order/${order.id}/address")
       .contentType(MediaType.APPLICATION_JSON)
       .body(
         BodyInserters.fromValue(
@@ -160,7 +120,7 @@ class DeviceWearerAddressControllerTest : IntegrationTestBase() {
     val order = createOrder()
 
     val result = webTestClient.post()
-      .uri("/api/order/${order.id}/address/")
+      .uri("/api/order/${order.id}/address")
       .contentType(MediaType.APPLICATION_JSON)
       .body(
         BodyInserters.fromValue(
@@ -187,7 +147,7 @@ class DeviceWearerAddressControllerTest : IntegrationTestBase() {
     val order = createOrder()
 
     val result = webTestClient.post()
-      .uri("/api/order/${order.id}/address/")
+      .uri("/api/order/${order.id}/address")
       .contentType(MediaType.APPLICATION_JSON)
       .body(
         BodyInserters.fromValue(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/DeviceWearerAddressControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/DeviceWearerAddressControllerTest.kt
@@ -1,0 +1,214 @@
+package uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.integration.resource
+
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.MediaType
+import org.springframework.web.reactive.function.BodyInserters
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.DeviceWearerAddress
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.DeviceWearerContactDetails
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.DeviceWearerAddressType
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.DeviceWearerAddressUsage
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.FormStatus
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.repository.DeviceWearerContactDetailsRepository
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.repository.DeviceWearerAddressRepository
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.repository.OrderFormRepository
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.resource.validator.ValidationError
+import java.util.*
+
+class DeviceWearerAddressControllerTest : IntegrationTestBase() {
+  @Autowired
+  lateinit var deviceWearerAddressRepo: DeviceWearerAddressRepository
+
+  @Autowired
+  lateinit var orderFormRepo: OrderFormRepository
+
+  private val mockAddressLine1: String = "mockAddressLine1"
+  private val mockAddressLine2: String = "mockAddressLine2"
+  private val mockAddressLine3: String = "mockAddressLine3"
+  private val mockAddressLine4: String = "mockAddressLine4"
+  private val mockPostCode: String = "mockPostCode"
+  private val mockAddressUsage: String = "WORK"
+
+  @BeforeEach
+  fun setup() {
+    deviceWearerAddressRepo.deleteAll()
+    orderFormRepo.deleteAll()
+  }
+
+  @Test
+  fun `Address details can be updated`() {
+    val order = createOrder()
+
+    val result = webTestClient.post()
+      .uri("/api/order/${order.id}/address/")
+      .contentType(MediaType.APPLICATION_JSON)
+      .body(
+        BodyInserters.fromValue(
+          """
+            {
+              "addressType": "PRIMARY",
+              "addressLine1": "$mockAddressLine1",
+              "addressLine2": "$mockAddressLine2",
+              "addressLine3": "$mockAddressLine3",
+              "addressLine4": "$mockAddressLine4",
+              "postCode": "$mockPostCode"
+            }
+          """.trimIndent()
+        )
+      )
+      .headers(setAuthorisation("AUTH_ADM"))
+      .exchange()
+      .expectStatus()
+      .isOk
+      .expectBody(DeviceWearerAddress::class.java)
+      .returnResult()
+
+    val address = result.responseBody!!
+
+    Assertions.assertThat(address.addressType).isEqualTo(DeviceWearerAddressType.PRIMARY)
+    Assertions.assertThat(address.addressLine1).isEqualTo(mockAddressLine1)
+    Assertions.assertThat(address.addressLine2).isEqualTo(mockAddressLine2)
+    Assertions.assertThat(address.addressLine3).isEqualTo(mockAddressLine3)
+    Assertions.assertThat(address.addressLine4).isEqualTo(mockAddressLine4)
+    Assertions.assertThat(address.postcode).isEqualTo(mockPostCode)
+    Assertions.assertThat(address.addressUsage).isEqualTo(DeviceWearerAddressUsage.NA)
+  }
+
+  @Test
+  fun `Address details can be updated with a usage type`() {
+    val order = createOrder()
+
+    val result = webTestClient.post()
+      .uri("/api/order/${order.id}/address/")
+      .contentType(MediaType.APPLICATION_JSON)
+      .body(
+        BodyInserters.fromValue(
+          """
+            {
+              "addressType": "PRIMARY",
+              "addressLine1": "$mockAddressLine1",
+              "addressLine2": "$mockAddressLine2",
+              "addressLine3": "$mockAddressLine3",
+              "addressLine4": "$mockAddressLine4",
+              "postCode": "$mockPostCode",
+              "addressUsage": "$mockAddressUsage"
+            }
+          """.trimIndent()
+        )
+      )
+      .headers(setAuthorisation("AUTH_ADM"))
+      .exchange()
+      .expectStatus()
+      .isOk
+      .expectBody(DeviceWearerAddress::class.java)
+      .returnResult()
+
+    val address = result.responseBody!!
+
+    Assertions.assertThat(address.addressType).isEqualTo(DeviceWearerAddressType.PRIMARY)
+    Assertions.assertThat(address.addressLine1).isEqualTo(mockAddressLine1)
+    Assertions.assertThat(address.addressLine2).isEqualTo(mockAddressLine2)
+    Assertions.assertThat(address.addressLine3).isEqualTo(mockAddressLine3)
+    Assertions.assertThat(address.addressLine4).isEqualTo(mockAddressLine4)
+    Assertions.assertThat(address.postcode).isEqualTo(mockPostCode)
+    Assertions.assertThat(address.addressUsage).isEqualTo(DeviceWearerAddressUsage.WORK)
+  }
+
+  @Test
+  fun `Primary address details are mandatory`() {
+    val order = createOrder()
+
+    val result = webTestClient.post()
+      .uri("/api/order/${order.id}/address/")
+      .contentType(MediaType.APPLICATION_JSON)
+      .body(
+        BodyInserters.fromValue(
+          """
+            {
+              "addressType": "PRIMARY",
+              "addressLine1": "",
+              "addressLine2": "",
+              "addressLine3": "",
+              "addressLine4": "",
+              "postCode": ""
+            }
+          """.trimIndent()
+        )
+      )
+      .headers(setAuthorisation("AUTH_ADM"))
+      .exchange()
+      .expectStatus()
+      .isBadRequest
+      .expectBodyList(ValidationError::class.java)
+      .returnResult()
+
+    Assertions.assertThat(result.responseBody).isNotNull
+    Assertions.assertThat(result.responseBody).hasSize(3)
+    Assertions.assertThat(result.responseBody!!).contains(
+      ValidationError("addressLine1", "Address line 1 is required"),
+    )
+    Assertions.assertThat(result.responseBody!!).contains(
+      ValidationError("addressLine2", "Address line 2 is required"),
+    )
+    Assertions.assertThat(result.responseBody!!).contains(
+      ValidationError("postCode", "Post code is required"),
+    )
+  }
+
+  @Test
+  fun `Secondary address details are not mandatory`() {
+    val order = createOrder()
+
+    val result = webTestClient.post()
+      .uri("/api/order/${order.id}/address/")
+      .contentType(MediaType.APPLICATION_JSON)
+      .body(
+        BodyInserters.fromValue(
+          """
+            {
+              "addressType": "SECONDARY",
+              "addressLine1": "",
+              "addressLine2": "",
+              "addressLine3": "",
+              "addressLine4": "",
+              "postCode": ""
+            }
+          """.trimIndent()
+        )
+      )
+      .headers(setAuthorisation("AUTH_ADM"))
+      .exchange()
+      .expectStatus()
+      .isOk
+  }
+
+  @Test
+  fun `Tertiary address details are not mandatory`() {
+    val order = createOrder()
+
+    val result = webTestClient.post()
+      .uri("/api/order/${order.id}/address/")
+      .contentType(MediaType.APPLICATION_JSON)
+      .body(
+        BodyInserters.fromValue(
+          """
+            {
+              "addressType": "TERTIARY",
+              "addressLine1": "",
+              "addressLine2": "",
+              "addressLine3": "",
+              "addressLine4": "",
+              "postCode": ""
+            }
+          """.trimIndent()
+        )
+      )
+      .headers(setAuthorisation("AUTH_ADM"))
+      .exchange()
+      .expectStatus()
+      .isOk
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/OrderFormControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/OrderFormControllerTest.kt
@@ -303,9 +303,9 @@ class OrderFormControllerTest : IntegrationTestBase() {
       fullName = "Mark Smith",
       contactNumber = "07401111111",
     )
-    orderForm.deviceWearer!!.deviceWearerAddresses = mutableListOf(
+    orderForm.deviceWearerAddresses = mutableListOf(
       DeviceWearerAddress(
-        deviceWearerId = orderForm.deviceWearer!!.id,
+        orderId = orderForm.id,
         addressLine1 = "20 Somewhere Street",
         addressLine2 = "Nowhere City",
         addressLine3 = "Random County",
@@ -314,7 +314,7 @@ class OrderFormControllerTest : IntegrationTestBase() {
         addressType = DeviceWearerAddressType.PRIMARY,
       ),
       DeviceWearerAddress(
-        deviceWearerId = orderForm.deviceWearer!!.id,
+        orderId = orderForm.id,
         addressLine1 = "22 Somewhere Street",
         addressLine2 = "Nowhere City",
         addressLine3 = "Random County",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/OrderFormServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/OrderFormServiceTest.kt
@@ -64,9 +64,9 @@ class OrderFormServiceTest {
       orderId = mockOrder.id,
       adultAtTimeOfInstallation = true, dateOfBirth = ZonedDateTime.of(1990, 1, 1, 1, 1, 1, 1, ZoneId.systemDefault()),
     )
-    mockOrder.deviceWearer!!.deviceWearerAddresses = mutableListOf(
+    mockOrder.deviceWearerAddresses = mutableListOf(
       DeviceWearerAddress(
-        deviceWearerId = mockOrder.deviceWearer!!.id,
+        orderId = mockOrder.id,
         addressLine1 = "20 Somewhere Street",
         addressLine2 = "Nowhere City",
         addressLine3 = "Random County",


### PR DESCRIPTION
Addresses are now related to the order not the device wearer. Conceptually this is wrong, but as we're collecting information related to a order, I think this is simpler.

Uses some spring magic to make the primary address have mandatory fields without adding the same constraints for the secondary and tertiary addresses.