### PR TITLE
Initial implementation of create a variation

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/Order.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/Order.kt
@@ -12,6 +12,7 @@ import jakarta.persistence.OneToOne
 import jakarta.persistence.Table
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.AddressType
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.OrderStatus
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.OrderType
 import java.util.UUID
 
 @Entity
@@ -28,6 +29,10 @@ data class Order(
   @Enumerated(EnumType.STRING)
   @Column(name = "STATUS", nullable = false)
   var status: OrderStatus,
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "TYPE", nullable = false)
+  var type: OrderType = OrderType.REQUEST,
 
   @Column(name = "FMS_RESULT_ID", nullable = true)
   var fmsResultId: UUID? = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/Order.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/Order.kt
@@ -32,7 +32,7 @@ data class Order(
 
   @Enumerated(EnumType.STRING)
   @Column(name = "TYPE", nullable = false)
-  var type: OrderType = OrderType.REQUEST,
+  var type: OrderType,
 
   @Column(name = "FMS_RESULT_ID", nullable = true)
   var fmsResultId: UUID? = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/dto/CreateOrderDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/dto/CreateOrderDto.kt
@@ -1,0 +1,7 @@
+package uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.dto
+
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.OrderType
+
+data class CreateOrderDto(
+  val type: OrderType = OrderType.REQUEST,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/enums/OrderType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/enums/OrderType.kt
@@ -1,0 +1,6 @@
+package uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums
+
+enum class OrderType {
+  REQUEST,
+  VARIATION,
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/resource/OrderController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/resource/OrderController.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.resource
 
+import jakarta.validation.Valid
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -9,11 +10,13 @@ import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.Order
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.criteria.OrderSearchCriteria
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.dto.CreateOrderDto
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.service.OrderService
 import java.util.UUID
 
@@ -25,10 +28,13 @@ class OrderController(
 ) {
 
   @PostMapping("/orders")
-  fun createOrder(authentication: Authentication): ResponseEntity<Order> {
+  fun createOrder(
+    authentication: Authentication,
+    @RequestBody @Valid createOrderRecord: CreateOrderDto = CreateOrderDto(),
+  ): ResponseEntity<Order> {
     val username = authentication.name
+    val order = orderService.createOrder(username, createOrderRecord)
 
-    val order = orderService.createOrder(username)
     return ResponseEntity(order, HttpStatus.OK)
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/OrderService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/OrderService.kt
@@ -10,6 +10,7 @@ import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.mo
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.dto.CreateOrderDto
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.FmsOrderSource
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.OrderStatus
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.OrderType
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.specification.OrderSpecification
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.repository.OrderRepository
 import java.util.UUID
@@ -60,6 +61,10 @@ class OrderService(
 
   fun submitOrder(id: UUID, username: String): Order {
     val order = getOrder(username, id)!!
+
+    if (order.type == OrderType.VARIATION) {
+      throw SubmitOrderException("A variation cannot be submitted yet!")
+    }
 
     if (order.status == OrderStatus.SUBMITTED) {
       throw SubmitOrderException("This order has already been submitted")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/OrderService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/OrderService.kt
@@ -7,6 +7,7 @@ import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.mo
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.MonitoringConditions
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.Order
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.criteria.OrderSearchCriteria
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.dto.CreateOrderDto
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.FmsOrderSource
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.OrderStatus
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.specification.OrderSpecification
@@ -19,16 +20,19 @@ class OrderService(
   val fmsService: FmsService,
 
 ) {
-  fun createOrder(username: String): Order {
+  fun createOrder(username: String, createRecord: CreateOrderDto): Order {
     val order = Order(
       username = username,
       status = OrderStatus.IN_PROGRESS,
+      type = createRecord.type,
     )
+
     order.deviceWearer = DeviceWearer(orderId = order.id)
     order.addresses = mutableListOf()
     order.monitoringConditions = MonitoringConditions(orderId = order.id)
     order.additionalDocuments = mutableListOf()
     order.enforcementZoneConditions = mutableListOf()
+
     repo.save(order)
     return order
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/courthearing/HearingEventHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/courthearing/HearingEventHandler.kt
@@ -22,6 +22,7 @@ import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.mo
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.FmsOrderSource
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.MonitoringConditionType
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.OrderStatus
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.OrderType
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.service.FmsService
 import java.time.LocalDate
 import java.time.LocalTime
@@ -144,7 +145,7 @@ class HearingEventHandler(
     val judicialResults = offences.flatMap { it.judicialResults }.toList()
 
     val prompts = judicialResults.flatMap { it.judicialResultPrompts }.toList()
-    val order = Order(username = commentPlatformUsername, status = OrderStatus.IN_PROGRESS)
+    val order = Order(username = commentPlatformUsername, status = OrderStatus.IN_PROGRESS, type = OrderType.REQUEST)
 
     val monitoringConditions = MonitoringConditions(orderId = order.id)
     val orderedDate = judicialResults.first().orderedDate

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/IntegrationTestBase.kt
@@ -7,6 +7,7 @@ import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDO
 import org.springframework.http.HttpHeaders
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.reactive.server.WebTestClient
+import org.springframework.web.reactive.function.BodyInserters
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.integration.wiremock.HmppsAuthApiExtension
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.integration.wiremock.HmppsAuthApiExtension.Companion.hmppsAuth
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.integration.wiremock.HmppsDocumentManagementApiExtension
@@ -53,6 +54,24 @@ abstract class IntegrationTestBase {
 
   fun createOrder(username: String? = "AUTH_ADM"): Order = webTestClient.post()
     .uri("/api/orders")
+    .headers(setAuthorisation(username))
+    .exchange()
+    .expectStatus()
+    .isOk
+    .returnResult(Order::class.java)
+    .responseBody.blockFirst()!!
+
+  fun createVariation(username: String? = "AUTH_ADM"): Order = webTestClient.post()
+    .uri("/api/orders")
+    .body(
+      BodyInserters.fromValue(
+        """
+            {
+              "type": "VARIATION"
+            }
+        """.trimIndent(),
+      ),
+    )
     .headers(setAuthorisation(username))
     .exchange()
     .expectStatus()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/IntegrationTestBase.kt
@@ -5,6 +5,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT
 import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.reactive.server.WebTestClient
 import org.springframework.web.reactive.function.BodyInserters
@@ -63,6 +64,7 @@ abstract class IntegrationTestBase {
 
   fun createVariation(username: String? = "AUTH_ADM"): Order = webTestClient.post()
     .uri("/api/orders")
+    .contentType(MediaType.APPLICATION_JSON)
     .body(
       BodyInserters.fromValue(
         """

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/AdditionalDocumentsControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/AdditionalDocumentsControllerTest.kt
@@ -23,6 +23,7 @@ import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.mo
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.documentmanagement.DocumentUploadResponse
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.DocumentType
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.OrderStatus
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.OrderType
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.repository.AdditionalDocumentRepository
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.repository.OrderRepository
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
@@ -38,7 +39,7 @@ class AdditionalDocumentsControllerTest : IntegrationTestBase() {
 
   @SpyBean
   lateinit var apiCLient: DocumentApiClient
-  val order = Order(username = "mockUser", status = OrderStatus.IN_PROGRESS)
+  val order = Order(username = "mockUser", status = OrderStatus.IN_PROGRESS, type = OrderType.REQUEST)
 
   @Suppress("ktlint:standard:max-line-length")
   private val filePath = "src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/assets/profile.jpeg"

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/EnforcementZoneControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/EnforcementZoneControllerTest.kt
@@ -22,6 +22,7 @@ import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.mo
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.documentmanagement.DocumentUploadResponse
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.EnforcementZoneType
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.OrderStatus
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.OrderType
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.repository.EnforcementZoneRepository
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.repository.OrderRepository
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.resource.validator.ValidationError
@@ -51,7 +52,7 @@ class EnforcementZoneControllerTest : IntegrationTestBase() {
   )
   private val mockPastEndDate = mockPastStartDate.plusDays(1)
   private final val mockUser = "AUTH_ADM"
-  private final val mockOrder = Order(username = mockUser, status = OrderStatus.IN_PROGRESS)
+  private final val mockOrder = Order(username = mockUser, status = OrderStatus.IN_PROGRESS, type = OrderType.REQUEST)
 
   @BeforeEach
   fun setup() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/OrderControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/OrderControllerTest.kt
@@ -427,7 +427,6 @@ class OrderControllerTest : IntegrationTestBase() {
     @Test
     fun `It should throw an error if an incomplete order is submitted`() {
       val order = createOrder()
-      repo.save(order)
 
       val result = webTestClient.post()
         .uri("/api/orders/${order.id}/submit")
@@ -441,6 +440,25 @@ class OrderControllerTest : IntegrationTestBase() {
       val error = result.responseBody!!
       assertThat(error.userMessage)
         .isEqualTo("Error submitting order: Please complete all mandatory fields before submitting this form")
+    }
+
+    @Test
+    fun `It should throw an error if a variation is submitted`() {
+      // Temporary test to ensure that variations can't be submitted
+      val order = createVariation()
+
+      val result = webTestClient.post()
+        .uri("/api/orders/${order.id}/submit")
+        .headers(setAuthorisation())
+        .exchange()
+        .expectStatus()
+        .is4xxClientError
+        .expectBody(ErrorResponse::class.java)
+        .returnResult()
+
+      val error = result.responseBody!!
+      assertThat(error.userMessage)
+        .isEqualTo("Error submitting order: A variation cannot be submitted yet!")
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/OrderControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/OrderControllerTest.kt
@@ -98,7 +98,7 @@ class OrderControllerTest : IntegrationTestBase() {
             {
               "type": "VARIATION"
             }
-          """.trimIndent(),
+            """.trimIndent(),
           ),
         )
         .headers(setAuthorisation())
@@ -601,7 +601,7 @@ class OrderControllerTest : IntegrationTestBase() {
       	"interpreter_required": "true",
       	"language": "British Sign"
       }
-    """.trimIndent()
+      """.trimIndent()
       val expectedOrderJson = """
       {
       	"case_id": "MockDeviceWearerId",
@@ -781,7 +781,7 @@ class OrderControllerTest : IntegrationTestBase() {
       	"revocation_type": "",
       	"order_status": "Not Started"
       }
-    """.trimIndent()
+      """.trimIndent()
 
       assertThat(submitResult!!.fmsDeviceWearerRequest).isEqualTo(expectedDWJson.removeWhitespaceAndNewlines())
       assertThat(submitResult.fmsOrderRequest).isEqualTo(expectedOrderJson.removeWhitespaceAndNewlines())
@@ -867,24 +867,20 @@ class OrderControllerTest : IntegrationTestBase() {
       	"interpreter_required": "true",
       	"language": "British Sign"
       }
-    """.trimIndent()
+      """.trimIndent()
 
       assertThat(submitResult!!.fmsDeviceWearerRequest).isEqualTo(expectedDWJson.removeWhitespaceAndNewlines())
 
       val updatedOrder = repo.findById(order.id).get()
       assertThat(updatedOrder.fmsResultId).isEqualTo(submitResult.id)
     }
-
   }
-
-
-
-
 
   fun createReadyToSubmitOrder(noFixedAddress: Boolean = false): Order {
     val order = Order(
       username = "AUTH_ADM",
       status = OrderStatus.IN_PROGRESS,
+      type = OrderType.REQUEST,
     )
     order.deviceWearer = DeviceWearer(
       orderId = order.id,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/repository/OrderRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/repository/OrderRepositoryTest.kt
@@ -13,6 +13,7 @@ import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.mo
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.AlcoholMonitoringType
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.DeviceWearerAddressUsage
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.OrderStatus
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.OrderType
 import java.time.LocalDate
 import java.time.LocalTime
 import java.time.ZoneId
@@ -70,6 +71,7 @@ class OrderRepositoryTest {
     id = mockOrderId,
     username = mockUsername,
     status = OrderStatus.IN_PROGRESS,
+    type = OrderType.REQUEST,
     monitoringConditionsAlcohol = AlcoholMonitoringConditions(
       id = mockAlcoholMonitoringConditionsId,
       orderId = mockOrderId,
@@ -88,6 +90,7 @@ class OrderRepositoryTest {
     id = mockOrderId,
     username = mockUsername,
     status = OrderStatus.IN_PROGRESS,
+    type = OrderType.REQUEST,
     monitoringConditionsAlcohol = AlcoholMonitoringConditions(
       id = mockAlcoholMonitoringConditionsId,
       orderId = mockOrderId,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/resources/OrderControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/resources/OrderControllerTest.kt
@@ -10,7 +10,9 @@ import org.springframework.security.core.Authentication
 import org.springframework.test.context.ActiveProfiles
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.Order
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.criteria.OrderSearchCriteria
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.dto.CreateOrderDto
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.OrderStatus
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.OrderType
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.resource.OrderController
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.service.OrderService
 import java.util.*
@@ -29,11 +31,11 @@ class OrderControllerTest {
 
   @Test
   fun `Create a new order and return`() {
-    val mockOrder = Order(username = "mockUser", status = OrderStatus.IN_PROGRESS)
-    `when`(orderService.createOrder("mockUser")).thenReturn(mockOrder)
+    val mockOrder = Order(username = "mockUser", status = OrderStatus.IN_PROGRESS, type = OrderType.REQUEST)
+    `when`(orderService.createOrder("mockUser", CreateOrderDto())).thenReturn(mockOrder)
     `when`(authentication.name).thenReturn("mockUser")
 
-    val result = controller.createOrder(authentication)
+    val result = controller.createOrder(authentication, CreateOrderDto())
     Assertions.assertThat(result.body).isNotNull
     Assertions.assertThat(result.body!!.username).isEqualTo("mockUser")
     Assertions.assertThat(result.body!!.status).isEqualTo(OrderStatus.IN_PROGRESS)
@@ -43,7 +45,7 @@ class OrderControllerTest {
 
   @Test
   fun `Query a single order and return`() {
-    val order = Order(username = "mockUser", status = OrderStatus.IN_PROGRESS)
+    val order = Order(username = "mockUser", status = OrderStatus.IN_PROGRESS, type = OrderType.REQUEST)
 
     `when`(orderService.getOrder("mockUser", order.id)).thenReturn(order)
     `when`(authentication.name).thenReturn("mockUser")
@@ -55,8 +57,8 @@ class OrderControllerTest {
   @Test
   fun `Query orders for current user and return`() {
     val orders: List<Order> = listOf(
-      Order(username = "mockUser", status = OrderStatus.IN_PROGRESS),
-      Order(username = "mockUser", status = OrderStatus.IN_PROGRESS),
+      Order(username = "mockUser", status = OrderStatus.IN_PROGRESS, type = OrderType.REQUEST),
+      Order(username = "mockUser", status = OrderStatus.IN_PROGRESS, type = OrderType.REQUEST),
     )
 
     `when`(orderService.listOrders(OrderSearchCriteria(username = "mockUser"))).thenReturn(orders)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/AdditionalDocumentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/AdditionalDocumentServiceTest.kt
@@ -25,6 +25,7 @@ import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.mo
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.Order
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.DocumentType
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.OrderStatus
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.OrderType
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.repository.AdditionalDocumentRepository
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.repository.OrderRepository
 import java.io.ByteArrayInputStream
@@ -39,7 +40,7 @@ class AdditionalDocumentServiceTest {
   private lateinit var orderRepop: OrderRepository
 
   val username: String = "username"
-  val order = Order(username = username, status = OrderStatus.IN_PROGRESS)
+  val order = Order(username = username, status = OrderStatus.IN_PROGRESS, type = OrderType.REQUEST)
   val orderId = order.id
   val docType: DocumentType = DocumentType.LICENCE
   val doc: AdditionalDocument = AdditionalDocument(orderId = orderId, fileType = docType)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/AddressServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/AddressServiceTest.kt
@@ -19,6 +19,7 @@ import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.mo
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.AlcoholMonitoringType
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.DeviceWearerAddressUsage
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.OrderStatus
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.OrderType
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.repository.OrderRepository
 import java.time.LocalDate
 import java.time.LocalTime
@@ -90,6 +91,7 @@ class AddressServiceTest {
     id = mockOrderId,
     username = mockUsername,
     status = OrderStatus.IN_PROGRESS,
+    type = OrderType.REQUEST,
     monitoringConditionsAlcohol = AlcoholMonitoringConditions(
       id = mockAlcoholMonitoringConditionsId,
       orderId = mockOrderId,
@@ -108,6 +110,7 @@ class AddressServiceTest {
     id = mockOrderId,
     username = mockUsername,
     status = OrderStatus.IN_PROGRESS,
+    type = OrderType.REQUEST,
     monitoringConditionsAlcohol = AlcoholMonitoringConditions(
       id = mockAlcoholMonitoringConditionsId,
       orderId = mockOrderId,
@@ -126,6 +129,7 @@ class AddressServiceTest {
     id = mockOrderId,
     username = mockUsername,
     status = OrderStatus.IN_PROGRESS,
+    type = OrderType.REQUEST,
     addresses = mutableListOf(),
   )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/MonitoringConditionsAlcoholServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/MonitoringConditionsAlcoholServiceTest.kt
@@ -17,6 +17,7 @@ import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.mo
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.AlcoholMonitoringType
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.DeviceWearerAddressUsage
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.OrderStatus
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.OrderType
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.repository.MonitoringConditionsAlcoholRepository
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.repository.OrderRepository
 import java.time.LocalDate
@@ -96,6 +97,7 @@ class MonitoringConditionsAlcoholServiceTest {
             id = mockOrderId,
             username = mockUsername,
             status = OrderStatus.IN_PROGRESS,
+            type = OrderType.REQUEST,
             monitoringConditionsAlcohol = AlcoholMonitoringConditions(
               id = mockAlcoholMonitoringConditionsId,
               orderId = mockOrderId,
@@ -146,6 +148,7 @@ class MonitoringConditionsAlcoholServiceTest {
             id = mockOrderId,
             username = mockUsername,
             status = OrderStatus.IN_PROGRESS,
+            type = OrderType.REQUEST,
             monitoringConditionsAlcohol = AlcoholMonitoringConditions(
               id = mockAlcoholMonitoringConditionsId,
               orderId = mockOrderId,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/OrderServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/OrderServiceTest.kt
@@ -28,6 +28,7 @@ import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.mo
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.ResponsibleAdult
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.SubmitFmsOrderResult
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.TrailMonitoringConditions
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.dto.CreateOrderDto
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.AddressType
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.AlcoholMonitoringInstallationLocationType
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.AlcoholMonitoringType
@@ -35,6 +36,7 @@ import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.mo
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.FmsOrderSource
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.MonitoringConditionType
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.OrderStatus
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.OrderType
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.OrderTypeDescription
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.repository.OrderRepository
 import java.time.DayOfWeek
@@ -58,7 +60,7 @@ class OrderServiceTest {
 
   @Test
   fun `Create a new order for user and save to database`() {
-    val result = service.createOrder("mockUser")
+    val result = service.createOrder("mockUser", CreateOrderDto())
 
     Assertions.assertThat(result.id).isNotNull()
     Assertions.assertThat(UUID.fromString(result.id.toString())).isEqualTo(result.id)
@@ -99,6 +101,7 @@ class OrderServiceTest {
     val order = Order(
       username = "AUTH_ADM",
       status = OrderStatus.IN_PROGRESS,
+      type = OrderType.REQUEST,
     )
     order.deviceWearer = DeviceWearer(
       orderId = order.id,


### PR DESCRIPTION
- Adds the `type` property to an order
- By default orders are created with the `REQUEST` type
  - Therefore doesn't break the existing user interface 
- Disables submission of variations until integration is implemented 
- Also refactored OrderController test suite to group tests by functionality / endpoint as they were becoming a bit unclear, e.g.

```text
  DELETE /api/orders/{orderId}

    Test It should delete an in progress order() PASSED
    Test It should return an error if the order is in a submitted state() PASSED
    Test It should return an error if the order does not exist() PASSED
    Test It should return an error if the order belongs to another user() PASSED

  GET /api/orders/{orderId}

    Test It should return not found if order belongs to another user() PASSED
    Test It should return not found if order does not exist() PASSED
    Test It should return the order if owned by the user() PASSED

  GET /api/orders

    Test It should return orders when an empty searchTerm is provided() PASSED
    Test It should return orders where the firstName matches the searchTerm() PASSED
    Test It should return orders where the lastName matches the searchTerm() PASSED
    Test It should only return orders belonging to user() PASSED
    Test It should return orders where the lastName matches the searchTerm with different casing() PASSED
    Test It should return orders when no searchTerm is provided() PASSED
    Test It should return orders where the firstName matches the searchTerm with different casing() PASSED
```