### PR TITLE
Enable preprod deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,20 +65,16 @@ workflows:
             - build_docker
             - helm_lint
           helm_timeout: 5m
-#      - request-preprod-approval:
-#          type: approval
-#          requires:
-#            - deploy_dev
-#      - hmpps/deploy_env:
-#          name: deploy_preprod
-#          env: "preprod"
-#          jira_update: true
-#          jira_env_type: staging
-#          pipeline_id: <<pipeline.id>>
-#          pipeline_number: <<pipeline.number>>
-#          context:
-#            - hmpps-common-vars
-#            - hmpps-electronic-monitoring-create-an-order-api-preprod
+      - hmpps/deploy_env:
+          name: deploy_preprod
+          env: "preprod"
+          jira_update: true
+          jira_env_type: staging
+          pipeline_id: <<pipeline.id>>
+          pipeline_number: <<pipeline.number>>
+          context:
+            - hmpps-common-vars
+            - hmpps-ems-cemo-ui-preprod
 #          requires:
 #            - request-preprod-approval
 #          helm_timeout: 5m

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,9 +75,9 @@ workflows:
           context:
             - hmpps-common-vars
             - hmpps-ems-cemo-ui-preprod
-#          requires:
-#            - request-preprod-approval
-#          helm_timeout: 5m
+          requires:
+            - deploy_dev
+          helm_timeout: 5m
 #      - request-prod-approval:
 #          type: approval
 #          requires:


### PR DESCRIPTION
- Created the RDS instance in this [PR](https://github.com/ministryofjustice/cloud-platform-environments/pull/26885).
- Created a placeholder `serco-secret` with the following content to allow the application to start:

```yaml
apiVersion: v1
data:
  SERCO_AUTH_URL: ""
  SERCO_CLIENT_ID: ""
  SERCO_CLIENT_SECRET: ""
  SERCO_PASSWORD: ""
  SERCO_URL: ""
  SERCO_USERNAME: ""
kind: Secret
metadata:
  creationTimestamp: "2024-10-15T14:43:07Z"
  name: serco-secret
  namespace: hmpps-ems-cemo-ui-preprod
  resourceVersion:
  uid: 
type: Opaque
```