### PR TITLE
Remove outdated monitoring conditions startDate validation

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/dto/UpdateMonitoringConditionsDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/dto/UpdateMonitoringConditionsDto.kt
@@ -1,7 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.dto
 
 import jakarta.validation.constraints.AssertTrue
-import jakarta.validation.constraints.Future
 import jakarta.validation.constraints.NotNull
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.MonitoringConditionType
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.OrderTypeDescription
@@ -25,7 +24,6 @@ data class UpdateMonitoringConditionsDto(
   var curfew: Boolean? = null,
 
   @field:NotNull(message = "Monitoring conditions start date is required")
-  @field:Future(message = "Monitoring conditions start date must be in the future")
   var startDate: ZonedDateTime? = null,
 
   var endDate: ZonedDateTime? = null,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/MonitoringConditionsControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/MonitoringConditionsControllerTest.kt
@@ -185,7 +185,8 @@ class MonitoringConditionsControllerTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `Update monitoring conditions returns 400 if start is in the past`() {
+  fun `Update monitoring conditions allows start date in the past`() {
+    val mockPastStartDate = ZonedDateTime.now(ZoneId.of("UTC")).minusMonths(1)
     val order = createOrder()
     val result = webTestClient.put()
       .uri("/api/orders/${order.id}/monitoring-conditions")
@@ -205,7 +206,7 @@ class MonitoringConditionsControllerTest : IntegrationTestBase() {
               "trail": "true",
               "mandatoryAttendance": "true",
               "alcohol": "true",
-              "startDate": "${mockStartDate.plusYears(-10)}",
+              "startDate": "$mockPastStartDate",
               "endDate": null
             }
           """.trimIndent(),
@@ -214,15 +215,8 @@ class MonitoringConditionsControllerTest : IntegrationTestBase() {
       .headers(setAuthorisation("AUTH_ADM"))
       .exchange()
       .expectStatus()
-      .isBadRequest
-      .expectBodyList(ValidationError::class.java)
-      .returnResult()
-
-    Assertions.assertThat(result.responseBody).isNotNull
-    Assertions.assertThat(result.responseBody).hasSize(1)
-    Assertions.assertThat(result.responseBody!!).contains(
-      ValidationError("startDate", "Monitoring conditions start date must be in the future"),
-    )
+      .isOk
+      .expectBodyList(MonitoringConditions::class.java)
   }
 
   @Test


### PR DESCRIPTION
Adds a missing update from [#84 update start dates to allow historic dates](#84 )