### PR TITLE
Update start dates to allow historic dates

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/CurfewConditions.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/CurfewConditions.kt
@@ -24,7 +24,6 @@ data class CurfewConditions(
   val orderId: UUID,
 
   @field:NotNull(message = "Enter curfew start day")
-  @field:Future(message = "Curfew start day must be in the future")
   @Column(name = "START_DATE", nullable = true)
   var startDate: ZonedDateTime? = null,
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/CurfewReleaseDateConditions.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/CurfewReleaseDateConditions.kt
@@ -8,7 +8,6 @@ import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.OneToOne
 import jakarta.persistence.Table
-import jakarta.validation.constraints.Future
 import jakarta.validation.constraints.NotNull
 import jakarta.validation.constraints.Size
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.AddressType
@@ -26,7 +25,6 @@ data class CurfewReleaseDateConditions(
   val orderId: UUID,
 
   @field:NotNull(message = "Enter curfew release day")
-  @field:Future(message = "Curfew release day must be in the future")
   @Column(name = "RELEASE_DATE", nullable = true)
   var releaseDate: ZonedDateTime? = null,
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/EnforcementZoneConditions.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/EnforcementZoneConditions.kt
@@ -32,10 +32,10 @@ data class EnforcementZoneConditions(
   var zoneType: EnforcementZoneType? = null,
 
   @field:NotNull(message = "Enforcement zone start date is required")
-  @field:Future(message = "Enforcement zone start date must be in the future")
   @Column(name = "START_DATE", nullable = false)
   var startDate: ZonedDateTime? = null,
 
+  @field:Future(message = "Enforcement zone end date must be in the future")
   @Column(name = "END_DATE", nullable = true)
   var endDate: ZonedDateTime? = null,
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/dto/UpdateAlcoholMonitoringConditionsDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/dto/UpdateAlcoholMonitoringConditionsDto.kt
@@ -12,7 +12,6 @@ data class UpdateAlcoholMonitoringConditionsDto(
   val monitoringType: AlcoholMonitoringType? = null,
 
   @field:NotNull(message = "Start date is required")
-  @field:Future(message = "Start date must be in the future")
   val startDate: ZonedDateTime? = null,
 
   @field:Future(message = "End date must be in the future")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/dto/UpdateTrailMonitoringConditionsDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/dto/UpdateTrailMonitoringConditionsDto.kt
@@ -6,7 +6,6 @@ import java.time.ZonedDateTime
 
 data class UpdateTrailMonitoringConditionsDto(
   @field:NotNull(message = "Start date is required")
-  @field:Future(message = "Start date must be in the future")
   val startDate: ZonedDateTime? = null,
   @field:Future(message = "End date must be in the future")
   val endDate: ZonedDateTime? = null,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/CurfewReleaseDateControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/CurfewReleaseDateControllerTest.kt
@@ -119,18 +119,17 @@ class CurfewReleaseDateControllerTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `Should return errors when release date is in the past`() {
+  fun `Should not return errors when release date is in the past`() {
     val order = createOrder()
-    order.status = OrderStatus.SUBMITTED
     orderRepo.save(order)
-    val result = webTestClient.put()
+    webTestClient.put()
       .uri("/api/orders/${order.id}/monitoring-conditions-curfew-release-date")
       .contentType(MediaType.APPLICATION_JSON)
       .body(
         BodyInserters.fromValue(
           mockRequestBody(
             order.id,
-            ZonedDateTime.now().plusDays(-3),
+            ZonedDateTime.now().minusDays(1),
             "19:00:00",
             "23:00:00",
             AddressType.PRIMARY,
@@ -140,15 +139,8 @@ class CurfewReleaseDateControllerTest : IntegrationTestBase() {
       .headers(setAuthorisation())
       .exchange()
       .expectStatus()
-      .isBadRequest
-      .expectBodyList(ValidationError::class.java)
-      .returnResult()
-    val error = result.responseBody!!
-    Assertions.assertThat(result.responseBody).hasSize(1)
-
-    Assertions.assertThat(
-      error,
-    ).contains(ValidationError("releaseDate", "Curfew release day must be in the future"))
+      .isOk
+      .expectBody(CurfewReleaseDateConditions::class.java)
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/EnforcementZoneControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/EnforcementZoneControllerTest.kt
@@ -190,7 +190,7 @@ class EnforcementZoneControllerTest : IntegrationTestBase() {
   fun `Should not return error when enforcement zone start date is in the past`() {
     val order = createOrder()
 
-    val result = webTestClient.put()
+    webTestClient.put()
       .uri("/api/orders/${order.id}/enforcementZone")
       .contentType(MediaType.APPLICATION_JSON)
       .body(
@@ -206,7 +206,6 @@ class EnforcementZoneControllerTest : IntegrationTestBase() {
       .expectStatus()
       .isOk()
       .expectBody(EnforcementZoneConditions::class.java)
-      .returnResult()
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/EnforcementZoneControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/EnforcementZoneControllerTest.kt
@@ -44,6 +44,12 @@ class EnforcementZoneControllerTest : IntegrationTestBase() {
 
   private val mockStartDate = ZonedDateTime.now(ZoneId.of("UTC")).plusMonths(1)
   private val mockEndDate = ZonedDateTime.now(ZoneId.of("UTC")).plusMonths(2)
+  private val mockPastStartDate = ZonedDateTime.of(
+    LocalDate.of(1970, 2, 1),
+    LocalTime.NOON,
+    ZoneId.of("UTC"),
+  )
+  private val mockPastEndDate = mockPastStartDate.plusDays(1)
   private final val mockUser = "AUTH_ADM"
   private final val mockOrder = Order(username = mockUser, status = OrderStatus.IN_PROGRESS)
 
@@ -151,7 +157,7 @@ class EnforcementZoneControllerTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `Should return error when enforcement zone start date and end date is in the past`() {
+  fun `Should return error when enforcement zone end date is in the past`() {
     val order = createOrder()
 
     val result = webTestClient.put()
@@ -161,11 +167,8 @@ class EnforcementZoneControllerTest : IntegrationTestBase() {
         BodyInserters.fromValue(
           mockRequestBody(
             order.id,
-            startDate = ZonedDateTime.of(
-              LocalDate.of(1970, 2, 1),
-              LocalTime.NOON,
-              ZoneId.of("UTC"),
-            ),
+            startDate = mockPastStartDate,
+            endDate = mockPastEndDate,
           ),
         ),
       )
@@ -179,8 +182,31 @@ class EnforcementZoneControllerTest : IntegrationTestBase() {
     Assertions.assertThat(result.responseBody).hasSize(1)
 
     Assertions.assertThat(result.responseBody!!).contains(
-      ValidationError("startDate", "Enforcement zone start date must be in the future"),
+      ValidationError("endDate", "Enforcement zone end date must be in the future"),
     )
+  }
+
+  @Test
+  fun `Should not return error when enforcement zone start date is in the past`() {
+    val order = createOrder()
+
+    val result = webTestClient.put()
+      .uri("/api/orders/${order.id}/enforcementZone")
+      .contentType(MediaType.APPLICATION_JSON)
+      .body(
+        BodyInserters.fromValue(
+          mockRequestBody(
+            order.id,
+            startDate = mockPastStartDate,
+          ),
+        ),
+      )
+      .headers(setAuthorisation(mockUser))
+      .exchange()
+      .expectStatus()
+      .isOk()
+      .expectBody(EnforcementZoneConditions::class.java)
+      .returnResult()
   }
 
   @Test
@@ -194,11 +220,8 @@ class EnforcementZoneControllerTest : IntegrationTestBase() {
         BodyInserters.fromValue(
           mockRequestBody(
             order.id,
-            endDate = ZonedDateTime.of(
-              LocalDate.of(1970, 2, 1),
-              LocalTime.NOON,
-              ZoneId.of("UTC"),
-            ),
+            startDate = mockStartDate,
+            endDate = mockStartDate.minusDays(1),
           ),
         ),
       )


### PR DESCRIPTION
### Context

User acceptance testing revealed that there are circumstances where users will input historic start dates for different monitoring conditions and/or a historic curfew release date.

## Changes proposed in this PR

This PR removes the validation that enforces future dates, where appropriate.