### PR TITLE
Add the ability to search for orders by firstName and lastName

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/criteria/OrderSearchCriteria.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/criteria/OrderSearchCriteria.kt
@@ -1,5 +1,6 @@
-package uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.dto
+package uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.criteria
 
-data class SearchOrdersDto(
+data class OrderSearchCriteria(
   val searchTerm: String = "",
+  val username: String,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/criteria/OrderSearchCriteria.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/criteria/OrderSearchCriteria.kt
@@ -1,0 +1,5 @@
+package uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.dto
+
+data class SearchOrdersDto(
+  val searchTerm: String = "",
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/specification/OrderSpecification.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/specification/OrderSpecification.kt
@@ -1,0 +1,4 @@
+package uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.specification
+
+class OrderSpecification {
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/specification/OrderSpecification.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/specification/OrderSpecification.kt
@@ -1,4 +1,73 @@
 package uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.specification
 
-class OrderSpecification {
+import jakarta.persistence.criteria.CriteriaBuilder
+import jakarta.persistence.criteria.CriteriaQuery
+import jakarta.persistence.criteria.Join
+import jakarta.persistence.criteria.Predicate
+import jakarta.persistence.criteria.Root
+import org.springframework.data.jpa.domain.Specification
+import org.springframework.lang.Nullable
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.DeviceWearer
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.Order
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.criteria.OrderSearchCriteria
+
+class OrderSpecification(private val criteria: OrderSearchCriteria) : Specification<Order> {
+  private fun wildcard(str: String): String {
+    return "%$str%"
+  }
+
+  private fun isOwnedByUser(root: Root<Order>, criteriaBuilder: CriteriaBuilder, username: String): Predicate {
+    return criteriaBuilder.equal(root.get<String>(Order::username.name), username)
+  }
+
+  private fun isLikeFirstname(
+    deviceWearer: Join<Order, DeviceWearer>,
+    criteriaBuilder: CriteriaBuilder,
+    keyword: String,
+  ): Predicate {
+    return criteriaBuilder.like(
+      criteriaBuilder.lower(
+        deviceWearer.get(DeviceWearer::firstName.name),
+      ),
+      wildcard(keyword).lowercase(),
+    )
+  }
+
+  private fun isLikeLastname(
+    deviceWearer: Join<Order, DeviceWearer>,
+    criteriaBuilder: CriteriaBuilder,
+    keyword: String,
+  ): Predicate {
+    return criteriaBuilder.like(
+      criteriaBuilder.lower(
+        deviceWearer.get(DeviceWearer::lastName.name),
+      ),
+      wildcard(keyword).lowercase(),
+    )
+  }
+
+  override fun toPredicate(
+    root: Root<Order>,
+    @Nullable query: CriteriaQuery<*>?,
+    criteriaBuilder: CriteriaBuilder,
+  ): Predicate? {
+    val predicates = mutableListOf<Predicate>()
+    val deviceWearer: Join<Order, DeviceWearer> = root.join("deviceWearer")
+
+    if (this.criteria.searchTerm.isNotEmpty()) {
+      predicates.add(isLikeFirstname(deviceWearer, criteriaBuilder, this.criteria.searchTerm))
+      predicates.add(isLikeLastname(deviceWearer, criteriaBuilder, this.criteria.searchTerm))
+    }
+
+    if (predicates.isNotEmpty()) {
+      return criteriaBuilder.and(
+        isOwnedByUser(root, criteriaBuilder, this.criteria.username),
+        criteriaBuilder.or(*predicates.toTypedArray()),
+      )
+    }
+
+    return criteriaBuilder.and(
+      isOwnedByUser(root, criteriaBuilder, this.criteria.username),
+    )
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/repository/OrderRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/repository/OrderRepository.kt
@@ -1,13 +1,19 @@
 package uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor
+import org.springframework.data.repository.PagingAndSortingRepository
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.Order
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.OrderStatus
 import java.util.*
 
 @Repository
-interface OrderRepository : JpaRepository<Order, UUID> {
+interface OrderRepository :
+  PagingAndSortingRepository<Order, UUID>,
+  JpaSpecificationExecutor<Order>,
+  JpaRepository<Order, UUID> {
+
   fun findByUsername(username: String): List<Order>
 
   fun findByUsernameAndId(username: String, id: UUID): Optional<Order>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/resource/OrderController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/resource/OrderController.kt
@@ -10,8 +10,10 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.Order
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.criteria.OrderSearchCriteria
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.service.OrderService
 import java.util.UUID
 
@@ -55,10 +57,10 @@ class OrderController(
   }
 
   @GetMapping("/orders")
-  fun listOrders(authentication: Authentication): ResponseEntity<List<Order>> {
+  fun listOrders(@RequestParam searchTerm: String = "", authentication: Authentication): ResponseEntity<List<Order>> {
     val username = authentication.name
+    val orders = orderService.listOrders(OrderSearchCriteria(searchTerm, username))
 
-    val orders = orderService.listOrdersForUser(username)
     return ResponseEntity(orders, HttpStatus.OK)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/OrderService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/OrderService.kt
@@ -6,8 +6,10 @@ import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.ex
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.DeviceWearer
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.MonitoringConditions
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.Order
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.criteria.OrderSearchCriteria
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.FmsOrderSource
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.OrderStatus
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.specification.OrderSpecification
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.repository.OrderRepository
 import java.util.UUID
 
@@ -89,9 +91,13 @@ class OrderService(
     return order
   }
 
-  fun listOrdersForUser(username: String): List<Order> {
-    return repo.findByUsername(
-      username,
+  fun listOrders(searchCriteria: OrderSearchCriteria): List<Order> {
+    return repo.findAll(
+      OrderSpecification(searchCriteria),
     )
+
+//    return repo.findByUsername(
+//      username,
+//    )
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/OrderService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/OrderService.kt
@@ -95,9 +95,5 @@ class OrderService(
     return repo.findAll(
       OrderSpecification(searchCriteria),
     )
-
-//    return repo.findByUsername(
-//      username,
-//    )
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/OrderControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/OrderControllerTest.kt
@@ -78,14 +78,118 @@ class OrderControllerTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `Only orders belonging to user returned from database`() {
+  fun `SEARCH should return orders when no searchTerm is provided`() {
+    createOrder("AUTH_ADM")
+
+    webTestClient.get()
+      .uri("/api/orders")
+      .headers(setAuthorisation("AUTH_ADM"))
+      .exchange()
+      .expectStatus()
+      .isOk
+      .expectBodyList(Order::class.java)
+      .hasSize(1)
+  }
+
+  @Test
+  fun `SEARCH should return orders when an empty searchTerm is provided`() {
+    createOrder("AUTH_ADM")
+
+    webTestClient.get()
+      .uri("/api/orders?searchTerm=")
+      .headers(setAuthorisation("AUTH_ADM"))
+      .exchange()
+      .expectStatus()
+      .isOk
+      .expectBodyList(Order::class.java)
+      .hasSize(1)
+  }
+
+  @Test
+  fun `SEARCH should return orders where the firstName matches the searchTerm`() {
+    val order = createOrder("AUTH_ADM")
+
+    order.deviceWearer = DeviceWearer(
+      orderId = order.id,
+      firstName = "John",
+    )
+    repo.save(order)
+
+    webTestClient.get()
+      .uri("/api/orders?searchTerm=John")
+      .headers(setAuthorisation("AUTH_ADM"))
+      .exchange()
+      .expectStatus()
+      .isOk
+      .expectBodyList(Order::class.java)
+      .hasSize(1)
+  }
+
+  @Test
+  fun `SEARCH should return orders where the lastName matches the searchTerm`() {
+    val order = createOrder("AUTH_ADM")
+
+    order.deviceWearer = DeviceWearer(
+      orderId = order.id,
+      lastName = "Smith",
+    )
+    repo.save(order)
+
+    webTestClient.get()
+      .uri("/api/orders?searchTerm=Smith")
+      .headers(setAuthorisation("AUTH_ADM"))
+      .exchange()
+      .expectStatus()
+      .isOk
+      .expectBodyList(Order::class.java)
+      .hasSize(1)
+  }
+
+  @Test
+  fun `SEARCH should return orders where the firstName matches the searchTerm with different casing`() {
+    val order = createOrder("AUTH_ADM")
+
+    order.deviceWearer = DeviceWearer(
+      orderId = order.id,
+      firstName = "John",
+    )
+    repo.save(order)
+
+    webTestClient.get()
+      .uri("/api/orders?searchTerm=john")
+      .headers(setAuthorisation("AUTH_ADM"))
+      .exchange()
+      .expectStatus()
+      .isOk
+      .expectBodyList(Order::class.java)
+      .hasSize(1)
+  }
+
+  @Test
+  fun `SEARCH should return orders where the lastName matches the searchTerm with different casing`() {
+    val order = createOrder("AUTH_ADM")
+
+    order.deviceWearer = DeviceWearer(
+      orderId = order.id,
+      lastName = "Smith",
+    )
+    repo.save(order)
+
+    webTestClient.get()
+      .uri("/api/orders?searchTerm=smith")
+      .headers(setAuthorisation("AUTH_ADM"))
+      .exchange()
+      .expectStatus()
+      .isOk
+      .expectBodyList(Order::class.java)
+      .hasSize(1)
+  }
+
+  @Test
+  fun `SEARCH should only return orders belonging to user`() {
     createOrder("AUTH_ADM")
     createOrder("AUTH_ADM")
     createOrder("AUTH_ADM_2")
-
-    // Verify the database is set up correctly
-    val allOrders = repo.findAll()
-    assertThat(allOrders).hasSize(3)
 
     webTestClient.get()
       .uri("/api/orders")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/resources/OrderControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/resources/OrderControllerTest.kt
@@ -9,6 +9,7 @@ import org.springframework.boot.test.autoconfigure.json.JsonTest
 import org.springframework.security.core.Authentication
 import org.springframework.test.context.ActiveProfiles
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.Order
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.criteria.OrderSearchCriteria
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.OrderStatus
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.resource.OrderController
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.service.OrderService
@@ -58,10 +59,10 @@ class OrderControllerTest {
       Order(username = "mockUser", status = OrderStatus.IN_PROGRESS),
     )
 
-    `when`(orderService.listOrdersForUser("mockUser")).thenReturn(orders)
+    `when`(orderService.listOrders(OrderSearchCriteria(username = "mockUser"))).thenReturn(orders)
     `when`(authentication.name).thenReturn("mockUser")
 
-    val result = controller.listOrders(authentication)
+    val result = controller.listOrders("", authentication)
     Assertions.assertThat(result.body).isEqualTo(orders)
   }
 }


### PR DESCRIPTION
- Implements searching for orders by `order.deviceWearer.firstName`
- Implements searching for orders by `order.deviceWearer.lastName`
- Searching is case insensitive
- Implements the search functionality using the [Spring JPA Specifications](https://docs.spring.io/spring-data/jpa/reference/jpa/specifications.html) to allow creation of more complex predicates than the normal repository methods would allow.
- Works with the existing UI implementation because `searchTerm` is optional in the controller and within the specification.