### PR TITLE
Addresses are not always related to a device wearer

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/Address.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/Address.kt
@@ -1,0 +1,30 @@
+package uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.util.*
+
+@Entity
+@Table(name = "ADDRESS")
+data class Address(
+  @Id
+  @Column(name = "ID", nullable = false, unique = true)
+  val id: UUID = UUID.randomUUID(),
+
+  @Column(name = "ADDRESS_LINE_1", nullable = true)
+  var addressLine1: String? = null,
+
+  @Column(name = "ADDRESS_LINE_2", nullable = true)
+  var addressLine2: String? = null,
+
+  @Column(name = "ADDRESS_LINE_3", nullable = true)
+  var addressLine3: String? = null,
+
+  @Column(name = "ADDRESS_LINE_4", nullable = true)
+  var addressLine4: String? = null,
+
+  @Column(name = "POSTCODE", nullable = true)
+  var postcode: String? = null,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/DeviceWearerAddress.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/DeviceWearerAddress.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models
 
+import jakarta.persistence.CascadeType
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
@@ -7,6 +8,7 @@ import jakarta.persistence.Enumerated
 import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
+import jakarta.persistence.OneToOne
 import jakarta.persistence.Table
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.DeviceWearerAddressType
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.DeviceWearerAddressUsage
@@ -23,20 +25,8 @@ data class DeviceWearerAddress(
   @Column(name = "ORDER_ID", nullable = false)
   val orderId: UUID,
 
-  @Column(name = "ADDRESS_LINE_1", nullable = true)
-  var addressLine1: String? = null,
-
-  @Column(name = "ADDRESS_LINE_2", nullable = true)
-  var addressLine2: String? = null,
-
-  @Column(name = "ADDRESS_LINE_3", nullable = true)
-  var addressLine3: String? = null,
-
-  @Column(name = "ADDRESS_LINE_4", nullable = true)
-  var addressLine4: String? = null,
-
-  @Column(name = "POSTCODE", nullable = true)
-  var postcode: String? = null,
+  @OneToOne(cascade = [CascadeType.ALL])
+  val address: Address,
 
   @Enumerated(EnumType.STRING)
   @Column(name = "ADDRESSTYPE", nullable = true)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/fms/DeviceWearer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/fms/DeviceWearer.kt
@@ -141,11 +141,11 @@ data class DeviceWearer(
         sex = order.deviceWearer?.sex,
         genderIdentity = order.deviceWearer?.gender,
         disability = disabilities,
-        address1 = primaryAddress.addressLine1,
-        address2 = primaryAddress.addressLine2,
-        address3 = primaryAddress.addressLine3,
-        address4 = primaryAddress.addressLine4,
-        addressPostCode = primaryAddress.postcode,
+        address1 = primaryAddress.address.addressLine1,
+        address2 = primaryAddress.address.addressLine2,
+        address3 = primaryAddress.address.addressLine3,
+        address4 = primaryAddress.address.addressLine4,
+        addressPostCode = primaryAddress.address.postcode,
         phoneNumber = order.deviceWearerContactDetails?.contactNumber,
         riskSeriousHarm = order.installationAndRisk?.riskOfSeriousHarm,
         riskSelfHarm = order.installationAndRisk?.riskOfSelfHarm,
@@ -159,11 +159,11 @@ data class DeviceWearer(
       order.deviceWearerAddresses?.find { address -> address.addressType == DeviceWearerAddressType.SECONDARY }.let { address ->
         {
           if (address != null) {
-            deviceWearer.secondaryAddress1 = address.addressLine1
-            deviceWearer.secondaryAddress2 = address.addressLine2
-            deviceWearer.secondaryAddress3 = address.addressLine3
-            deviceWearer.secondaryAddress4 = address.addressLine4
-            deviceWearer.secondaryAddressPostCode = address.postcode
+            deviceWearer.secondaryAddress1 = address.address.addressLine1
+            deviceWearer.secondaryAddress2 = address.address.addressLine2
+            deviceWearer.secondaryAddress3 = address.address.addressLine3
+            deviceWearer.secondaryAddress4 = address.address.addressLine4
+            deviceWearer.secondaryAddressPostCode = address.address.postcode
           }
         }
       }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/DeviceWearerAddressService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/DeviceWearerAddressService.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.s
 
 import jakarta.persistence.EntityNotFoundException
 import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.Address
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.DeviceWearerAddress
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.DeviceWearerAddressType
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.FormStatus
@@ -38,6 +39,7 @@ class DeviceWearerAddressService(
     ).orElse(
       DeviceWearerAddress(
         orderId = orderId,
+        address = Address(),
         addressType = addressType,
       ),
     )
@@ -55,11 +57,11 @@ class DeviceWearerAddressService(
     )
 
     with(deviceWearerAddressUpdateRecord) {
-      address.addressLine1 = addressLine1
-      address.addressLine2 = addressLine2
-      address.addressLine3 = addressLine3
-      address.addressLine4 = addressLine4
-      address.postcode = postcode
+      address.address.addressLine1 = addressLine1
+      address.address.addressLine2 = addressLine2
+      address.address.addressLine3 = addressLine3
+      address.address.addressLine4 = addressLine4
+      address.address.postcode = postcode
     }
 
     return addressRepo.save(address)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/DeviceWearerAddressControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/DeviceWearerAddressControllerTest.kt
@@ -28,7 +28,6 @@ class DeviceWearerAddressControllerTest : IntegrationTestBase() {
   private val mockAddressLine3: String = "mockAddressLine3"
   private val mockAddressLine4: String = "mockAddressLine4"
   private val mockPostcode: String = "mockPostcode"
-  private val mockAddressUsage: String = "WORK"
 
   @BeforeEach
   fun setup() {
@@ -149,11 +148,11 @@ class DeviceWearerAddressControllerTest : IntegrationTestBase() {
     val address = result.responseBody!!
 
     Assertions.assertThat(address.addressType).isEqualTo(DeviceWearerAddressType.PRIMARY)
-    Assertions.assertThat(address.addressLine1).isEqualTo(mockAddressLine1)
-    Assertions.assertThat(address.addressLine2).isEqualTo(mockAddressLine2)
-    Assertions.assertThat(address.addressLine3).isEqualTo(mockAddressLine3)
-    Assertions.assertThat(address.addressLine4).isEqualTo(mockAddressLine4)
-    Assertions.assertThat(address.postcode).isEqualTo(mockPostcode)
+    Assertions.assertThat(address.address.addressLine1).isEqualTo(mockAddressLine1)
+    Assertions.assertThat(address.address.addressLine2).isEqualTo(mockAddressLine2)
+    Assertions.assertThat(address.address.addressLine3).isEqualTo(mockAddressLine3)
+    Assertions.assertThat(address.address.addressLine4).isEqualTo(mockAddressLine4)
+    Assertions.assertThat(address.address.postcode).isEqualTo(mockPostcode)
     Assertions.assertThat(address.addressUsage).isEqualTo(DeviceWearerAddressUsage.NA)
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/OrderFormControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/OrderFormControllerTest.kt
@@ -3,12 +3,12 @@ package uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.i
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.mockito.kotlin.times
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpStatus
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.integration.wiremock.SercoAuthMockServerExtension.Companion.sercoAuthApi
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.integration.wiremock.SercoMockApiExtension.Companion.sercoApi
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.Address
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.DeviceWearer
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.DeviceWearerAddress
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.DeviceWearerContactDetails
@@ -306,20 +306,24 @@ class OrderFormControllerTest : IntegrationTestBase() {
     orderForm.deviceWearerAddresses = mutableListOf(
       DeviceWearerAddress(
         orderId = orderForm.id,
-        addressLine1 = "20 Somewhere Street",
-        addressLine2 = "Nowhere City",
-        addressLine3 = "Random County",
-        addressLine4 = "United Kingdom",
-        postcode = "SW11 1NC",
+        address = Address(
+          addressLine1 = "20 Somewhere Street",
+          addressLine2 = "Nowhere City",
+          addressLine3 = "Random County",
+          addressLine4 = "United Kingdom",
+          postcode = "SW11 1NC",
+        ),
         addressType = DeviceWearerAddressType.PRIMARY,
       ),
       DeviceWearerAddress(
         orderId = orderForm.id,
-        addressLine1 = "22 Somewhere Street",
-        addressLine2 = "Nowhere City",
-        addressLine3 = "Random County",
-        addressLine4 = "United Kingdom",
-        postcode = "SW11 1NC",
+        address = Address(
+          addressLine1 = "22 Somewhere Street",
+          addressLine2 = "Nowhere City",
+          addressLine3 = "Random County",
+          addressLine4 = "United Kingdom",
+          postcode = "SW11 1NC",
+        ),
         addressType = DeviceWearerAddressType.PRIMARY,
       ),
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/OrderFormServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/OrderFormServiceTest.kt
@@ -13,6 +13,7 @@ import org.mockito.kotlin.whenever
 import org.springframework.boot.test.autoconfigure.json.JsonTest
 import org.springframework.test.context.ActiveProfiles
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.client.SercoClient
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.Address
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.DeviceWearer
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.DeviceWearerAddress
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.OrderForm
@@ -67,11 +68,13 @@ class OrderFormServiceTest {
     mockOrder.deviceWearerAddresses = mutableListOf(
       DeviceWearerAddress(
         orderId = mockOrder.id,
-        addressLine1 = "20 Somewhere Street",
-        addressLine2 = "Nowhere City",
-        addressLine3 = "Random County",
-        addressLine4 = "United Kingdom",
-        postcode = "SW11 1NC",
+        address = Address(
+          addressLine1 = "20 Somewhere Street",
+          addressLine2 = "Nowhere City",
+          addressLine3 = "Random County",
+          addressLine4 = "United Kingdom",
+          postcode = "SW11 1NC",
+        ),
         addressType = DeviceWearerAddressType.PRIMARY,
       ),
     )


### PR DESCRIPTION
Addresses are required during the creation of monitoring conditions (e.g. alcohol monitoring installation address, mandatory attendance addresses) so decouple the address from the use of the address.