### PR TITLE
Allow an address to be updated multiple times

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/AddressService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/AddressService.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.service
 
 import jakarta.persistence.EntityNotFoundException
+import jakarta.transaction.Transactional
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.Address
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.AddressType
@@ -28,6 +29,7 @@ class AddressService(
     )
   }
 
+  @Transactional
   fun updateAddress(
     orderId: UUID,
     username: String,
@@ -48,6 +50,8 @@ class AddressService(
       username,
       updateRecord.addressType,
     )
+
+    addressRepo.flush()
 
     // Create a new address
     val address = Address(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/AddressControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/AddressControllerTest.kt
@@ -200,4 +200,53 @@ class AddressControllerTest : IntegrationTestBase() {
       ValidationError("postcode", "Postcode is required"),
     )
   }
+
+  @Test
+  fun `Address details can be updated multiple times`() {
+    val order = createOrder()
+
+    webTestClient.put()
+      .uri("/api/orders/${order.id}/address")
+      .contentType(MediaType.APPLICATION_JSON)
+      .body(
+        BodyInserters.fromValue(
+          """
+            {
+              "addressType": "PRIMARY",
+              "addressLine1": "$mockAddressLine1",
+              "addressLine2": "$mockAddressLine2",
+              "addressLine3": "$mockAddressLine3",
+              "addressLine4": "$mockAddressLine4",
+              "postcode": "$mockPostcode"
+            }
+          """.trimIndent(),
+        ),
+      )
+      .headers(setAuthorisation("AUTH_ADM"))
+      .exchange()
+      .expectStatus()
+      .isOk
+
+    webTestClient.put()
+      .uri("/api/orders/${order.id}/address")
+      .contentType(MediaType.APPLICATION_JSON)
+      .body(
+        BodyInserters.fromValue(
+          """
+            {
+              "addressType": "PRIMARY",
+              "addressLine1": "$mockAddressLine1",
+              "addressLine2": "$mockAddressLine2",
+              "addressLine3": "$mockAddressLine3",
+              "addressLine4": "$mockAddressLine4",
+              "postcode": "$mockPostcode"
+            }
+          """.trimIndent(),
+        ),
+      )
+      .headers(setAuthorisation("AUTH_ADM"))
+      .exchange()
+      .expectStatus()
+      .isOk
+  }
 }


### PR DESCRIPTION
When updating an already existing address, the following error occurred:

```shell
Unexpected error: No EntityManager with actual transaction available for current thread - cannot reliably process 'remove' call
```

Adding the `@Transactional` decorator solved this problem but introduced a new problem.

```shell
Unexpected error: could not execute statement [ERROR: duplicate key value violates unique constraint "address_order_id_address_type_key" Detail: Key (order_id, address_type)=(f53c1c81-7fa5-46c7-90e3-54818cffd3b8, PRIMARY) already exists.]
```

This occurs because the entity manager does all `inserts` before it does any `deletes`.

We get around this by flushing the entity manager after the delete and before the insert.

