### PR TITLE
Device wearer responsible adult endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/DeviceWearer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/DeviceWearer.kt
@@ -65,8 +65,5 @@ data class DeviceWearer(
   private val order: OrderForm? = null,
 
   @OneToOne(fetch = FetchType.LAZY, cascade = [ALL], mappedBy = "deviceWearer", orphanRemoval = true)
-  var responsibleAdult: ResponsibleAdult? = null,
-
-  @OneToOne(fetch = FetchType.LAZY, cascade = [ALL], mappedBy = "deviceWearer", orphanRemoval = true)
   var alternativeContactDetails: AlternativeContractDetails? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/OrderForm.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/OrderForm.kt
@@ -36,6 +36,9 @@ data class OrderForm(
   var deviceWearer: DeviceWearer? = null,
 
   @OneToOne(fetch = FetchType.LAZY, cascade = [ALL], mappedBy = "order", orphanRemoval = true)
+  var deviceWearerResponsibleAdult: ResponsibleAdult? = null,
+
+  @OneToOne(fetch = FetchType.LAZY, cascade = [ALL], mappedBy = "order", orphanRemoval = true)
   var responsibleOfficer: ResponsibleOfficer? = null,
 
   @OneToOne(fetch = FetchType.LAZY, cascade = [ALL], mappedBy = "order", orphanRemoval = true)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/ResponsibleAdult.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/ResponsibleAdult.kt
@@ -15,8 +15,8 @@ data class ResponsibleAdult(
   @Column(name = "ID", nullable = false, unique = true)
   val id: UUID = UUID.randomUUID(),
 
-  @Column(name = "DEVICE_WEARER_ID", nullable = false, unique = true)
-  val deviceWearerId: UUID,
+  @Column(name = "ORDER_ID", nullable = false)
+  val orderId: UUID,
 
   @Column(name = "FULL_NAME", nullable = true)
   var fullName: String? = null,
@@ -24,10 +24,13 @@ data class ResponsibleAdult(
   @Column(name = "RELATIONSHIP", nullable = true)
   var relationship: String? = null,
 
+  @Column(name = "OTHER_RELATIONSHIP_DETAILS", nullable = true)
+  var otherRelationshipDetails: String? = null,
+
   @Column(name = "CONTACT_NUMBER", nullable = true)
   var contactNumber: String? = null,
 
   @OneToOne
-  @JoinColumn(name = "DEVICE_WEARER_ID", updatable = false, insertable = false)
-  private val deviceWearer: DeviceWearer? = null,
+  @JoinColumn(name = "ORDER_ID", updatable = false, insertable = false)
+  private val order: OrderForm? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/fms/DeviceWearer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/fms/DeviceWearer.kt
@@ -152,9 +152,9 @@ data class DeviceWearer(
         riskDetails = order.installationAndRisk?.riskDetails,
         mappa = order.installationAndRisk?.mappaLevel,
         mappaCaseType = order.installationAndRisk?.mappaCaseType,
-        responsibleAdultRequired = (order.deviceWearer?.responsibleAdult != null).toString(),
-        parent = "${order.deviceWearer?.responsibleAdult?.fullName}",
-        parentPhoneNumber = order.deviceWearer?.responsibleAdult?.contactNumber,
+        responsibleAdultRequired = (order.deviceWearerResponsibleAdult != null).toString(),
+        parent = "${order.deviceWearerResponsibleAdult?.fullName}",
+        parentPhoneNumber = order.deviceWearerResponsibleAdult?.contactNumber,
       )
       order.deviceWearerAddresses?.find { address -> address.addressType == DeviceWearerAddressType.SECONDARY }.let { address ->
         {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/repository/DeviceWearerResponsibleAdultRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/repository/DeviceWearerResponsibleAdultRepository.kt
@@ -1,0 +1,16 @@
+package uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.ResponsibleAdult
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.FormStatus
+import java.util.*
+
+@Repository
+interface DeviceWearerResponsibleAdultRepository : JpaRepository<ResponsibleAdult, UUID> {
+  fun findByOrderIdAndOrderUsernameAndOrderStatus(
+    id: UUID,
+    username: String,
+    status: FormStatus,
+  ): Optional<ResponsibleAdult>
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/resource/DeviceWearerResponsibleAdultController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/resource/DeviceWearerResponsibleAdultController.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.resource
 
 import jakarta.validation.Valid
+import jakarta.validation.constraints.AssertTrue
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -52,4 +53,24 @@ data class UpdateDeviceWearerResponsibleAdultDto(
   val relationship: String,
   val otherRelationshipDetails: String?,
   val contactNumber: String,
-)
+) {
+  @AssertTrue(message = "Full name is required")
+  fun isFullName(): Boolean {
+    return this.fullName.isNotBlank()
+  }
+
+  @AssertTrue(message = "Relationship is required")
+  fun isRelationship(): Boolean {
+    return this.relationship.isNotBlank()
+  }
+
+  @AssertTrue(message = "You must provide details of the responsible adult to the device wearer")
+  fun isOtherRelationshipDetails(): Boolean {
+    return !(relationship == "other" && otherRelationshipDetails.isNullOrBlank())
+  }
+
+  @AssertTrue(message = "Contact number is required")
+  fun isContactNumber(): Boolean {
+    return this.contactNumber.isNotBlank()
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/resource/DeviceWearerResponsibleAdultController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/resource/DeviceWearerResponsibleAdultController.kt
@@ -1,0 +1,55 @@
+package uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.resource
+
+import jakarta.validation.Valid
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.security.core.Authentication
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.ResponsibleAdult
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.service.DeviceWearerResponsibleAdultService
+import java.util.*
+
+@RestController
+@PreAuthorize("hasRole('ROLE_EM_CEMO__CREATE_ORDER')")
+@RequestMapping("/api/")
+class DeviceWearerResponsibleAdultController(
+  @Autowired val deviceWearerResponsibleAdultService: DeviceWearerResponsibleAdultService,
+) {
+
+  @GetMapping("/order/{orderId}/device-wearer-responsible-adult")
+  fun getResponsibleAdult(
+    @PathVariable orderId: UUID,
+    authentication: Authentication,
+  ): ResponseEntity<ResponsibleAdult> {
+    val username = authentication.name
+    val responsibleAdult = deviceWearerResponsibleAdultService.getResponsibleAdult(orderId, username)
+
+    return ResponseEntity(responsibleAdult, HttpStatus.OK)
+  }
+
+  @PostMapping("/order/{orderId}/device-wearer-responsible-adult")
+  fun updateResponsibleAdult(
+    @PathVariable orderId: UUID,
+    @RequestBody @Valid responsibleAdultUpdateRecord: UpdateDeviceWearerResponsibleAdultDto,
+    authentication: Authentication,
+  ): ResponseEntity<ResponsibleAdult> {
+    val username = authentication.name
+    val responsibleAdult = deviceWearerResponsibleAdultService.createOrUpdateResponsibleAdult(orderId, username, responsibleAdultUpdateRecord)
+
+    return ResponseEntity(responsibleAdult, HttpStatus.OK)
+  }
+}
+
+data class UpdateDeviceWearerResponsibleAdultDto(
+  val fullName: String,
+  val relationship: String,
+  val otherRelationshipDetails: String?,
+  val contactNumber: String,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/DeviceWearerResponsibleAdultService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/DeviceWearerResponsibleAdultService.kt
@@ -1,0 +1,58 @@
+package uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.service
+
+import jakarta.persistence.EntityNotFoundException
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.ResponsibleAdult
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.FormStatus
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.repository.DeviceWearerResponsibleAdultRepository
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.repository.OrderFormRepository
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.resource.UpdateDeviceWearerResponsibleAdultDto
+import java.util.UUID
+
+@Service
+class DeviceWearerResponsibleAdultService(
+  val orderRepo: OrderFormRepository,
+  val resonsibleAdultRepo: DeviceWearerResponsibleAdultRepository,
+) {
+  fun getResponsibleAdult(orderId: UUID, username: String): ResponsibleAdult {
+    // Verify the order belongs to the user and is in draft state
+    val order = orderRepo.findByIdAndUsernameAndStatus(
+      orderId,
+      username,
+      FormStatus.IN_PROGRESS,
+    ).orElseThrow {
+      EntityNotFoundException("An editable order with $orderId does not exist")
+    }
+
+    // Find an existing address or create a new address
+    return resonsibleAdultRepo.findByOrderIdAndOrderUsernameAndOrderStatus(
+      order.id,
+      order.username,
+      order.status,
+    ).orElse(
+      ResponsibleAdult(
+        orderId = orderId,
+      ),
+    )
+  }
+
+  fun createOrUpdateResponsibleAdult(
+    orderId: UUID,
+    username: String,
+    deviceWearerResponsibleAdultUpdateRecord: UpdateDeviceWearerResponsibleAdultDto,
+  ): ResponsibleAdult {
+    val responsibleAdult = this.getResponsibleAdult(
+      orderId,
+      username,
+    )
+
+    with(deviceWearerResponsibleAdultUpdateRecord) {
+      responsibleAdult.fullName = fullName
+      responsibleAdult.relationship = relationship
+      responsibleAdult.otherRelationshipDetails = otherRelationshipDetails
+      responsibleAdult.contactNumber = contactNumber
+    }
+
+    return resonsibleAdultRepo.save(responsibleAdult)
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/DeviceWearerResponsibleAdultService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/DeviceWearerResponsibleAdultService.kt
@@ -12,7 +12,7 @@ import java.util.UUID
 @Service
 class DeviceWearerResponsibleAdultService(
   val orderRepo: OrderFormRepository,
-  val resonsibleAdultRepo: DeviceWearerResponsibleAdultRepository,
+  val responsibleAdultRepo: DeviceWearerResponsibleAdultRepository,
 ) {
   fun getResponsibleAdult(orderId: UUID, username: String): ResponsibleAdult {
     // Verify the order belongs to the user and is in draft state
@@ -24,8 +24,8 @@ class DeviceWearerResponsibleAdultService(
       EntityNotFoundException("An editable order with $orderId does not exist")
     }
 
-    // Find an existing address or create a new address
-    return resonsibleAdultRepo.findByOrderIdAndOrderUsernameAndOrderStatus(
+    // Find an existing responsible adult or create a new responsible adult
+    return responsibleAdultRepo.findByOrderIdAndOrderUsernameAndOrderStatus(
       order.id,
       order.username,
       order.status,
@@ -53,6 +53,6 @@ class DeviceWearerResponsibleAdultService(
       responsibleAdult.contactNumber = contactNumber
     }
 
-    return resonsibleAdultRepo.save(responsibleAdult)
+    return responsibleAdultRepo.save(responsibleAdult)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/DeviceWearerAddressControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/DeviceWearerAddressControllerTest.kt
@@ -82,7 +82,7 @@ class DeviceWearerAddressControllerTest : IntegrationTestBase() {
           """.trimIndent(),
         ),
       )
-      .headers(setAuthorisation("AUTH_ADM_2"))
+      .headers(setAuthorisation("AUTH_ADM"))
       .exchange()
       .expectStatus()
       .isNotFound
@@ -112,7 +112,7 @@ class DeviceWearerAddressControllerTest : IntegrationTestBase() {
           """.trimIndent(),
         ),
       )
-      .headers(setAuthorisation("AUTH_ADM_2"))
+      .headers(setAuthorisation("AUTH_ADM"))
       .exchange()
       .expectStatus()
       .isNotFound

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/DeviceWearerResponsibleAdultControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/DeviceWearerResponsibleAdultControllerTest.kt
@@ -1,0 +1,236 @@
+package uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.integration.resource
+
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.MediaType
+import org.springframework.web.reactive.function.BodyInserters
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.ResponsibleAdult
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.FormStatus
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.repository.DeviceWearerResponsibleAdultRepository
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.repository.OrderFormRepository
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.resource.validator.ValidationError
+import java.util.*
+
+class DeviceWearerResponsibleAdultControllerTest : IntegrationTestBase() {
+  @Autowired
+  lateinit var responsibleAdultRepo: DeviceWearerResponsibleAdultRepository
+
+  @Autowired
+  lateinit var orderFormRepo: OrderFormRepository
+
+  private val mockFullName: String = "mockFullName"
+  private val mockRelationship: String = "mockRelationship"
+  private val mockContactNumber: String = "mockcontactNumber"
+
+  @BeforeEach
+  fun setup() {
+    responsibleAdultRepo.deleteAll()
+    orderFormRepo.deleteAll()
+  }
+
+  @Test
+  fun `ResponsibleAdult details for an order created by a different user are not update-able`() {
+    val order = createOrder()
+
+    webTestClient.post()
+      .uri("/api/order/${order.id}/device-wearer-responsible-adult")
+      .contentType(MediaType.APPLICATION_JSON)
+      .body(
+        BodyInserters.fromValue(
+          """
+            {
+              "fullName": "$mockFullName",
+              "relationship": "$mockRelationship",
+              "contactNumber": "$mockContactNumber"
+            }
+          """.trimIndent(),
+        ),
+      )
+      .headers(setAuthorisation("AUTH_ADM_2"))
+      .exchange()
+      .expectStatus()
+      .isNotFound
+  }
+
+  @Test
+  fun `ResponsibleAdult details for an non-existent order are not update-able`() {
+    webTestClient.post()
+      .uri("/api/order/${UUID.randomUUID()}/ResponsibleAdult")
+      .contentType(MediaType.APPLICATION_JSON)
+      .body(
+        BodyInserters.fromValue(
+          """
+            {
+              "fullName": "$mockFullName",
+              "relationship": "$mockRelationship",
+              "contactNumber": "$mockContactNumber"
+            }
+          """.trimIndent(),
+        ),
+      )
+      .headers(setAuthorisation("AUTH_ADM"))
+      .exchange()
+      .expectStatus()
+      .isNotFound
+  }
+
+  @Test
+  fun `ResponsibleAdult details for a submitted order are not update-able`() {
+    val order = createOrder()
+
+    order.status = FormStatus.SUBMITTED
+    orderFormRepo.save(order)
+
+    webTestClient.post()
+      .uri("/api/order/${order.id}/device-wearer-responsible-adult")
+      .contentType(MediaType.APPLICATION_JSON)
+      .body(
+        BodyInserters.fromValue(
+          """
+            {
+              "fullName": "$mockFullName",
+              "relationship": "$mockRelationship",
+              "contactNumber": "$mockContactNumber"
+            }
+          """.trimIndent(),
+        ),
+      )
+      .headers(setAuthorisation("AUTH_ADM"))
+      .exchange()
+      .expectStatus()
+      .isNotFound
+  }
+
+  @Test
+  fun `ResponsibleAdult details can be updated`() {
+    val order = createOrder()
+
+    val result = webTestClient.post()
+      .uri("/api/order/${order.id}/device-wearer-responsible-adult")
+      .contentType(MediaType.APPLICATION_JSON)
+      .body(
+        BodyInserters.fromValue(
+          """
+            {
+              "fullName": "$mockFullName",
+              "relationship": "$mockRelationship",
+              "contactNumber": "$mockContactNumber"
+            }
+          """.trimIndent(),
+        ),
+      )
+      .headers(setAuthorisation("AUTH_ADM"))
+      .exchange()
+      .expectStatus()
+      .isOk
+      .expectBody(ResponsibleAdult::class.java)
+      .returnResult()
+
+    val responsibleAdult = result.responseBody!!
+
+    Assertions.assertThat(responsibleAdult.fullName).isEqualTo(mockFullName)
+    Assertions.assertThat(responsibleAdult.relationship).isEqualTo(mockRelationship)
+    Assertions.assertThat(responsibleAdult.contactNumber).isEqualTo(mockContactNumber)
+  }
+
+  @Test
+  fun `Responsible Adult Details are mandatory`() {
+    val order = createOrder()
+
+    val result = webTestClient.post()
+      .uri("/api/order/${order.id}/device-wearer-responsible-adult")
+      .contentType(MediaType.APPLICATION_JSON)
+      .body(
+        BodyInserters.fromValue(
+          """
+            {
+              "fullName": "",
+              "relationship": "",
+              "contactNumber": ""
+            }
+          """.trimIndent(),
+        ),
+      )
+      .headers(setAuthorisation("AUTH_ADM"))
+      .exchange()
+      .expectStatus()
+      .isBadRequest
+      .expectBodyList(ValidationError::class.java)
+      .returnResult()
+
+    Assertions.assertThat(result.responseBody).isNotNull
+    Assertions.assertThat(result.responseBody).hasSize(3)
+    Assertions.assertThat(result.responseBody!!).contains(
+      ValidationError("fullName", "Full name is required"),
+    )
+    Assertions.assertThat(result.responseBody!!).contains(
+      ValidationError("relationship", "Relationship is required"),
+    )
+    Assertions.assertThat(result.responseBody!!).contains(
+      ValidationError("contactNumber", "Contact number is required"),
+    )
+  }
+
+  @Nested
+  inner class OtherRelationshipDetails {
+    @Test
+    fun `Other relationship details is not mandatory when a relationship type except 'Other' is selected`() {
+      val order = createOrder()
+
+      webTestClient.post()
+        .uri("/api/order/${order.id}/device-wearer-responsible-adult")
+        .contentType(MediaType.APPLICATION_JSON)
+        .body(
+          BodyInserters.fromValue(
+            """
+            {
+              "fullName": "$mockFullName",
+              "relationship": "Parent",
+              "contactNumber": "$mockContactNumber"
+            }
+            """.trimIndent(),
+          ),
+        )
+        .headers(setAuthorisation("AUTH_ADM"))
+        .exchange()
+        .expectStatus()
+        .isOk
+    }
+
+    @Test
+    fun `Other relationship details is mandatory when relationship type 'Other' is selected`() {
+      val order = createOrder()
+
+      val result = webTestClient.post()
+        .uri("/api/order/${order.id}/device-wearer-responsible-adult")
+        .contentType(MediaType.APPLICATION_JSON)
+        .body(
+          BodyInserters.fromValue(
+            """
+            {
+              "fullName": "$mockFullName",
+              "relationship": "other",
+              "contactNumber": "$mockContactNumber"
+            }
+            """.trimIndent(),
+          ),
+        )
+        .headers(setAuthorisation("AUTH_ADM"))
+        .exchange()
+        .expectStatus()
+        .isBadRequest
+        .expectBodyList(ValidationError::class.java)
+        .returnResult()
+
+      Assertions.assertThat(result.responseBody).isNotNull
+      Assertions.assertThat(result.responseBody).hasSize(1)
+      Assertions.assertThat(result.responseBody!!).contains(
+        ValidationError("otherRelationshipDetails", "You must provide details of the responsible adult to the device wearer"),
+      )
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/OrderFormControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/OrderFormControllerTest.kt
@@ -298,8 +298,8 @@ class OrderFormControllerTest : IntegrationTestBase() {
       disabilities = "Vision,Hearing",
     )
 
-    orderForm.deviceWearer!!.responsibleAdult = ResponsibleAdult(
-      deviceWearerId = orderForm.deviceWearer!!.id,
+    orderForm.deviceWearerResponsibleAdult = ResponsibleAdult(
+      orderId = orderForm.id,
       fullName = "Mark Smith",
       contactNumber = "07401111111",
     )


### PR DESCRIPTION
As with [Addresses](https://github.com/ministryofjustice/hmpps-electronic-monitoring-create-an-order-api/pull/30), Device Wearer Responsible Adult is now related to the order rather than the device wearer.