### PR TITLE
Deploy the preprod api to the dev namespace

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,9 +72,10 @@ workflows:
           jira_env_type: staging
           pipeline_id: <<pipeline.id>>
           pipeline_number: <<pipeline.number>>
+          release_name: PROJECT_NAME_ENV_NAME
           context:
             - hmpps-common-vars
-            - hmpps-ems-cemo-ui-preprod
+            # - hmpps-ems-cemo-ui-preprod
           requires:
             - deploy_dev
           helm_timeout: 5m

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -12,6 +12,7 @@ generic-service:
     HMPPS_AUTH_URL: "https://sign-in-preprod.hmpps.service.justice.gov.uk/auth"
     DOCUMENT_MANAGEMENT_URL: "https://document-api-preprod.hmpps.service.justice.gov.uk/"
     SENTRY_ENVIRONMENT: preprod
+    DB_NAME: preprod
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts


### PR DESCRIPTION
This is a temporary change to deploy an additional copy of the api to the `dev` namespace. This works by removing the reference to the preprod circleci context which contains the values needed to configure helm to deploy to preprod. 

Adjusting the default `release_name` to `PROJECT_NAME_ENV_NAME` should result in there being 2 distinct k8s deployments within the namespace `hmpps-electronic-monitoring-create-an-order-api` (dev) and `hmpps-electronic-monitoring-create-an-order-api-preprod` (preprod).

By deploying the preprod environment to the dev namespace, the preprod environment will use the dev secrets for `hmpps-auth` where we have greater control of user management (allowing us to create test users for UAT).