### PR TITLE
Responsible organisation address fields are optional

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/Address.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/Address.kt
@@ -9,7 +9,6 @@ import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
 import jakarta.persistence.UniqueConstraint
-import jakarta.validation.constraints.NotBlank
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.AddressType
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.DeviceWearerAddressUsage
 import java.util.*
@@ -38,11 +37,9 @@ data class Address(
   var addressUsage: DeviceWearerAddressUsage = DeviceWearerAddressUsage.NA,
 
   @Column(name = "ADDRESS_LINE_1", nullable = false)
-  @field:NotBlank(message = "Address line 1 is required")
   var addressLine1: String,
 
   @Column(name = "ADDRESS_LINE_2", nullable = false)
-  @field:NotBlank(message = "Address line 2 is required")
   var addressLine2: String,
 
   @Column(name = "ADDRESS_LINE_3", nullable = false)
@@ -52,7 +49,6 @@ data class Address(
   var addressLine4: String = "",
 
   @Column(name = "POSTCODE", nullable = false)
-  @field:NotBlank(message = "Postcode is required")
   var postcode: String,
 
   @ManyToOne(optional = true)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/dto/UpdateAddressDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/dto/UpdateAddressDto.kt
@@ -1,12 +1,20 @@
 package uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.dto
-
+import jakarta.validation.constraints.NotBlank
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.AddressType
 
 data class UpdateAddressDto(
   val addressType: AddressType,
+
+  @field:NotBlank(message = "Address line 1 is required")
   val addressLine1: String = "",
+
+  @field:NotBlank(message = "Address line 2 is required")
   val addressLine2: String = "",
+
   val addressLine3: String = "",
+
   val addressLine4: String = "",
+
+  @field:NotBlank(message = "Postcode is required")
   val postcode: String = "",
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/dto/UpdateInterestedPartiesDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/dto/UpdateInterestedPartiesDto.kt
@@ -1,5 +1,4 @@
 package uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.dto
-import jakarta.validation.constraints.NotBlank
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.ResponsibleOrganisation
 
 data class UpdateInterestedPartiesDto(
@@ -17,16 +16,13 @@ data class UpdateInterestedPartiesDto(
 
   val responsibleOrganisationEmail: String = "",
 
-  @field:NotBlank(message = "Address line 1 is required")
   val responsibleOrganisationAddressLine1: String = "",
 
-  @field:NotBlank(message = "Address line 2 is required")
   val responsibleOrganisationAddressLine2: String = "",
 
   val responsibleOrganisationAddressLine3: String = "",
 
   val responsibleOrganisationAddressLine4: String = "",
 
-  @field:NotBlank(message = "Postcode is required")
   val responsibleOrganisationAddressPostcode: String = "",
 )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/InterestedPartiesControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/InterestedPartiesControllerTest.kt
@@ -13,7 +13,6 @@ import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.mo
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.OrderStatus
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.ResponsibleOrganisation
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.repository.OrderRepository
-import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.resource.validator.ValidationError
 import java.util.*
 
 class InterestedPartiesControllerTest : IntegrationTestBase() {
@@ -255,7 +254,7 @@ class InterestedPartiesControllerTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `Interested parties details mandatory fields must contain valid values`() {
+  fun `Interested parties fields are all optional`() {
     val order = createOrder()
 
     val result = webTestClient.put()
@@ -264,40 +263,38 @@ class InterestedPartiesControllerTest : IntegrationTestBase() {
       .body(
         BodyInserters.fromValue(
           """
-            {
-              "notifyingOrganisationEmail": "",
-              "responsibleOfficerName": "",
-              "responsibleOfficerPhoneNumber": null,
-              "responsibleOrganisation": null,
-              "responsibleOrganisationRegion": "",
-              "responsibleOrganisationPhoneNumber": null,
-              "responsibleOrganisationEmail": "",
-              "responsibleOrganisationAddressLine1": "",
-              "responsibleOrganisationAddressLine2": "",
-              "responsibleOrganisationAddressLine3": "",
-              "responsibleOrganisationAddressLine4": "",
-              "responsibleOrganisationAddressPostcode": ""
-            }
+            {}
           """.trimIndent(),
         ),
       )
       .headers(setAuthorisation("AUTH_ADM"))
       .exchange()
       .expectStatus()
-      .isBadRequest
-      .expectBodyList(ValidationError::class.java)
+      .isOk
+      .expectBody(InterestedParties::class.java)
       .returnResult()
 
-    Assertions.assertThat(result.responseBody).isNotNull
-    Assertions.assertThat(result.responseBody).hasSize(3)
-    Assertions.assertThat(result.responseBody!!).contains(
-      ValidationError("responsibleOrganisationAddressLine1", "Address line 1 is required"),
-    )
-    Assertions.assertThat(result.responseBody!!).contains(
-      ValidationError("responsibleOrganisationAddressLine2", "Address line 2 is required"),
-    )
-    Assertions.assertThat(result.responseBody!!).contains(
-      ValidationError("responsibleOrganisationAddressPostcode", "Postcode is required"),
-    )
+    val interestedParties = result.responseBody!!
+
+    Assertions.assertThat(interestedParties.notifyingOrganisationEmail).isEqualTo("")
+    Assertions.assertThat(interestedParties.responsibleOfficerName).isEqualTo("")
+    Assertions.assertThat(interestedParties.responsibleOfficerPhoneNumber).isEqualTo(null)
+    Assertions.assertThat(interestedParties.responsibleOrganisation).isEqualTo(null)
+    Assertions.assertThat(interestedParties.responsibleOrganisationRegion).isEqualTo("")
+    Assertions.assertThat(
+      interestedParties.responsibleOrganisationPhoneNumber,
+    ).isEqualTo(null)
+    Assertions.assertThat(interestedParties.responsibleOrganisationEmail).isEqualTo("")
+    Assertions.assertThat(
+      interestedParties.responsibleOrganisationAddress.addressType,
+    ).isEqualTo(AddressType.RESPONSIBLE_ORGANISATION)
+    Assertions.assertThat(interestedParties.responsibleOrganisationAddress.addressLine1).isEqualTo("")
+    Assertions.assertThat(interestedParties.responsibleOrganisationAddress.addressLine2).isEqualTo("")
+    Assertions.assertThat(interestedParties.responsibleOrganisationAddress.addressLine3).isEqualTo("")
+    Assertions.assertThat(interestedParties.responsibleOrganisationAddress.addressLine4).isEqualTo("")
+    Assertions.assertThat(interestedParties.responsibleOrganisationAddress.postcode).isEqualTo("")
+    Assertions.assertThat(
+      interestedParties.responsibleOrganisationAddress.addressUsage,
+    ).isEqualTo(DeviceWearerAddressUsage.NA)
   }
 }


### PR DESCRIPTION
Feedback from product owner is that all interested party fields are optional.

- Addresses can now be stored with empty strings for all values (addressLine1, addressLine2, ... , postcode) therefore allowing us to create the responsible organisation address without the user having to provide values.
- The `UpdateAddressDto` does validation for all other addresses, (primary, secondary, tertiary, installation) ensuring that they remain valid when created by the end user.