### PR TITLE
Update addresses to enable all possible options in the frontend

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/Address.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/Address.kt
@@ -4,6 +4,7 @@ import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.Id
 import jakarta.persistence.Table
+import jakarta.validation.constraints.NotBlank
 import java.util.*
 
 @Entity
@@ -13,18 +14,21 @@ data class Address(
   @Column(name = "ID", nullable = false, unique = true)
   val id: UUID = UUID.randomUUID(),
 
-  @Column(name = "ADDRESS_LINE_1", nullable = true)
-  var addressLine1: String? = null,
+  @Column(name = "ADDRESS_LINE_1", nullable = false)
+  @field:NotBlank(message = "Address line 1 is required")
+  var addressLine1: String,
 
-  @Column(name = "ADDRESS_LINE_2", nullable = true)
-  var addressLine2: String? = null,
+  @Column(name = "ADDRESS_LINE_2", nullable = false)
+  @field:NotBlank(message = "Address line 2 is required")
+  var addressLine2: String,
 
-  @Column(name = "ADDRESS_LINE_3", nullable = true)
-  var addressLine3: String? = null,
+  @Column(name = "ADDRESS_LINE_3", nullable = false)
+  var addressLine3: String = "",
 
-  @Column(name = "ADDRESS_LINE_4", nullable = true)
-  var addressLine4: String? = null,
+  @Column(name = "ADDRESS_LINE_4", nullable = false)
+  var addressLine4: String = "",
 
-  @Column(name = "POSTCODE", nullable = true)
-  var postcode: String? = null,
+  @Column(name = "POSTCODE", nullable = false)
+  @field:NotBlank(message = "Postcode is required")
+  var postcode: String,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/DeviceWearerAddress.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/DeviceWearerAddress.kt
@@ -25,8 +25,8 @@ data class DeviceWearerAddress(
   @Column(name = "ORDER_ID", nullable = false)
   val orderId: UUID,
 
-  @OneToOne(cascade = [CascadeType.ALL])
-  val address: Address,
+  @OneToOne(cascade = [CascadeType.ALL], optional = true)
+  var address: Address? = null,
 
   @Enumerated(EnumType.STRING)
   @Column(name = "ADDRESSTYPE", nullable = true)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/DeviceWearerAddress.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/DeviceWearerAddress.kt
@@ -32,6 +32,9 @@ data class DeviceWearerAddress(
   @Column(name = "ADDRESSTYPE", nullable = true)
   var addressType: DeviceWearerAddressType,
 
+  @Column(name = "INSTALLATION_ADDRESS", nullable = false)
+  var installationAddress: Boolean = false,
+
   @Enumerated(EnumType.STRING)
   @Column(name = "ADDRESSUSAGE", nullable = true)
   var addressUsage: DeviceWearerAddressUsage? = DeviceWearerAddressUsage.NA,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/enums/DeviceWearerAddressType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/enums/DeviceWearerAddressType.kt
@@ -4,4 +4,6 @@ enum class DeviceWearerAddressType {
   PRIMARY,
   SECONDARY,
   TERTIARY,
+  NO_FIXED_ABODE,
+  INSTALLATION,
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/fms/DeviceWearer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/fms/DeviceWearer.kt
@@ -130,7 +130,7 @@ data class DeviceWearer(
       if (!order.deviceWearer?.adultAtTimeOfInstallation!!) {
         adultChild = "child"
       }
-      val primaryAddress = order.deviceWearerAddresses?.find { address -> address.addressType == DeviceWearerAddressType.PRIMARY }!!
+      val primaryAddress = order.deviceWearerAddresses.find { address -> address.addressType == DeviceWearerAddressType.PRIMARY }!!
       val disabilities = order.deviceWearer?.disabilities?.split(',')?.map { disability -> Disability(disability) }?.toList()
       val deviceWearer = DeviceWearer(
         firstName = order.deviceWearer?.firstName,
@@ -141,11 +141,11 @@ data class DeviceWearer(
         sex = order.deviceWearer?.sex,
         genderIdentity = order.deviceWearer?.gender,
         disability = disabilities,
-        address1 = primaryAddress.address.addressLine1,
-        address2 = primaryAddress.address.addressLine2,
-        address3 = primaryAddress.address.addressLine3,
-        address4 = primaryAddress.address.addressLine4,
-        addressPostCode = primaryAddress.address.postcode,
+        address1 = primaryAddress.address?.addressLine1,
+        address2 = primaryAddress.address?.addressLine2,
+        address3 = primaryAddress.address?.addressLine3,
+        address4 = primaryAddress.address?.addressLine4,
+        addressPostCode = primaryAddress.address?.postcode,
         phoneNumber = order.deviceWearerContactDetails?.contactNumber,
         riskSeriousHarm = order.installationAndRisk?.riskOfSeriousHarm,
         riskSelfHarm = order.installationAndRisk?.riskOfSelfHarm,
@@ -156,14 +156,14 @@ data class DeviceWearer(
         parent = "${order.deviceWearerResponsibleAdult?.fullName}",
         parentPhoneNumber = order.deviceWearerResponsibleAdult?.contactNumber,
       )
-      order.deviceWearerAddresses?.find { address -> address.addressType == DeviceWearerAddressType.SECONDARY }.let { address ->
+      order.deviceWearerAddresses.find { address -> address.addressType == DeviceWearerAddressType.SECONDARY }.let { address ->
         {
           if (address != null) {
-            deviceWearer.secondaryAddress1 = address.address.addressLine1
-            deviceWearer.secondaryAddress2 = address.address.addressLine2
-            deviceWearer.secondaryAddress3 = address.address.addressLine3
-            deviceWearer.secondaryAddress4 = address.address.addressLine4
-            deviceWearer.secondaryAddressPostCode = address.address.postcode
+            deviceWearer.secondaryAddress1 = address.address?.addressLine1
+            deviceWearer.secondaryAddress2 = address.address?.addressLine2
+            deviceWearer.secondaryAddress3 = address.address?.addressLine3
+            deviceWearer.secondaryAddress4 = address.address?.addressLine4
+            deviceWearer.secondaryAddressPostCode = address.address?.postcode
           }
         }
       }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/resource/DeviceWearerAddressController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/resource/DeviceWearerAddressController.kt
@@ -42,9 +42,10 @@ class DeviceWearerAddressController(
 
 data class UpdateDeviceWearerAddressDto(
   val addressType: DeviceWearerAddressType,
-  val addressLine1: String,
-  val addressLine2: String,
-  val addressLine3: String,
-  val addressLine4: String,
-  val postcode: String,
+  val installationAddress: Boolean = false,
+  val addressLine1: String = "",
+  val addressLine2: String = "",
+  val addressLine3: String = "",
+  val addressLine4: String = "",
+  val postcode: String = "",
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/resource/DeviceWearerAddressController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/resource/DeviceWearerAddressController.kt
@@ -1,7 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.resource
 
 import jakarta.validation.Valid
-import jakarta.validation.constraints.AssertTrue
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -48,28 +47,4 @@ data class UpdateDeviceWearerAddressDto(
   val addressLine3: String,
   val addressLine4: String,
   val postcode: String,
-) {
-  @AssertTrue(message = "Address line 1 is required")
-  fun isAddressLine1(): Boolean {
-    if (this.addressType === DeviceWearerAddressType.PRIMARY) {
-      return this.addressLine1.isNotBlank()
-    }
-    return true
-  }
-
-  @AssertTrue(message = "Address line 2 is required")
-  fun isAddressLine2(): Boolean {
-    if (this.addressType === DeviceWearerAddressType.PRIMARY) {
-      return this.addressLine2.isNotBlank()
-    }
-    return true
-  }
-
-  @AssertTrue(message = "Postcode is required")
-  fun isPostcode(): Boolean {
-    if (this.addressType === DeviceWearerAddressType.PRIMARY) {
-      return this.postcode.isNotBlank()
-    }
-    return true
-  }
-}
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/DeviceWearerAddressService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/DeviceWearerAddressService.kt
@@ -39,7 +39,6 @@ class DeviceWearerAddressService(
     ).orElse(
       DeviceWearerAddress(
         orderId = orderId,
-        address = Address(),
         addressType = addressType,
       ),
     )
@@ -56,12 +55,16 @@ class DeviceWearerAddressService(
       deviceWearerAddressUpdateRecord.addressType,
     )
 
-    with(deviceWearerAddressUpdateRecord) {
-      address.address.addressLine1 = addressLine1
-      address.address.addressLine2 = addressLine2
-      address.address.addressLine3 = addressLine3
-      address.address.addressLine4 = addressLine4
-      address.address.postcode = postcode
+    if (deviceWearerAddressUpdateRecord.addressType !== DeviceWearerAddressType.NO_FIXED_ABODE) {
+      with(deviceWearerAddressUpdateRecord) {
+        address.address = Address(
+          addressLine1 = addressLine1,
+          addressLine2 = addressLine2,
+          addressLine3 = addressLine3,
+          addressLine4 = addressLine4,
+          postcode = postcode,
+        )
+      }
     }
 
     return addressRepo.save(address)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/DeviceWearerAddressService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/DeviceWearerAddressService.kt
@@ -64,6 +64,7 @@ class DeviceWearerAddressService(
           addressLine4 = addressLine4,
           postcode = postcode,
         )
+        address.installationAddress = installationAddress
       }
     }
 


### PR DESCRIPTION
Changes:
- Allow a device wearer address to be flagged as no fixed abode
- Allow an address to be flagged as an installation address
- Allow an additional `INSTALLATION` address type

Future:
- There is a large possibility that addresses will end up in an "invalid" state without additional validation / checks.