### PR TITLE
Elm 3101 serco v5 dec 2024 changes

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/CurfewConditions.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/CurfewConditions.kt
@@ -11,6 +11,7 @@ import jakarta.validation.constraints.AssertTrue
 import jakarta.validation.constraints.Future
 import jakarta.validation.constraints.NotNull
 import jakarta.validation.constraints.Size
+import net.minidev.json.annotate.JsonIgnore
 import java.time.ZonedDateTime
 import java.util.*
 
@@ -36,6 +37,9 @@ data class CurfewConditions(
   @Column(name = "CURFEW_ADDRESS", nullable = true)
   @field:Size(min = 1, message = "Curfew address is required")
   var curfewAddress: String? = null,
+
+  @JsonIgnore
+  var curfewDescription: String? = "",
 
   @Schema(hidden = true)
   @OneToOne

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/fms/DeviceWearer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/fms/DeviceWearer.kt
@@ -175,8 +175,8 @@ data class DeviceWearer(
         val primaryAddress = order.addresses.find { address -> address.addressType == AddressType.PRIMARY }!!
         deviceWearer.address1 = primaryAddress.addressLine1
         deviceWearer.address2 = primaryAddress.addressLine2
-        deviceWearer.address3 = if (deviceWearer.address3 == "") "N/A" else primaryAddress.addressLine3
-        deviceWearer.address4 = if (deviceWearer.address4 == "") "N/A" else primaryAddress.addressLine4
+        deviceWearer.address3 = if (primaryAddress.addressLine3 == "") "N/A" else primaryAddress.addressLine3
+        deviceWearer.address4 = if (primaryAddress.addressLine4 == "") "N/A" else primaryAddress.addressLine4
         deviceWearer.addressPostCode = primaryAddress.postcode
       }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/fms/DeviceWearer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/fms/DeviceWearer.kt
@@ -175,19 +175,10 @@ data class DeviceWearer(
         val primaryAddress = order.addresses.find { address -> address.addressType == AddressType.PRIMARY }!!
         deviceWearer.address1 = primaryAddress.addressLine1
         deviceWearer.address2 = primaryAddress.addressLine2
-        deviceWearer.address3 = primaryAddress.addressLine3
-        deviceWearer.address4 = primaryAddress.addressLine4
+        deviceWearer.address3 = if (deviceWearer.address3 == "") "N/A" else primaryAddress.addressLine3
+        deviceWearer.address4 = if (deviceWearer.address4 == "") "N/A" else primaryAddress.addressLine4
         deviceWearer.addressPostCode = primaryAddress.postcode
-      } else {
-        deviceWearer.address1 = "No Fixed Address"
-        deviceWearer.address2 = "No Fixed Address"
-        deviceWearer.address3 = "No Fixed Address"
-        deviceWearer.address4 = "No Fixed Address"
-        deviceWearer.addressPostCode = "No Fixed Address"
       }
-
-      if (deviceWearer.address3 == "") deviceWearer.address3 = "N/A"
-      if (deviceWearer.address4 == "") deviceWearer.address4 = "N/A"
 
       order.addresses.find { address -> address.addressType == AddressType.SECONDARY }.let { address ->
         {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/fms/MonitoringOrder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/fms/MonitoringOrder.kt
@@ -165,6 +165,20 @@ data class MonitoringOrder(
   var revocationDate: String? = "",
   @JsonProperty("revocation_type")
   var revocationType: String? = "",
+  @JsonProperty("installation_address_1")
+  var installationAddress1: String? = "",
+  @JsonProperty("installation_address_2")
+  var installationAddress2: String? = "",
+  @JsonProperty("installation_address_3")
+  var installationAddress3: String? = "",
+  @JsonProperty("installation_address_4")
+  var installationAddress4: String? = "",
+  @JsonProperty("installation_address_post_code")
+  var installationAddressPostcode: String? = "",
+  @JsonProperty("crown_court_case_reference_number")
+  var crownCourtCaseReferenceNumber: String? = "",
+  @JsonProperty("magistrate_court_case_reference_number")
+  var magistrateCourtCaseReferenceNumber: String? = "",
   @JsonProperty("order_status")
   var orderStatus: String? = "",
 ) {
@@ -308,6 +322,14 @@ data class MonitoringOrder(
           monitoringOrder.roAddress4 = address.addressLine4
           monitoringOrder.roPostCode = address.postcode
         }
+      }
+
+      order.addresses.firstOrNull { it.addressType == AddressType.INSTALLATION }?.let {
+        monitoringOrder.installationAddress1 = it.addressLine1
+        monitoringOrder.installationAddress2 = it.addressLine2
+        monitoringOrder.installationAddress3 = it.addressLine3
+        monitoringOrder.installationAddress4 = it.addressLine4
+        monitoringOrder.installationAddressPostcode = it.postcode
       }
 
       return monitoringOrder

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/fms/MonitoringOrder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/fms/MonitoringOrder.kt
@@ -230,15 +230,14 @@ data class MonitoringOrder(
       }
 
       if (conditions.exclusionZone != null && conditions.exclusionZone!!) {
-        order.enforcementZoneConditions.forEach { it ->
-          monitoringOrder.enforceableCondition!!.add(
-            EnforceableCondition(
-              "EM Exclusion / Inclusion Zone",
-              startDate = it.startDate?.format(dateTimeFormatter),
-              endDate = it.endDate?.format(dateTimeFormatter),
-            ),
-          )
-
+        monitoringOrder.enforceableCondition!!.add(
+          EnforceableCondition(
+            "EM Exclusion / Inclusion Zone",
+            startDate = conditions.startDate?.format(dateTimeFormatter),
+            endDate = conditions.endDate?.format(dateTimeFormatter),
+          ),
+        )
+        order.enforcementZoneConditions.forEach {
           if (it.zoneType == EnforcementZoneType.EXCLUSION) {
             monitoringOrder.exclusionZones.add(
               Zone(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/fms/MonitoringOrder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/fms/MonitoringOrder.kt
@@ -235,7 +235,7 @@ data class MonitoringOrder(
             EnforceableCondition(
               "EM Exclusion / Inclusion Zone",
               startDate = it.startDate?.format(dateTimeFormatter),
-              endDate = it.startDate?.format(dateTimeFormatter),
+              endDate = it.endDate?.format(dateTimeFormatter),
             ),
           )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/courthearing/HearingEventHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/courthearing/HearingEventHandler.kt
@@ -214,12 +214,14 @@ class HearingEventHandler(
       val alcoholConditions = AlcoholMonitoringConditions(
         orderId = order.id,
         monitoringType = AlcoholMonitoringType.ALCOHOL_ABSTINENCE,
+        startDate = monitoringConditions.startDate,
+        endDate = getPromptValue(prompts, "Until")?.let {
+          val localDate = LocalDate.parse(it, formatter)
+          ZonedDateTime.of(localDate, LocalTime.MIDNIGHT, ZoneId.of("GMT"))
+        },
       )
 
-      monitoringConditions.endDate = getPromptValue(prompts, "Until")?.let {
-        val localDate = LocalDate.parse(it, formatter)
-        ZonedDateTime.of(localDate, LocalTime.MIDNIGHT, ZoneId.of("GMT"))
-      }
+      monitoringConditions.endDate = alcoholConditions.endDate
       order.monitoringConditionsAlcohol = alcoholConditions
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/courthearing/HearingEventHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/courthearing/HearingEventHandler.kt
@@ -456,8 +456,8 @@ class HearingEventHandler(
   ): EnforcementZoneConditions {
     val condition = EnforcementZoneConditions(orderId = orderId)
     condition.zoneType = zoneType
-    condition.zoneLocation = conditionPrompt.value
-    condition.description = conditionPrompt.label
+
+    condition.description = "${conditionPrompt.label} ${conditionPrompt.value}"
     condition.startDate = ZonedDateTime.of(startDate, LocalTime.MIDNIGHT, ZoneId.of("GMT"))
     return condition
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/OrderControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/OrderControllerTest.kt
@@ -824,6 +824,11 @@ class OrderControllerTest : IntegrationTestBase() {
       	"checkin_schedule": [],
       	"revocation_date": "",
       	"revocation_type": "",
+        "installation_address_1": "24 Somewhere Street",
+        "installation_address_2": "Nowhere City",
+        "installation_address_3": "Random County",
+        "installation_address_4": "United Kingdom",
+        "installation_address_post_code": "SW11 1NC",
         "crown_court_case_reference_number": "",
         "magistrate_court_case_reference_number": "",
       	"order_status": "Not Started"

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/OrderControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/OrderControllerTest.kt
@@ -627,22 +627,34 @@ class OrderControllerTest : IntegrationTestBase() {
       	"atv_allowance": "",
       	"condition_type": "Requirement of a Community Order",
       	"court": "",
-      	"court_order_email": "",
-      	"describe_exclusion": "Mock Exclusion Zone",
+      	"court_order_email": "",      	
       	"device_type": "",
       	"device_wearer": "John Smith",
       	"enforceable_condition": [
       		{
-      			"condition": "Curfew with EM"
+      			"condition": "Curfew with EM",
+            "start_date": "${mockStartDate.format(dateTimeFormatter)}",
+            "end_date": "${mockEndDate.format(dateTimeFormatter)}"
       		},
       		{
-      			"condition": "Location Monitoring (Fitted Device)"
+      			"condition": "Location Monitoring (Fitted Device)",
+            "start_date": "${mockStartDate.format(dateTimeFormatter)}",
+            "end_date": "${mockEndDate.format(dateTimeFormatter)}"
       		},
       		{
-      			"condition": "EM Exclusion / Inclusion Zone"
+      			"condition": "EM Exclusion / Inclusion Zone",
+            "start_date": "${mockStartDate.format(dateTimeFormatter)}",
+            "end_date": "${mockEndDate.format(dateTimeFormatter)}"
+      		},
+          {
+      			"condition": "EM Exclusion / Inclusion Zone",
+            "start_date": "${mockStartDate.format(dateTimeFormatter)}",
+            "end_date": "${mockEndDate.format(dateTimeFormatter)}"
       		},
       		{
-      			"condition": "AAMR"
+      			"condition": "AAMR",
+            "start_date": "${mockStartDate.format(dateTimeFormatter)}",
+            "end_date": "${mockEndDate.format(dateTimeFormatter)}"
       		}
       	],
       	"exclusion_allday": "",
@@ -701,8 +713,9 @@ class OrderControllerTest : IntegrationTestBase() {
       	"reason_for_order_ending_early": "",
       	"business_unit": "",
         "service_end_date": "${mockEndDate.format(formatter)}",
+        "curfew_description": "",
       	"curfew_start": "${mockStartDate.format(dateTimeFormatter)}",
-      	"curfew_end": null,
+      	"curfew_end": "${mockEndDate.format(dateTimeFormatter)}",
       	"curfew_duration": [
       		{
       			"location": "primary",
@@ -788,13 +801,26 @@ class OrderControllerTest : IntegrationTestBase() {
       		}
       	],
       	"trail_monitoring": "No",
-      	"exclusion_zones": "",
-      	"exclusion_zones_duration": "Mock Exclusion Duration",
-      	"inclusion_zones": "",
-      	"inclusion_zones_duration": "",
+      	"exclusion_zones": [
+          {
+            "description": "Mock Exclusion Zone",
+            "duration": "Mock Exclusion Duration",
+            "start": "${mockStartDate.format(formatter)}",
+            "end": "${mockEndDate.format(formatter)}"
+          }
+          ],      	
+      	"inclusion_zones": [
+          {
+            "description": "Mock Inclusion Zone",
+            "duration": "Mock Inclusion Duration",
+            "start": "${mockStartDate.format(formatter)}",
+            "end": "${mockEndDate.format(formatter)}"
+          }
+          ],
+      	
       	"abstinence": "Yes",
       	"schedule": "",
-      	"checkin_schedule": "",
+      	"checkin_schedule": [],
       	"revocation_date": "",
       	"revocation_type": "",
       	"order_status": "Not Started"
@@ -809,7 +835,7 @@ class OrderControllerTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `It should default address to No Fixed Address if device wearer no fixed Abode is true`() {
+    fun `It should map installation address if device wearer no fixed Abode is true`() {
       val order = createAndPersistReadyToSubmitOrder(true)
       sercoAuthApi.stubGrantToken()
 
@@ -850,10 +876,10 @@ class OrderControllerTest : IntegrationTestBase() {
       			"disability": "Learning, understanding or concentrating"
       		}
       	],
-      	"address_1": "No Fixed Address",
-      	"address_2": "No Fixed Address",
-      	"address_3": "No Fixed Address",
-      	"address_4": "No Fixed Address",
+      	"address_1": "",
+      	"address_2": "",
+      	"address_3": "",
+      	"address_4": "",
       	"address_post_code": "No Fixed Address",
       	"secondary_address_1": "",
       	"secondary_address_2": "",
@@ -1005,6 +1031,7 @@ class OrderControllerTest : IntegrationTestBase() {
     val curfewConditions = CurfewConditions(
       orderId = order.id,
       startDate = mockStartDate,
+      endDate = mockEndDate,
       curfewAddress = "PRIMARY,SECONDARY",
     )
 
@@ -1049,8 +1076,21 @@ class OrderControllerTest : IntegrationTestBase() {
       ),
     )
 
+    order.enforcementZoneConditions.add(
+      EnforcementZoneConditions(
+        orderId = order.id,
+        description = "Mock Inclusion Zone",
+        duration = "Mock Inclusion Duration",
+        startDate = mockStartDate,
+        endDate = mockEndDate,
+        zoneType = EnforcementZoneType.INCLUSION,
+      ),
+    )
+
     order.monitoringConditionsAlcohol = AlcoholMonitoringConditions(
       orderId = order.id,
+      startDate = mockStartDate,
+      endDate = mockEndDate,
       monitoringType = AlcoholMonitoringType.ALCOHOL_ABSTINENCE,
       installationLocation = AlcoholMonitoringInstallationLocationType.PRIMARY,
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/OrderControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/OrderControllerTest.kt
@@ -646,12 +646,7 @@ class OrderControllerTest : IntegrationTestBase() {
       			"condition": "EM Exclusion / Inclusion Zone",
             "start_date": "${mockStartDate.format(dateTimeFormatter)}",
             "end_date": "${mockEndDate.format(dateTimeFormatter)}"
-      		},
-          {
-      			"condition": "EM Exclusion / Inclusion Zone",
-            "start_date": "${mockStartDate.format(dateTimeFormatter)}",
-            "end_date": "${mockEndDate.format(dateTimeFormatter)}"
-      		},
+      		},          
       		{
       			"condition": "AAMR",
             "start_date": "${mockStartDate.format(dateTimeFormatter)}",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/OrderControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/OrderControllerTest.kt
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
+import org.springframework.test.util.JsonPathExpectationsHelper
 import org.springframework.web.reactive.function.BodyInserters
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.integration.wiremock.SercoAuthMockServerExtension.Companion.sercoAuthApi
@@ -823,6 +824,8 @@ class OrderControllerTest : IntegrationTestBase() {
       	"checkin_schedule": [],
       	"revocation_date": "",
       	"revocation_type": "",
+        "crown_court_case_reference_number": "",
+        "magistrate_court_case_reference_number": "",
       	"order_status": "Not Started"
       }
       """.trimIndent()
@@ -880,7 +883,7 @@ class OrderControllerTest : IntegrationTestBase() {
       	"address_2": "",
       	"address_3": "",
       	"address_4": "",
-      	"address_post_code": "No Fixed Address",
+      	"address_post_code": "",
       	"secondary_address_1": "",
       	"secondary_address_2": "",
       	"secondary_address_3": "",
@@ -914,7 +917,13 @@ class OrderControllerTest : IntegrationTestBase() {
       """.trimIndent()
 
       assertThat(submitResult!!.fmsDeviceWearerRequest).isEqualTo(expectedDWJson.removeWhitespaceAndNewlines())
+      val fmsOrderRequest = submitResult.fmsOrderRequest!!
 
+      JsonPathExpectationsHelper("installation_address_1").assertValue(fmsOrderRequest, "24 Somewhere Street")
+      JsonPathExpectationsHelper("installation_address_2").assertValue(fmsOrderRequest, "Nowhere City")
+      JsonPathExpectationsHelper("installation_address_3").assertValue(fmsOrderRequest, "Random County")
+      JsonPathExpectationsHelper("installation_address_4").assertValue(fmsOrderRequest, "United Kingdom")
+      JsonPathExpectationsHelper("installation_address_post_code").assertValue(fmsOrderRequest, "SW11 1NC")
       val updatedOrder = repo.findById(order.id).get()
       assertThat(updatedOrder.fmsResultId).isEqualTo(submitResult.id)
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/OrderServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/OrderServiceTest.kt
@@ -97,7 +97,7 @@ class OrderServiceTest {
 
   val mockStartDate: ZonedDateTime = ZonedDateTime.now().plusMonths(1)
   val mockEndDate: ZonedDateTime = ZonedDateTime.now().plusMonths(2)
-  private fun createReadyToSubmitOrder(noFixedAddress: Boolean = false): Order {
+  fun createReadyToSubmitOrder(noFixedAddress: Boolean = false): Order {
     val order = Order(
       username = "AUTH_ADM",
       status = OrderStatus.IN_PROGRESS,
@@ -112,8 +112,15 @@ class OrderServiceTest {
       adultAtTimeOfInstallation = true,
       sex = "Male",
       gender = "Male",
-      disabilities = "Vision,Hearing",
-      noFixedAbode = false,
+      disabilities = "VISION,LEARNING_UNDERSTANDING_CONCENTRATING",
+      interpreterRequired = true,
+      language = "British Sign",
+      pncId = "pncId",
+      deliusId = "deliusId",
+      nomisId = "nomisId",
+      prisonNumber = "prisonNumber",
+      homeOfficeReferenceNumber = "homeOfficeReferenceNumber",
+      noFixedAbode = noFixedAddress,
     )
 
     order.deviceWearerResponsibleAdult = ResponsibleAdult(
@@ -121,47 +128,60 @@ class OrderServiceTest {
       fullName = "Mark Smith",
       contactNumber = "07401111111",
     )
-    order.addresses = mutableListOf(
-      Address(
-        orderId = order.id,
-        addressLine1 = "20 Somewhere Street",
-        addressLine2 = "Nowhere City",
-        addressLine3 = "Random County",
-        addressLine4 = "United Kingdom",
-        postcode = "SW11 1NC",
-        addressType = AddressType.PRIMARY,
-      ),
-      Address(
-        orderId = order.id,
-        addressLine1 = "22 Somewhere Street",
-        addressLine2 = "Nowhere City",
-        addressLine3 = "Random County",
-        addressLine4 = "United Kingdom",
-        postcode = "SW11 1NC",
-        addressType = AddressType.SECONDARY,
-      ),
-      Address(
-        orderId = order.id,
-        addressLine1 = "24 Somewhere Street",
-        addressLine2 = "Nowhere City",
-        addressLine3 = "Random County",
-        addressLine4 = "United Kingdom",
-        postcode = "SW11 1NC",
-        addressType = AddressType.INSTALLATION,
-      ),
-      Address(
-        orderId = order.id,
-        addressLine1 = "Line 1",
-        addressLine2 = "Line 2",
-        addressLine3 = "",
-        addressLine4 = "",
-        postcode = "AB11 1CD",
-        addressType = AddressType.RESPONSIBLE_ORGANISATION,
-      ),
+
+    val responsibleOrganisationAddress = Address(
+      orderId = order.id,
+      addressLine1 = "Line 1",
+      addressLine2 = "Line 2",
+      addressLine3 = "",
+      addressLine4 = "",
+      postcode = "AB11 1CD",
+      addressType = AddressType.RESPONSIBLE_ORGANISATION,
     )
+
+    val installationAddress = Address(
+      orderId = order.id,
+      addressLine1 = "24 Somewhere Street",
+      addressLine2 = "Nowhere City",
+      addressLine3 = "Random County",
+      addressLine4 = "United Kingdom",
+      postcode = "SW11 1NC",
+      addressType = AddressType.INSTALLATION,
+    )
+
+    if (!noFixedAddress) {
+      order.addresses = mutableListOf(
+        Address(
+          orderId = order.id,
+          addressLine1 = "20 Somewhere Street",
+          addressLine2 = "Nowhere City",
+          addressLine3 = "Random County",
+          addressLine4 = "United Kingdom",
+          postcode = "SW11 1NC",
+          addressType = AddressType.PRIMARY,
+        ),
+        Address(
+          orderId = order.id,
+          addressLine1 = "22 Somewhere Street",
+          addressLine2 = "Nowhere City",
+          addressLine3 = "Random County",
+          addressLine4 = "United Kingdom",
+          postcode = "SW11 1NC",
+          addressType = AddressType.SECONDARY,
+        ),
+        responsibleOrganisationAddress,
+        installationAddress,
+      )
+    } else {
+      order.addresses = mutableListOf(
+        responsibleOrganisationAddress,
+        installationAddress,
+      )
+    }
+
     order.installationAndRisk = InstallationAndRisk(
       orderId = order.id,
-      offence = "Robbery",
+      offence = "Fraud Offences",
       riskDetails = "Danger",
       mappaLevel = "MAAPA 1",
       mappaCaseType = "CPPC (Critical Public Protection Case)",
@@ -171,9 +191,7 @@ class OrderServiceTest {
       orderId = order.id,
       contactNumber = "07401111111",
     )
-    order.monitoringConditions = MonitoringConditions(orderId = order.id)
-    order.additionalDocuments = mutableListOf()
-    val conditions = MonitoringConditions(
+    order.monitoringConditions = MonitoringConditions(
       orderId = order.id,
       orderType = "community",
       orderTypeDescription = OrderTypeDescription.DAPOL,
@@ -186,9 +204,11 @@ class OrderServiceTest {
       caseId = "d8ea62e61bb8d610a10c20e0b24bcb85",
       conditionType = MonitoringConditionType.REQUIREMENT_OF_A_COMMUNITY_ORDER,
     )
+    order.additionalDocuments = mutableListOf()
     val curfewConditions = CurfewConditions(
       orderId = order.id,
       startDate = mockStartDate,
+      endDate = mockEndDate,
       curfewAddress = "PRIMARY,SECONDARY",
     )
 
@@ -214,14 +234,13 @@ class OrderServiceTest {
     order.curfewTimeTable.addAll(secondTimeTable)
     order.curfewConditions = curfewConditions
 
-    val releaseDay = CurfewReleaseDateConditions(
+    order.curfewReleaseDateConditions = CurfewReleaseDateConditions(
       orderId = order.id,
       releaseDate = mockStartDate,
       startTime = "19:00",
       endTime = "23:00",
       curfewAddress = AddressType.PRIMARY,
     )
-    order.curfewReleaseDateConditions = releaseDay
 
     order.enforcementZoneConditions.add(
       EnforcementZoneConditions(
@@ -234,8 +253,21 @@ class OrderServiceTest {
       ),
     )
 
+    order.enforcementZoneConditions.add(
+      EnforcementZoneConditions(
+        orderId = order.id,
+        description = "Mock Inclusion Zone",
+        duration = "Mock Inclusion Duration",
+        startDate = mockStartDate,
+        endDate = mockEndDate,
+        zoneType = EnforcementZoneType.INCLUSION,
+      ),
+    )
+
     order.monitoringConditionsAlcohol = AlcoholMonitoringConditions(
       orderId = order.id,
+      startDate = mockStartDate,
+      endDate = mockEndDate,
       monitoringType = AlcoholMonitoringType.ALCOHOL_ABSTINENCE,
       installationLocation = AlcoholMonitoringInstallationLocationType.PRIMARY,
     )
@@ -252,23 +284,12 @@ class OrderServiceTest {
       responsibleOfficerPhoneNumber = "07401111111",
       responsibleOrganisation = "Avon and Somerset Constabulary",
       responsibleOrganisationRegion = "Mock Region",
-      responsibleOrganisationAddress = Address(
-        orderId = order.id,
-        addressLine1 = "Line 1",
-        addressLine2 = "Line 2",
-        addressLine3 = "",
-        addressLine4 = "",
-        postcode = "AB11 1CD",
-        addressType = AddressType.RESPONSIBLE_ORGANISATION,
-      ),
+      responsibleOrganisationAddress = responsibleOrganisationAddress,
       responsibleOrganisationPhoneNumber = "07401111111",
       responsibleOrganisationEmail = "abc@def.com",
       notifyingOrganisation = "Mock Organisation",
       notifyingOrganisationEmail = "",
     )
-
-    order.monitoringConditions = conditions
-    repo.save(order)
     return order
   }
 }

--- a/src/test/resources/json/CCSIB_BAIL_EXCLUSION/expected_fms_order.json
+++ b/src/test/resources/json/CCSIB_BAIL_EXCLUSION/expected_fms_order.json
@@ -77,7 +77,7 @@
   "trail_monitoring": "No",
   "exclusion_zones": [
     {
-      "description": "Exclusion - not to enter a place",
+      "description": "Exclusion - not to enter a place Place or area:London Mayfair",
       "duration": null,
       "start": "2024-10-25",
       "end": "2024-10-29"

--- a/src/test/resources/json/CCSIB_BAIL_EXCLUSION/expected_fms_order.json
+++ b/src/test/resources/json/CCSIB_BAIL_EXCLUSION/expected_fms_order.json
@@ -5,12 +5,13 @@
   "condition_type": "Bail Order",
   "court": "",
   "court_order_email": "",
-  "describe_exclusion": "Exclusion - not to enter a place",
   "device_type": "",
   "device_wearer": "Person Mock",
   "enforceable_condition": [
     {
-      "condition": "EM Exclusion / Inclusion Zone"
+      "condition": "EM Exclusion / Inclusion Zone",
+      "start_date": "2024-10-25 00:00:00",
+      "end_date": "2024-10-29 10:00:00"
     }
   ],
   "exclusion_allday": "",
@@ -69,18 +70,31 @@
   "reason_for_order_ending_early": "",
   "business_unit": "",
   "service_end_date": "2024-10-29",
+  "curfew_description": "",
   "curfew_start": "",
   "curfew_end": "",
   "curfew_duration": [],
   "trail_monitoring": "No",
-  "exclusion_zones": "Place or area:London Mayfair",
-  "exclusion_zones_duration": null,
-  "inclusion_zones": "",
-  "inclusion_zones_duration": "",
+  "exclusion_zones": [
+    {
+      "description": "Exclusion - not to enter a place",
+      "duration": null,
+      "start": "2024-10-25",
+      "end": "2024-10-29"
+    }
+  ],
+  "inclusion_zones": [],
   "abstinence": "",
   "schedule": "",
-  "checkin_schedule": "",
+  "checkin_schedule": [],
   "revocation_date": "",
   "revocation_type": "",
+  "installation_address_1": "",
+  "installation_address_2": "",
+  "installation_address_3": "",
+  "installation_address_4": "",
+  "installation_address_post_code": "",
+  "crown_court_case_reference_number": "",
+  "magistrate_court_case_reference_number": "",
   "order_status": "Not Started"
 }

--- a/src/test/resources/json/CCSIB_Crown_Court_BAIL_EXCLUSION/expected_fms_order.json
+++ b/src/test/resources/json/CCSIB_Crown_Court_BAIL_EXCLUSION/expected_fms_order.json
@@ -77,7 +77,7 @@
   "trail_monitoring": "No",
   "exclusion_zones": [
     {
-      "description": "Exclusion - not to enter a place",
+      "description": "Exclusion - not to enter a place Place or area:London Mayfair",
       "duration": null,
       "start": "2024-10-25",
       "end": "2024-10-29"

--- a/src/test/resources/json/CCSIB_Crown_Court_BAIL_EXCLUSION/expected_fms_order.json
+++ b/src/test/resources/json/CCSIB_Crown_Court_BAIL_EXCLUSION/expected_fms_order.json
@@ -5,12 +5,13 @@
   "condition_type": "Bail Order",
   "court": "",
   "court_order_email": "",
-  "describe_exclusion": "Exclusion - not to enter a place",
   "device_type": "",
   "device_wearer": "Person Mock",
   "enforceable_condition": [
     {
-      "condition": "EM Exclusion / Inclusion Zone"
+      "condition": "EM Exclusion / Inclusion Zone",
+      "start_date": "2024-10-25 00:00:00",
+      "end_date": "2024-10-29 10:00:00"
     }
   ],
   "exclusion_allday": "",
@@ -69,18 +70,31 @@
   "reason_for_order_ending_early": "",
   "business_unit": "",
   "service_end_date": "2024-10-29",
+  "curfew_description": "",
   "curfew_start": "",
   "curfew_end": "",
   "curfew_duration": [],
   "trail_monitoring": "No",
-  "exclusion_zones": "Place or area:London Mayfair",
-  "exclusion_zones_duration": null,
-  "inclusion_zones": "",
-  "inclusion_zones_duration": "",
+  "exclusion_zones": [
+    {
+      "description": "Exclusion - not to enter a place",
+      "duration": null,
+      "start": "2024-10-25",
+      "end": "2024-10-29"
+    }
+  ],
+  "inclusion_zones": [],
   "abstinence": "",
   "schedule": "",
-  "checkin_schedule": "",
+  "checkin_schedule": [],
   "revocation_date": "",
   "revocation_type": "",
+  "installation_address_1": "",
+  "installation_address_2": "",
+  "installation_address_3": "",
+  "installation_address_4": "",
+  "installation_address_post_code": "",
+  "crown_court_case_reference_number": "",
+  "magistrate_court_case_reference_number": "",
   "order_status": "Not Started"
 }

--- a/src/test/resources/json/COEW_AAR/expected_fms_order.json
+++ b/src/test/resources/json/COEW_AAR/expected_fms_order.json
@@ -5,12 +5,13 @@
   "condition_type": "Requirement of a Community Order",
   "court": "",
   "court_order_email": "",
-  "describe_exclusion": "",
   "device_type": "",
   "device_wearer": "Person Mock",
   "enforceable_condition": [
     {
-      "condition": "AAMR"
+      "condition": "AAMR",
+      "start_date": "2024-10-21 00:00:00",
+      "end_date": "2025-05-17 00:00:00"
     }
   ],
   "exclusion_allday": "",
@@ -69,18 +70,24 @@
   "reason_for_order_ending_early": "",
   "business_unit": "",
   "service_end_date": "2025-05-17",
+  "curfew_description": "",
   "curfew_start": "",
   "curfew_end": "",
   "curfew_duration": [],
   "trail_monitoring": "",
-  "exclusion_zones": "",
-  "exclusion_zones_duration": "",
-  "inclusion_zones": "",
-  "inclusion_zones_duration": "",
+  "exclusion_zones": [],
+  "inclusion_zones": [],
   "abstinence": "Yes",
   "schedule": "",
-  "checkin_schedule": "",
+  "checkin_schedule": [],
   "revocation_date": "",
   "revocation_type": "",
+  "installation_address_1": "",
+  "installation_address_2": "",
+  "installation_address_3": "",
+  "installation_address_4": "",
+  "installation_address_post_code": "",
+  "crown_court_case_reference_number": "",
+  "magistrate_court_case_reference_number": "",
   "order_status": "Not Started"
 }

--- a/src/test/resources/json/COV_Community_Order_Trail/expected_fms_order.json
+++ b/src/test/resources/json/COV_Community_Order_Trail/expected_fms_order.json
@@ -5,12 +5,13 @@
   "condition_type": "Requirement of a Community Order",
   "court": "",
   "court_order_email": "",
-  "describe_exclusion": "",
   "device_type": "",
   "device_wearer": "Person Mock",
   "enforceable_condition": [
     {
-      "condition": "Location Monitoring (Fitted Device)"
+      "condition": "Location Monitoring (Fitted Device)",
+      "start_date": "2024-10-18 10:00:00",
+      "end_date": "2025-05-18 10:00:00"
     }
   ],
   "exclusion_allday": "",
@@ -69,18 +70,24 @@
   "reason_for_order_ending_early": "",
   "business_unit": "",
   "service_end_date": "2025-05-18",
+  "curfew_description": "",
   "curfew_start": "",
   "curfew_end": "",
   "curfew_duration": [],
   "trail_monitoring": "Yes",
-  "exclusion_zones": "",
-  "exclusion_zones_duration": "",
-  "inclusion_zones": "",
-  "inclusion_zones_duration": "",
+  "exclusion_zones": [],
+  "inclusion_zones": [],
   "abstinence": "",
   "schedule": "",
-  "checkin_schedule": "",
+  "checkin_schedule": [],
   "revocation_date": "",
   "revocation_type": "",
+  "installation_address_1": "",
+  "installation_address_2": "",
+  "installation_address_3": "",
+  "installation_address_4": "",
+  "installation_address_post_code": "",
+  "crown_court_case_reference_number": "",
+  "magistrate_court_case_reference_number": "",
   "order_status": "Not Started"
 }

--- a/src/test/resources/json/CommunityOrder_Curfew/expected_fms_order.json
+++ b/src/test/resources/json/CommunityOrder_Curfew/expected_fms_order.json
@@ -5,12 +5,13 @@
   "condition_type": "Requirement of a Community Order",
   "court": "",
   "court_order_email": "",
-  "describe_exclusion": "",
   "device_type": "",
   "device_wearer": "Person Mock",
   "enforceable_condition": [
     {
-      "condition": "Curfew with EM"
+      "condition": "Curfew with EM",
+      "start_date": "2024-12-07 19:00:00",
+      "end_date": "2025-04-06 07:00:00"
     }
   ],
   "exclusion_allday": "",
@@ -69,18 +70,24 @@
   "reason_for_order_ending_early": "",
   "business_unit": "",
   "service_end_date": null,
+  "curfew_description": "",
   "curfew_start": "2024-12-07 19:00:00",
   "curfew_end": "2025-04-06 07:00:00",
   "curfew_duration": [],
   "trail_monitoring": "",
-  "exclusion_zones": "",
-  "exclusion_zones_duration": "",
-  "inclusion_zones": "",
-  "inclusion_zones_duration": "",
+  "exclusion_zones": [],
+  "inclusion_zones": [],
   "abstinence": "",
   "schedule": "",
-  "checkin_schedule": "",
+  "checkin_schedule": [],
   "revocation_date": "",
   "revocation_type": "",
+  "installation_address_1": "",
+  "installation_address_2": "",
+  "installation_address_3": "",
+  "installation_address_4": "",
+  "installation_address_post_code": "",
+  "crown_court_case_reference_number": "",
+  "magistrate_court_case_reference_number": "",
   "order_status": "Not Started"
 }

--- a/src/test/resources/json/RC_BAIL_INCLUSION/expected_fms_order.json
+++ b/src/test/resources/json/RC_BAIL_INCLUSION/expected_fms_order.json
@@ -5,12 +5,13 @@
   "condition_type": "Bail Order",
   "court": "",
   "court_order_email": "",
-  "describe_exclusion": "Exclusion - not to leave",
   "device_type": "",
   "device_wearer": "JoUser2G91Rb BOT2G91Rb",
   "enforceable_condition": [
     {
-      "condition": "EM Exclusion / Inclusion Zone"
+      "condition": "EM Exclusion / Inclusion Zone",
+      "start_date": "2024-10-25 00:00:00",
+      "end_date": "2024-10-31 14:00:00"
     }
   ],
   "exclusion_allday": "",
@@ -69,18 +70,31 @@
   "reason_for_order_ending_early": "",
   "business_unit": "",
   "service_end_date": "2024-10-31",
+  "curfew_description": "",
   "curfew_start": "",
   "curfew_end": "",
   "curfew_duration": [],
   "trail_monitoring": "No",
-  "exclusion_zones": "",
-  "exclusion_zones_duration": "",
-  "inclusion_zones": "Place or area:Home at Mitcham avenue",
-  "inclusion_zones_duration": null,
+  "exclusion_zones": [],
+  "inclusion_zones": [
+    {
+      "description": "Exclusion - not to leave",
+      "duration": null,
+      "start": "2024-10-25",
+      "end": "2024-10-31"
+    }
+  ],
   "abstinence": "",
   "schedule": "",
-  "checkin_schedule": "",
+  "checkin_schedule": [],
   "revocation_date": "",
   "revocation_type": "",
+  "installation_address_1": "",
+  "installation_address_2": "",
+  "installation_address_3": "",
+  "installation_address_4": "",
+  "installation_address_post_code": "",
+  "crown_court_case_reference_number": "",
+  "magistrate_court_case_reference_number": "",
   "order_status": "Not Started"
 }

--- a/src/test/resources/json/RC_BAIL_INCLUSION/expected_fms_order.json
+++ b/src/test/resources/json/RC_BAIL_INCLUSION/expected_fms_order.json
@@ -78,7 +78,7 @@
   "exclusion_zones": [],
   "inclusion_zones": [
     {
-      "description": "Exclusion - not to leave",
+      "description": "Exclusion - not to leave Place or area:Home at Mitcham avenue",
       "duration": null,
       "start": "2024-10-25",
       "end": "2024-10-31"

--- a/src/test/resources/json/REMCB_BAIL_CURFEW/expected_fms_order.json
+++ b/src/test/resources/json/REMCB_BAIL_CURFEW/expected_fms_order.json
@@ -5,12 +5,13 @@
   "condition_type": "Bail Order",
   "court": "",
   "court_order_email": "",
-  "describe_exclusion": "",
   "device_type": "",
   "device_wearer": "Person Mock",
   "enforceable_condition": [
     {
-      "condition": "Curfew with EM"
+      "condition": "Curfew with EM",
+      "start_date": "2024-10-25 00:00:00",
+      "end_date": "2024-10-30 10:00:00"
     }
   ],
   "exclusion_allday": "",
@@ -69,18 +70,24 @@
   "reason_for_order_ending_early": "",
   "business_unit": "",
   "service_end_date": "2024-10-30",
+  "curfew_description":"",
   "curfew_start": "2024-10-25 00:00:00",
   "curfew_end": "2024-10-30 10:00:00",
   "curfew_duration": [],
   "trail_monitoring": "",
-  "exclusion_zones": "",
-  "exclusion_zones_duration": "",
-  "inclusion_zones": "",
-  "inclusion_zones_duration": "",
+  "exclusion_zones": [],
+  "inclusion_zones": [],
   "abstinence": "",
   "schedule": "",
-  "checkin_schedule": "",
+  "checkin_schedule": [],
   "revocation_date": "",
   "revocation_type": "",
+  "installation_address_1": "",
+  "installation_address_2": "",
+  "installation_address_3": "",
+  "installation_address_4": "",
+  "installation_address_post_code": "",
+  "crown_court_case_reference_number": "",
+  "magistrate_court_case_reference_number": "",
   "order_status": "Not Started"
 }

--- a/src/test/resources/json/RIB_BAIL_EXCLUSION_EXCEPT_COURT_OR_APPOINTMENT/expected_fms_order.json
+++ b/src/test/resources/json/RIB_BAIL_EXCLUSION_EXCEPT_COURT_OR_APPOINTMENT/expected_fms_order.json
@@ -5,12 +5,13 @@
   "condition_type": "Bail Order",
   "court": "",
   "court_order_email": "",
-  "describe_exclusion": "Exclusion - not to enter a place except to attend court or pre-arranged appointment with solicitor",
   "device_type": "",
   "device_wearer": "Person Mock",
   "enforceable_condition": [
     {
-      "condition": "EM Exclusion / Inclusion Zone"
+      "condition": "EM Exclusion / Inclusion Zone",
+      "start_date": "2024-10-25 00:00:00",
+      "end_date": "2024-10-30 10:00:00"
     }
   ],
   "exclusion_allday": "",
@@ -69,18 +70,31 @@
   "reason_for_order_ending_early": "",
   "business_unit": "",
   "service_end_date": "2024-10-30",
+  "curfew_description": "",
   "curfew_start": "",
   "curfew_end": "",
   "curfew_duration": [],
   "trail_monitoring": "No",
-  "exclusion_zones": "Place or area:London Mayfair",
-  "exclusion_zones_duration": null,
-  "inclusion_zones": "",
-  "inclusion_zones_duration": "",
+  "exclusion_zones": [
+    {
+      "description": "Exclusion - not to enter a place except to attend court or pre-arranged appointment with solicitor",
+      "duration": null,
+      "start": "2024-10-25",
+      "end": "2024-10-30"
+    }
+  ],
+  "inclusion_zones": [],
   "abstinence": "",
   "schedule": "",
-  "checkin_schedule": "",
+  "checkin_schedule": [],
   "revocation_date": "",
   "revocation_type": "",
+  "installation_address_1": "",
+  "installation_address_2": "",
+  "installation_address_3": "",
+  "installation_address_4": "",
+  "installation_address_post_code": "",
+  "crown_court_case_reference_number": "",
+  "magistrate_court_case_reference_number": "",
   "order_status": "Not Started"
 }

--- a/src/test/resources/json/RIB_BAIL_EXCLUSION_EXCEPT_COURT_OR_APPOINTMENT/expected_fms_order.json
+++ b/src/test/resources/json/RIB_BAIL_EXCLUSION_EXCEPT_COURT_OR_APPOINTMENT/expected_fms_order.json
@@ -77,7 +77,7 @@
   "trail_monitoring": "No",
   "exclusion_zones": [
     {
-      "description": "Exclusion - not to enter a place except to attend court or pre-arranged appointment with solicitor",
+      "description": "Exclusion - not to enter a place except to attend court or pre-arranged appointment with solicitor Place or area:London Mayfair",
       "duration": null,
       "start": "2024-10-25",
       "end": "2024-10-30"

--- a/src/test/resources/json/RILAB_BAIL_INCLUSION/expected_fms_order.json
+++ b/src/test/resources/json/RILAB_BAIL_INCLUSION/expected_fms_order.json
@@ -78,7 +78,7 @@
   "exclusion_zones": [],
   "inclusion_zones": [
     {
-      "description": "Exclusion - not to go more than a specified radius from a specified place",
+      "description": "Exclusion - not to go more than a specified radius from a specified place Radius:2 miles\nPlace or area:Mitcham avenue",
       "duration": null,
       "start": "2024-10-25",
       "end": "2024-10-30"

--- a/src/test/resources/json/RILAB_BAIL_INCLUSION/expected_fms_order.json
+++ b/src/test/resources/json/RILAB_BAIL_INCLUSION/expected_fms_order.json
@@ -5,12 +5,13 @@
   "condition_type": "Bail Order",
   "court": "",
   "court_order_email": "",
-  "describe_exclusion": "Exclusion - not to go more than a specified radius from a specified place",
   "device_type": "",
   "device_wearer": "Person Mock",
   "enforceable_condition": [
     {
-      "condition": "EM Exclusion / Inclusion Zone"
+      "condition": "EM Exclusion / Inclusion Zone",
+      "start_date": "2024-10-25 00:00:00",
+      "end_date": "2024-10-30 10:00:00"
     }
   ],
   "exclusion_allday": "",
@@ -69,18 +70,31 @@
   "reason_for_order_ending_early": "",
   "business_unit": "",
   "service_end_date": "2024-10-30",
+  "curfew_description": "",
   "curfew_start": "",
   "curfew_end": "",
   "curfew_duration": [],
   "trail_monitoring": "No",
-  "exclusion_zones": "",
-  "exclusion_zones_duration": "",
-  "inclusion_zones": "Radius:2 miles\nPlace or area:Mitcham avenue",
-  "inclusion_zones_duration": null,
+  "exclusion_zones": [],
+  "inclusion_zones": [
+    {
+      "description": "Exclusion - not to go more than a specified radius from a specified place",
+      "duration": null,
+      "start": "2024-10-25",
+      "end": "2024-10-30"
+    }
+  ],
   "abstinence": "",
   "schedule": "",
-  "checkin_schedule": "",
+  "checkin_schedule": [],
   "revocation_date": "",
   "revocation_type": "",
+  "installation_address_1": "",
+  "installation_address_2": "",
+  "installation_address_3": "",
+  "installation_address_4": "",
+  "installation_address_post_code": "",
+  "crown_court_case_reference_number": "",
+  "magistrate_court_case_reference_number": "",
   "order_status": "Not Started"
 }

--- a/src/test/resources/json/SSO_IMPRISONMENT/expected_fms_order.json
+++ b/src/test/resources/json/SSO_IMPRISONMENT/expected_fms_order.json
@@ -5,12 +5,13 @@
   "condition_type": "Requirement of a Community Order",
   "court": "",
   "court_order_email": "",
-  "describe_exclusion": "ERLPEM - Exclusion not to leave a place for a period with electronic monitoring\nExclusion Requirement with Electronic Monitoring: Not to leave 11 Copperfields Avenue\nSE30 5MJ. This exclusion with electronic monitoring lasts for 5 Months. Start date 10/11/2024. Start time 10:00. End date 10/05/2025. End time 10:00. ",
   "device_type": "",
   "device_wearer": "Person Mock",
   "enforceable_condition": [
     {
-      "condition": "EM Exclusion / Inclusion Zone"
+      "condition": "EM Exclusion / Inclusion Zone",
+      "start_date": "2024-11-10 10:00:00",
+      "end_date": "2025-05-10 10:00:00"
     }
   ],
   "exclusion_allday": "",
@@ -69,18 +70,31 @@
   "reason_for_order_ending_early": "",
   "business_unit": "",
   "service_end_date": "2025-05-10",
+  "curfew_description": "",
   "curfew_start": "",
   "curfew_end": "",
   "curfew_duration": [],
   "trail_monitoring": "No",
-  "exclusion_zones": "",
-  "exclusion_zones_duration": "",
-  "inclusion_zones": "11 Copperfields Avenue\nSE30 5MJ",
-  "inclusion_zones_duration": "5 Months",
+  "exclusion_zones": [],
+  "inclusion_zones": [
+    {
+      "description": "ERLPEM - Exclusion not to leave a place for a period with electronic monitoring\nExclusion Requirement with Electronic Monitoring: Not to leave 11 Copperfields Avenue\nSE30 5MJ. This exclusion with electronic monitoring lasts for 5 Months. Start date 10/11/2024. Start time 10:00. End date 10/05/2025. End time 10:00. ",
+      "duration": "5 Months",
+      "start": "2024-11-10",
+      "end": "2025-05-10"
+    }
+  ],
   "abstinence": "",
   "schedule": "",
-  "checkin_schedule": "",
+  "checkin_schedule": [],
   "revocation_date": "",
   "revocation_type": "",
+  "installation_address_1": "",
+  "installation_address_2": "",
+  "installation_address_3": "",
+  "installation_address_4": "",
+  "installation_address_post_code": "",
+  "crown_court_case_reference_number": "",
+  "magistrate_court_case_reference_number": "",
   "order_status": "Not Started"
 }

--- a/src/test/resources/json/SSO_YOUNG_OFFENDER_INSTITUTION_DETENTION/expected_fms_order.json
+++ b/src/test/resources/json/SSO_YOUNG_OFFENDER_INSTITUTION_DETENTION/expected_fms_order.json
@@ -5,12 +5,13 @@
   "condition_type": "Requirement of a Community Order",
   "court": "",
   "court_order_email": "",
-  "describe_exclusion": "ERPEM - Exclusion not to enter for a period with electronic monitoring\nExclusion Requirement with Electronic Monitoring: Not to enter 11 Mayfair\nLONDON. This exclusion with electronic monitoring lasts for 6 Months. Start date 10/11/2024. Start time 10:00. End date 10/11/2025. End time 10:00. ",
   "device_type": "",
   "device_wearer": "Person Mock",
   "enforceable_condition": [
     {
-      "condition": "EM Exclusion / Inclusion Zone"
+      "condition": "EM Exclusion / Inclusion Zone",
+      "start_date": "2024-11-10 10:00:00",
+      "end_date": "2025-11-10 10:00:00"
     }
   ],
   "exclusion_allday": "",
@@ -69,18 +70,31 @@
   "reason_for_order_ending_early": "",
   "business_unit": "",
   "service_end_date": "2025-11-10",
+  "curfew_description": "",
   "curfew_start": "",
   "curfew_end": "",
   "curfew_duration": [],
   "trail_monitoring": "No",
-  "exclusion_zones": "11 Mayfair\nLONDON",
-  "exclusion_zones_duration": "6 Months",
-  "inclusion_zones": "",
-  "inclusion_zones_duration": "",
+  "exclusion_zones": [
+    {
+      "description": "ERPEM - Exclusion not to enter for a period with electronic monitoring\nExclusion Requirement with Electronic Monitoring: Not to enter 11 Mayfair\nLONDON. This exclusion with electronic monitoring lasts for 6 Months. Start date 10/11/2024. Start time 10:00. End date 10/11/2025. End time 10:00. ",
+      "duration": "6 Months",
+      "start": "2024-11-10",
+      "end": "2025-11-10"
+    }
+  ],
+  "inclusion_zones": [],
   "abstinence": "",
   "schedule": "",
-  "checkin_schedule": "",
+  "checkin_schedule": [],
   "revocation_date": "",
   "revocation_type": "",
+  "installation_address_1": "",
+  "installation_address_2": "",
+  "installation_address_3": "",
+  "installation_address_4": "",
+  "installation_address_post_code": "",
+  "crown_court_case_reference_number": "",
+  "magistrate_court_case_reference_number": "",
   "order_status": "Not Started"
 }


### PR DESCRIPTION
Ticket: https://dsdmoj.atlassian.net/browse/ELM-3101

The following changed made to reflect Serco api schema change for v5 - Dec 2024:

- enforceable_condition now has start_date and end_date fields, example:

```
 {
      "condition": "EM Exclusion / Inclusion Zone",
      "start_date": "2024-11-27 07:00:00",
      "end_date": "2024-12-27 07:00:00"
    }
```

- Added text field curfew_description

- exclusion_zones and inclusion_zones is now a list object , example:


```
"exclusion_zones": [
    {
      "description": "Zone 1",
      "duration": "Mon-Fri 10-22",
      "start": "28/11/2024",
      "end": "28/12/2024"
    },
    {
      "description": "Zone 2",
      "duration": "Mon-Fri 11-23",
      "start": "28/11/2024",
      "end": "28/01/2025"
    }
  ]


 "inclusion_zones": [
    {
      "description": "Zone 3",
      "duration": "Mon-Fri 10-22",
      "start": "28/11/2024",
      "end": "28/12/2024"
    },
    {
      "description": "Zone 4",
      "duration": "Tue-Fri 10-22",
      "start": "28/12/2024",
      "end": "28/02/2025"
    }
  ]
```

- Added fields for installation address , example:



```
"installation_address_1": "Installation Address Street",
  "installation_address_2": "Installation Address Town",
  "installation_address_3": "Installation Address County",
  "installation_address_4": "United Kingdom",
  "installation_address_post_code": "NW28 T7",
```