### PR TITLE
Allow creation / updates to variation details

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/Order.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/Order.kt
@@ -82,6 +82,9 @@ data class Order(
   @OneToMany(fetch = FetchType.LAZY, cascade = [ALL], mappedBy = "order", orphanRemoval = true)
   var curfewTimeTable: MutableList<CurfewTimeTable> = mutableListOf(),
 
+  @OneToOne(fetch = FetchType.LAZY, cascade = [ALL], mappedBy = "order", orphanRemoval = true)
+  var variationDetails: VariationDetails? = null,
+
 ) {
   private val adultOrHasResponsibleAdult: Boolean
     get() = (

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/VariationDetails.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/VariationDetails.kt
@@ -1,0 +1,37 @@
+package uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.OneToOne
+import jakarta.persistence.Table
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.VariationType
+import java.time.ZonedDateTime
+import java.util.*
+
+@Entity
+@Table(name = "VARIATION_DETAILS")
+data class VariationDetails(
+  @Id
+  @Column(name = "ID", nullable = false, unique = true)
+  val id: UUID = UUID.randomUUID(),
+
+  @Column(name = "ORDER_ID", nullable = false, unique = true)
+  val orderId: UUID,
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "VARIATION_TYPE", nullable = false)
+  val variationType: VariationType,
+
+  @Column(name = "VARIATION_DATE", nullable = true)
+  var variationDate: ZonedDateTime? = null,
+
+  @Schema(hidden = true)
+  @OneToOne
+  @JoinColumn(name = "ORDER_ID", updatable = false, insertable = false)
+  private val order: Order? = null,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/dto/UpdateVariationDetailsDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/dto/UpdateVariationDetailsDto.kt
@@ -8,7 +8,6 @@ import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.mo
 import java.time.ZonedDateTime
 import java.time.format.DateTimeParseException
 
-@GroupSequence(NotEmpty::class, Pattern::class, UpdateVariationDetailsDto::class)
 data class UpdateVariationDetailsDto(
   @field:NotEmpty(message = "Variation type is required")
   val variationType: String = "",
@@ -23,8 +22,8 @@ data class UpdateVariationDetailsDto(
       return true
     }
 
-    for (v in VariationType.entries) {
-      if (v.name == variationType) {
+    for (entry in VariationType.entries) {
+      if (entry.name == variationType) {
         return true
       }
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/dto/UpdateVariationDetailsDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/dto/UpdateVariationDetailsDto.kt
@@ -1,0 +1,49 @@
+package uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.dto
+
+import jakarta.validation.GroupSequence
+import jakarta.validation.constraints.AssertTrue
+import jakarta.validation.constraints.NotEmpty
+import jakarta.validation.constraints.Pattern
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.VariationType
+import java.time.ZonedDateTime
+import java.time.format.DateTimeParseException
+
+@GroupSequence(NotEmpty::class, Pattern::class, UpdateVariationDetailsDto::class)
+data class UpdateVariationDetailsDto(
+  @field:NotEmpty(message = "Variation type is required")
+  val variationType: String = "",
+
+  @field:NotEmpty(message = "Variation date is required")
+  val variationDate: String = "",
+) {
+  @AssertTrue(message = "Variation type must be a valid variation type")
+  fun isVariationType(): Boolean {
+    // Prevent additional error being generated for empty string
+    if (variationType == "") {
+      return true
+    }
+
+    for (v in VariationType.entries) {
+      if (v.name == variationType) {
+        return true
+      }
+    }
+
+    return false
+  }
+
+  @AssertTrue(message = "Variation date must be a valid date")
+  fun isVariationDate(): Boolean {
+    // Prevent additional error being generated for empty string
+    if (variationDate == "") {
+      return true
+    }
+
+    try {
+      ZonedDateTime.parse(variationDate)
+      return true
+    } catch (e: DateTimeParseException) {
+      return false
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/dto/UpdateVariationDetailsDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/dto/UpdateVariationDetailsDto.kt
@@ -1,9 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.dto
 
-import jakarta.validation.GroupSequence
 import jakarta.validation.constraints.AssertTrue
 import jakarta.validation.constraints.NotEmpty
-import jakarta.validation.constraints.Pattern
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.VariationType
 import java.time.ZonedDateTime
 import java.time.format.DateTimeParseException

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/enums/VariationType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/enums/VariationType.kt
@@ -1,0 +1,9 @@
+package uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums
+
+enum class VariationType {
+  CURFEW_HOURS,
+  ADDRESS,
+  ENFORCEMENT_ADD,
+  ENFORCEMENT_UPDATE,
+  SUSPENSION,
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/resource/VariationController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/resource/VariationController.kt
@@ -1,0 +1,40 @@
+package uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.resource
+
+import jakarta.validation.Valid
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.security.core.Authentication
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.VariationDetails
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.dto.UpdateVariationDetailsDto
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.service.VariationService
+import java.util.*
+
+@RestController
+@PreAuthorize("hasRole('ROLE_EM_CEMO__CREATE_ORDER')")
+@RequestMapping("/api/")
+class VariationController(
+  @Autowired val variationService: VariationService,
+) {
+  @PutMapping("/orders/{orderId}/variation")
+  fun updateVariationDetails(
+    @PathVariable orderId: UUID,
+    @RequestBody @Valid updateRecord: UpdateVariationDetailsDto,
+    authentication: Authentication,
+  ): ResponseEntity<VariationDetails> {
+    val username = authentication.name
+    val variationDetails = variationService.updateVariationDetails(
+      orderId,
+      username,
+      updateRecord,
+    )
+
+    return ResponseEntity(variationDetails, HttpStatus.OK)
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/VariationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/VariationService.kt
@@ -1,0 +1,30 @@
+package uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.service
+
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.VariationDetails
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.dto.UpdateVariationDetailsDto
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.VariationType
+import java.time.ZonedDateTime
+import java.util.*
+
+@Service
+class VariationService() : OrderSectionServiceBase() {
+  fun updateVariationDetails(
+    orderId: UUID,
+    username: String,
+    updateRecord: UpdateVariationDetailsDto,
+  ): VariationDetails {
+    val order = this.findEditableOrder(orderId, username)
+
+    with(updateRecord) {
+      order.variationDetails = VariationDetails(
+        orderId = orderId,
+        variationType = VariationType.valueOf(variationType),
+        variationDate = ZonedDateTime.parse(variationDate),
+      )
+    }
+
+    orderRepo.save(order)
+    return order.variationDetails!!
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/VariationControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/VariationControllerTest.kt
@@ -1,0 +1,229 @@
+package uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.integration.resource
+
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.MediaType
+import org.springframework.web.reactive.function.BodyInserters
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.VariationDetails
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.OrderStatus
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.VariationType
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.repository.OrderRepository
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.resource.validator.ValidationError
+import java.time.ZonedDateTime
+import java.util.*
+
+class VariationControllerTest : IntegrationTestBase() {
+  @Autowired
+  lateinit var repo: OrderRepository
+
+  @BeforeEach
+  fun setup() {
+    repo.deleteAll()
+  }
+
+  @Nested
+  @DisplayName("POST /api/orders/{orderId}/variation")
+  inner class PostVariation {
+
+    @Test
+    fun `it should not be possible to update the variation details if the variation is owned by another user`() {
+      val variation = createVariation()
+
+      webTestClient.put()
+        .uri("/api/orders/${variation.id}/variation")
+        .contentType(MediaType.APPLICATION_JSON)
+        .body(
+          BodyInserters.fromValue(
+            """
+              {
+                "variationType": "ADDRESS",
+                "variationDate": "2024-01-01T00:00:00.000Z"
+              }
+            """.trimIndent(),
+          ),
+        )
+        .headers(setAuthorisation("AUTH_ADM_2"))
+        .exchange()
+        .expectStatus()
+        .isNotFound
+    }
+
+    @Test
+    fun `it should not be possible to update the variation details if the variation does not exist`() {
+      webTestClient.put()
+        .uri("/api/orders/${UUID.randomUUID()}/variation")
+        .contentType(MediaType.APPLICATION_JSON)
+        .body(
+          BodyInserters.fromValue(
+            """
+              {
+                "variationType": "ADDRESS",
+                "variationDate": "2024-01-01T00:00:00.000Z"
+              }
+            """.trimIndent(),
+          ),
+        )
+        .headers(setAuthorisation("AUTH_ADM"))
+        .exchange()
+        .expectStatus()
+        .isNotFound
+    }
+
+    @Test
+    fun `it should not be possible to update the variation details if the variation has been submitted`() {
+      val variation = createVariation()
+
+      variation.status = OrderStatus.SUBMITTED
+      repo.save(variation)
+
+      webTestClient.put()
+        .uri("/api/orders/${variation.id}/variation")
+        .contentType(MediaType.APPLICATION_JSON)
+        .body(
+          BodyInserters.fromValue(
+            """
+              {
+                "variationType": "ADDRESS",
+                "variationDate": "2024-01-01T00:00:00.000Z"
+              }
+            """.trimIndent(),
+          ),
+        )
+        .headers(setAuthorisation("AUTH_ADM"))
+        .exchange()
+        .expectStatus()
+        .isNotFound
+    }
+
+    @Test
+    fun `it should not be possible to update the variation details if the mandatory fields are missing`() {
+      val variation = createVariation()
+
+      val result = webTestClient.put()
+        .uri("/api/orders/${variation.id}/variation")
+        .contentType(MediaType.APPLICATION_JSON)
+        .body(
+          BodyInserters.fromValue(
+            """
+              {}
+            """.trimIndent(),
+          ),
+        )
+        .headers(setAuthorisation("AUTH_ADM"))
+        .exchange()
+        .expectStatus()
+        .isBadRequest
+        .expectBodyList(ValidationError::class.java)
+        .returnResult()
+
+      Assertions.assertThat(result.responseBody).isNotNull
+      Assertions.assertThat(result.responseBody).hasSize(2)
+      Assertions.assertThat(result.responseBody!!).contains(
+        ValidationError("variationType", "Variation type is required"),
+      )
+      Assertions.assertThat(result.responseBody!!).contains(
+        ValidationError("variationDate", "Variation date is required"),
+      )
+    }
+
+    @Test
+    fun `it should not be possible to update the variation details with an invalid variationType`() {
+      val variation = createVariation()
+
+      val result = webTestClient.put()
+        .uri("/api/orders/${variation.id}/variation")
+        .contentType(MediaType.APPLICATION_JSON)
+        .body(
+          BodyInserters.fromValue(
+            """
+              {
+                "variationType": "UNKNOWN",
+                "variationDate": "2024-01-01T00:00:00.000Z"
+              }
+            """.trimIndent(),
+          ),
+        )
+        .headers(setAuthorisation("AUTH_ADM"))
+        .exchange()
+        .expectStatus()
+        .isBadRequest
+        .expectBodyList(ValidationError::class.java)
+        .returnResult()
+
+      Assertions.assertThat(result.responseBody).isNotNull
+      Assertions.assertThat(result.responseBody).hasSize(1)
+      Assertions.assertThat(result.responseBody!!).contains(
+        ValidationError("variationType", "Variation type must be a valid variation type"),
+      )
+    }
+
+    @Test
+    fun `it should not be possible to update the variation details with an invalid variationDate`() {
+      val variation = createVariation()
+
+      val result = webTestClient.put()
+        .uri("/api/orders/${variation.id}/variation")
+        .contentType(MediaType.APPLICATION_JSON)
+        .body(
+          BodyInserters.fromValue(
+            """
+              {
+                "variationType": "ADDRESS",
+                "variationDate": "2024-02-31T00:00:00.000Z"
+              }
+            """.trimIndent(),
+          ),
+        )
+        .headers(setAuthorisation("AUTH_ADM"))
+        .exchange()
+        .expectStatus()
+        .isBadRequest
+        .expectBodyList(ValidationError::class.java)
+        .returnResult()
+
+      Assertions.assertThat(result.responseBody).isNotNull
+      Assertions.assertThat(result.responseBody).hasSize(1)
+      Assertions.assertThat(result.responseBody!!).contains(
+        ValidationError("variationDate", "Variation date must be a valid date"),
+      )
+    }
+
+    @ParameterizedTest(name = "it should be possible to update the variation details with variationType = {0}")
+    @ValueSource(strings = ["CURFEW_HOURS", "ADDRESS", "ENFORCEMENT_ADD", "ENFORCEMENT_UPDATE", "SUSPENSION"])
+    fun `it should be possible to update the variation details with all variation types`(variationType: String) {
+      val variation = createVariation()
+
+      val result = webTestClient.put()
+        .uri("/api/orders/${variation.id}/variation")
+        .contentType(MediaType.APPLICATION_JSON)
+        .body(
+          BodyInserters.fromValue(
+            """
+              {
+                "variationType": "$variationType",
+                "variationDate": "2024-01-01T00:00:00.000Z"
+              }
+            """.trimIndent(),
+          ),
+        )
+        .headers(setAuthorisation("AUTH_ADM"))
+        .exchange()
+        .expectStatus()
+        .isOk
+        .expectBody(VariationDetails::class.java)
+        .returnResult()
+        .responseBody!!
+
+      Assertions.assertThat(result.orderId).isEqualTo(variation.id)
+      Assertions.assertThat(result.variationType).isEqualTo(VariationType.valueOf(variationType))
+      Assertions.assertThat(result.variationDate).isEqualTo(ZonedDateTime.parse("2024-01-01T00:00:00.000Z"))
+    }
+  }
+}


### PR DESCRIPTION
This sets up a new controller for variations with a simple put endpoint for creating / updating variation details.

The DTO receives the variationType and variationDate as simple string values and then validates that they can be parsed to the correct type during validation. The alternative would be to allow the framework to cast them to the desired datatypes (`Enum` / `ZonedDateTime`), however this can generate `HttpMessageNotReadableException` exceptions if either of the fields are missing or contain invalid values (e.g. a bad datetime string) and wouldn't allow us to generate client friendly validation error messages.