### PR TITLE
Fix bug additional docs

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/AdditionalDocumentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/AdditionalDocumentService.kt
@@ -45,6 +45,7 @@ class AdditionalDocumentService(
     val order = findEditableOrder(orderId, username)
     val doc = order.additionalDocuments.firstOrNull { it.fileType == documentType }
     if (doc != null) {
+      order.additionalDocuments.remove(doc)
       attachmentRepo.deleteById(doc.id)
       webClient.deleteDocument(doc.id.toString())
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/AdditionalDocumentsControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/AdditionalDocumentsControllerTest.kt
@@ -358,7 +358,13 @@ class AdditionalDocumentsControllerTest : IntegrationTestBase() {
       .expectStatus()
       .isNoContent
 
-    verify(documentRepo, Times(1)).deleteById(doc.id)
-    verify(apiCLient, Times(1)).deleteDocument(doc.id.toString())
+    val latestOrder = webTestClient.get()
+      .uri("/api/orders/${order.id}")
+      .headers(setAuthorisation("mockUser"))
+      .exchange()
+      .expectBody(Order::class.java)
+      .returnResult()
+
+    assertThat(latestOrder.responseBody?.additionalDocuments?.count()).isEqualTo(0)
   }
 }


### PR DESCRIPTION
When deleting a document associated with an order, although the repository method was successfully called, the deletion would not take place. This PR removes the document from the order object, resulting in successful deletion.