### PR TITLE
Update allow list

### DIFF
--- a/helm_deploy/hmpps-electronic-monitoring-create-an-order-api/values.yaml
+++ b/helm_deploy/hmpps-electronic-monitoring-create-an-order-api/values.yaml
@@ -59,7 +59,7 @@ generic-service:
       HMPPS_SQS_QUEUES_COURTHEARINGEVENTQUEUE_DLQNAME: "sqs_queue_name"
   allowlist:
     groups:
-      - internal
+      - digital_staff_and_mojo
 
 generic-prometheus-alerts:
   targetApplication: hmpps-electronic-monitoring-create-an-order-api


### PR DESCRIPTION
This PR replaces the deprecated 'internal' [allow list group](https://github.com/ministryofjustice/hmpps-ip-allowlists) for our preprod and prod environments with the newer 'digital_staff_and_mojo' group.