### PR TITLE
Implement and enable submissions of variations to Serco

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/VariationDetails.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/VariationDetails.kt
@@ -27,8 +27,8 @@ data class VariationDetails(
   @Column(name = "VARIATION_TYPE", nullable = false)
   val variationType: VariationType,
 
-  @Column(name = "VARIATION_DATE", nullable = true)
-  var variationDate: ZonedDateTime? = null,
+  @Column(name = "VARIATION_DATE", nullable = false)
+  var variationDate: ZonedDateTime,
 
   @Schema(hidden = true)
   @OneToOne

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/enums/OrderType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/enums/OrderType.kt
@@ -1,6 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums
 
-enum class OrderType {
-  REQUEST,
-  VARIATION,
+enum class OrderType(val value: String) {
+  REQUEST("New Order"),
+  VARIATION("Variation"),
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/enums/VariationType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/enums/VariationType.kt
@@ -1,9 +1,9 @@
 package uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums
 
-enum class VariationType {
-  CURFEW_HOURS,
-  ADDRESS,
-  ENFORCEMENT_ADD,
-  ENFORCEMENT_UPDATE,
-  SUSPENSION,
+enum class VariationType(val value: String) {
+  CURFEW_HOURS("Change of curfew hours"),
+  ADDRESS("Change of address"),
+  ENFORCEMENT_ADD("Change to add an Inclusion or Exclusion Zone(s)"),
+  ENFORCEMENT_UPDATE("Change to an existing Inclusion or Exclusion Zone(s)"),
+  SUSPENSION("Order Suspension"),
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/fms/MonitoringOrder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/fms/MonitoringOrder.kt
@@ -7,6 +7,7 @@ import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.mo
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.AddressType
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.AlcoholMonitoringType
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.EnforcementZoneType
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.OrderType
 import java.time.DayOfWeek
 import java.time.format.DateTimeFormatter
 
@@ -191,6 +192,7 @@ data class MonitoringOrder(
       val monitoringOrder = MonitoringOrder(
         deviceWearer = "${order.deviceWearer!!.firstName} ${order.deviceWearer!!.lastName}",
         orderType = conditions.orderType,
+        orderRequestType = order.type.value,
         orderTypeDescription = conditions.orderTypeDescription?.value,
         orderStart = conditions.startDate?.format(dateTimeFormatter),
         orderEnd = conditions.endDate?.format(dateTimeFormatter) ?: "",
@@ -330,6 +332,11 @@ data class MonitoringOrder(
         monitoringOrder.installationAddress3 = it.addressLine3
         monitoringOrder.installationAddress4 = it.addressLine4
         monitoringOrder.installationAddressPostcode = it.postcode
+      }
+
+      if (order.type === OrderType.VARIATION) {
+        monitoringOrder.orderVariationType = order.variationDetails!!.variationType.value
+        monitoringOrder.orderVariationDate = order.variationDetails!!.variationDate.format(dateTimeFormatter)
       }
 
       return monitoringOrder

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/FmsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/FmsService.kt
@@ -29,7 +29,7 @@ class FmsService(
     }
 
     if (order.type === OrderType.VARIATION) {
-      return FmsVariationSubmissionStrategy()
+      return FmsVariationSubmissionStrategy(this.objectMapper, this.fmsClient)
     }
 
     return FmsOrderSubmissionStrategy(this.objectMapper, this.fmsClient)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/OrderService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/OrderService.kt
@@ -10,7 +10,6 @@ import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.mo
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.dto.CreateOrderDto
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.FmsOrderSource
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.OrderStatus
-import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.OrderType
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.specification.OrderSpecification
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.repository.OrderRepository
 import java.util.UUID
@@ -61,10 +60,6 @@ class OrderService(
 
   fun submitOrder(id: UUID, username: String): Order {
     val order = getOrder(username, id)!!
-
-    if (order.type == OrderType.VARIATION) {
-      throw SubmitOrderException("A variation cannot be submitted yet!")
-    }
 
     if (order.status == OrderStatus.SUBMITTED) {
       throw SubmitOrderException("This order has already been submitted")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/strategy/FmsVariationSubmissionStrategy.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/strategy/FmsVariationSubmissionStrategy.kt
@@ -1,70 +1,168 @@
 package uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.service.strategy
 
-import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.stereotype.Component
+import com.fasterxml.jackson.databind.ObjectMapper
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.client.FmsClient
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.Order
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.SubmitFmsOrderResult
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.FmsOrderSource
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.fms.DeviceWearer
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.fms.FmsRequestResult
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.fms.FmsSubmissionStrategyKind
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.fms.MonitoringOrder
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.fms.Result
+import java.util.*
 
-@Component
-class FmsVariationSubmissionStrategy() : FmsSubmissionStrategy {
+class FmsVariationSubmissionStrategy(
+  objectMapper: ObjectMapper,
+  val fmsClient: FmsClient,
+) : FmsSubmissionStrategyBase(objectMapper) {
 
-  @Autowired
-  lateinit var fmsClient: FmsClient
+  private fun submitUpdateDeviceWearerRequest(deviceWearer: DeviceWearer, orderId: UUID): Result<String> {
+    return try {
+      // TODO: Should call updateDeviceWearer endpoint, but not currently possible
+      Result(
+        success = true,
+        data = fmsClient.createDeviceWearer(deviceWearer, orderId).result.first().id,
+      )
+    } catch (e: Exception) {
+      Result(
+        success = false,
+        error = Exception("Failed to submit FMS Device Wearer", e),
+      )
+    }
+  }
 
-  private fun updateDeviceWearer(order: Order): Result<String> {
-    return Result.failure(
-      Exception("Not implemented"),
+  private fun submitUpdateMonitoringOrderRequest(monitoringOrder: MonitoringOrder, orderId: UUID): Result<String> {
+    return try {
+      Result(
+        success = true,
+        data = fmsClient.updateMonitoringOrder(monitoringOrder, orderId).result.first().id,
+      )
+    } catch (e: Exception) {
+      Result(
+        success = false,
+        error = Exception("Failed to submit FMS Monitoring Order", e),
+      )
+    }
+  }
+
+  private fun updateDeviceWearer(order: Order): FmsRequestResult {
+    val deviceWearerResult = this.getDeviceWearer(order)
+
+    if (!deviceWearerResult.success) {
+      return FmsRequestResult(
+        success = false,
+        error = deviceWearerResult.error.toString(),
+      )
+    }
+
+    val deviceWearer = deviceWearerResult.data!!
+    val serialiseResult = this.serialiseDeviceWearer(deviceWearer)
+
+    if (!serialiseResult.success) {
+      return FmsRequestResult(
+        success = false,
+        error = serialiseResult.error.toString(),
+      )
+    }
+
+    val submissionResult = this.submitUpdateDeviceWearerRequest(deviceWearer, order.id)
+
+    if (!submissionResult.success) {
+      return FmsRequestResult(
+        success = false,
+        error = submissionResult.error.toString(),
+        payload = submissionResult.data!!,
+      )
+    }
+
+    return FmsRequestResult(
+      success = true,
+      id = submissionResult.data!!,
+      payload = serialiseResult.data!!,
     )
   }
 
-  private fun updateMonitoringOrder(order: Order): Result<String> {
-    return Result.failure(
-      Exception("Not implemented"),
+  private fun updateMonitoringOrder(order: Order, deviceWearerId: String): FmsRequestResult {
+    val monitoringOrderResult = this.getMonitoringOrder(order, deviceWearerId)
+
+    if (!monitoringOrderResult.success) {
+      return FmsRequestResult(
+        success = false,
+        error = monitoringOrderResult.error.toString(),
+      )
+    }
+
+    val monitoringOrder = monitoringOrderResult.data!!
+    val serialiseResult = this.serialiseMonitoringOrder(monitoringOrder)
+
+    if (!serialiseResult.success) {
+      return FmsRequestResult(
+        success = false,
+        error = serialiseResult.error.toString(),
+      )
+    }
+
+    val submissionResult = this.submitUpdateMonitoringOrderRequest(monitoringOrder, order.id)
+
+    if (!submissionResult.success) {
+      return FmsRequestResult(
+        success = false,
+        error = submissionResult.error.toString(),
+        payload = serialiseResult.data!!,
+      )
+    }
+
+    return FmsRequestResult(
+      success = true,
+      id = submissionResult.data!!,
+      payload = serialiseResult.data!!,
     )
   }
 
   override fun submitOrder(order: Order, orderSource: FmsOrderSource): SubmitFmsOrderResult {
-    val updateDeviceWearerResult = this.updateDeviceWearer(order)
+    val createDeviceWearerResult = this.updateDeviceWearer(order)
+    val deviceWearerId = createDeviceWearerResult.id
+    val deviceWearerRequest = createDeviceWearerResult.payload
 
-    if (updateDeviceWearerResult.isFailure) {
+    if (!createDeviceWearerResult.success) {
       return SubmitFmsOrderResult(
+        id = order.id,
         success = false,
-        strategy = FmsSubmissionStrategyKind.VARIATION,
-        error = "Failed to update the device wearer",
-        deviceWearerId = "",
-        fmsDeviceWearerRequest = "",
-        fmsOrderRequest = "",
-        fmsOrderId = "",
+        strategy = FmsSubmissionStrategyKind.ORDER,
+        error = createDeviceWearerResult.error,
+        deviceWearerId = deviceWearerId,
+        fmsDeviceWearerRequest = deviceWearerRequest,
         orderSource = orderSource,
       )
     }
 
-    val updateMonitoringOrderResult = this.updateMonitoringOrder(order)
+    val createMonitoringOrderResult = this.updateMonitoringOrder(order, deviceWearerId)
+    val monitoringOrderId = createMonitoringOrderResult.id
+    val monitoringOrderRequest = createMonitoringOrderResult.payload
 
-    if (updateMonitoringOrderResult.isFailure) {
+    if (!createMonitoringOrderResult.success) {
       return SubmitFmsOrderResult(
+        id = order.id,
         success = false,
-        strategy = FmsSubmissionStrategyKind.VARIATION,
-        error = "Failed to update the monitoring order",
-        deviceWearerId = updateDeviceWearerResult.getOrDefault(""),
-        fmsDeviceWearerRequest = "",
-        fmsOrderId = "",
-        fmsOrderRequest = "",
+        strategy = FmsSubmissionStrategyKind.ORDER,
+        error = createMonitoringOrderResult.error,
+        deviceWearerId = deviceWearerId,
+        fmsDeviceWearerRequest = deviceWearerRequest,
+        fmsOrderId = monitoringOrderId,
+        fmsOrderRequest = monitoringOrderRequest,
         orderSource = orderSource,
       )
     }
 
     return SubmitFmsOrderResult(
+      id = order.id,
       success = true,
-      strategy = FmsSubmissionStrategyKind.VARIATION,
-      error = "",
-      deviceWearerId = updateDeviceWearerResult.getOrDefault(""),
-      fmsDeviceWearerRequest = "",
-      fmsOrderId = updateDeviceWearerResult.getOrDefault(""),
-      fmsOrderRequest = "",
+      strategy = FmsSubmissionStrategyKind.ORDER,
+      deviceWearerId = deviceWearerId,
+      fmsDeviceWearerRequest = deviceWearerRequest,
+      fmsOrderId = monitoringOrderId,
+      fmsOrderRequest = monitoringOrderRequest,
       orderSource = orderSource,
     )
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/strategy/FmsVariationSubmissionStrategy.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/strategy/FmsVariationSubmissionStrategy.kt
@@ -129,7 +129,7 @@ class FmsVariationSubmissionStrategy(
       return SubmitFmsOrderResult(
         id = order.id,
         success = false,
-        strategy = FmsSubmissionStrategyKind.ORDER,
+        strategy = FmsSubmissionStrategyKind.VARIATION,
         error = createDeviceWearerResult.error,
         deviceWearerId = deviceWearerId,
         fmsDeviceWearerRequest = deviceWearerRequest,
@@ -145,7 +145,7 @@ class FmsVariationSubmissionStrategy(
       return SubmitFmsOrderResult(
         id = order.id,
         success = false,
-        strategy = FmsSubmissionStrategyKind.ORDER,
+        strategy = FmsSubmissionStrategyKind.VARIATION,
         error = createMonitoringOrderResult.error,
         deviceWearerId = deviceWearerId,
         fmsDeviceWearerRequest = deviceWearerRequest,
@@ -158,7 +158,7 @@ class FmsVariationSubmissionStrategy(
     return SubmitFmsOrderResult(
       id = order.id,
       success = true,
-      strategy = FmsSubmissionStrategyKind.ORDER,
+      strategy = FmsSubmissionStrategyKind.VARIATION,
       deviceWearerId = deviceWearerId,
       fmsDeviceWearerRequest = deviceWearerRequest,
       fmsOrderId = monitoringOrderId,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/listener/CourtHearingEventListenerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/listener/CourtHearingEventListenerTest.kt
@@ -112,7 +112,7 @@ class CourtHearingEventListenerTest : IntegrationTestBase() {
       HttpStatus.OK,
       FmsResponse(result = listOf(FmsResult(message = "", id = "MockDeviceWearerId"))),
     )
-    sercoApi.stubMonitoringOrder(
+    sercoApi.stubCreateMonitoringOrder(
       HttpStatus.OK,
       FmsResponse(result = listOf(FmsResult(message = "", id = "MockMonitoringOrderId"))),
     )
@@ -249,7 +249,7 @@ class CourtHearingEventListenerTest : IntegrationTestBase() {
       HttpStatus.OK,
       FmsResponse(result = listOf(FmsResult(message = "", id = "MockDeviceWearerId"))),
     )
-    sercoApi.stubMonitoringOrder(
+    sercoApi.stubCreateMonitoringOrder(
       HttpStatus.OK,
       FmsResponse(result = listOf(FmsResult(message = "", id = "MockMonitoringOrderId"))),
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/OrderControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/OrderControllerTest.kt
@@ -27,6 +27,7 @@ import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.mo
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.Order
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.ResponsibleAdult
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.TrailMonitoringConditions
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.VariationDetails
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.AddressType
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.AlcoholMonitoringInstallationLocationType
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.AlcoholMonitoringType
@@ -35,6 +36,7 @@ import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.mo
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.OrderStatus
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.OrderType
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.OrderTypeDescription
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.VariationType
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.fms.FmsErrorResponse
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.fms.FmsResponse
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.fms.FmsResult
@@ -444,25 +446,6 @@ class OrderControllerTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `It should throw an error if a variation is submitted`() {
-      // Temporary test to ensure that variations can't be submitted
-      val order = createVariation()
-
-      val result = webTestClient.post()
-        .uri("/api/orders/${order.id}/submit")
-        .headers(setAuthorisation())
-        .exchange()
-        .expectStatus()
-        .is4xxClientError
-        .expectBody(ErrorResponse::class.java)
-        .returnResult()
-
-      val error = result.responseBody!!
-      assertThat(error.userMessage)
-        .isEqualTo("Error submitting order: A variation cannot be submitted yet!")
-    }
-
-    @Test
     fun `It should return an error if serco auth service returned error`() {
       val order = createAndPersistReadyToSubmitOrder()
 
@@ -515,7 +498,7 @@ class OrderControllerTest : IntegrationTestBase() {
         HttpStatus.OK,
         FmsResponse(result = listOf(FmsResult(message = "", id = "MockDeviceWearerId"))),
       )
-      sercoApi.stubMonitoringOrder(
+      sercoApi.stubCreateMonitoringOrder(
         HttpStatus.INTERNAL_SERVER_ERROR,
         FmsResponse(),
         FmsErrorResponse(error = FmsErrorResponseDetails("", "Mock Create MO Error")),
@@ -552,7 +535,7 @@ class OrderControllerTest : IntegrationTestBase() {
         HttpStatus.OK,
         FmsResponse(result = listOf(FmsResult(message = "", id = "MockDeviceWearerId"))),
       )
-      sercoApi.stubMonitoringOrder(
+      sercoApi.stubCreateMonitoringOrder(
         HttpStatus.OK,
         FmsResponse(result = listOf(FmsResult(message = "", id = "MockMonitoringOrderId"))),
       )
@@ -673,7 +656,7 @@ class OrderControllerTest : IntegrationTestBase() {
       	"offence_date": "",
       	"order_end": "${mockEndDate.format(dateTimeFormatter)}",
       	"order_id": "${order.id}",
-      	"order_request_type": "",
+      	"order_request_type": "New Order",
       	"order_start": "${mockStartDate.format(dateTimeFormatter)}",
       	"order_type": "community",
       	"order_type_description": "DAPOL",
@@ -838,6 +821,300 @@ class OrderControllerTest : IntegrationTestBase() {
     }
 
     @Test
+    fun `It should update order with device wearer id, monitoring id & order status, and return 200 for a variation`() {
+      val order = createAndPersistReadyToSubmitOrder(false, OrderType.VARIATION)
+      sercoAuthApi.stubGrantToken()
+
+      sercoApi.stubCreateDeviceWearer(
+        HttpStatus.OK,
+        FmsResponse(result = listOf(FmsResult(message = "", id = "MockDeviceWearerId"))),
+      )
+      sercoApi.stubUpdateMonitoringOrder(
+        HttpStatus.OK,
+        FmsResponse(result = listOf(FmsResult(message = "", id = "MockMonitoringOrderId"))),
+      )
+      webTestClient.post()
+        .uri("/api/orders/${order.id}/submit")
+        .headers(setAuthorisation())
+        .exchange()
+        .expectStatus()
+        .isOk
+
+      val submitResult = fmsResultRepository.findAll().firstOrNull()
+      assertThat(submitResult).isNotNull
+
+      val expectedDWJson = """
+      {
+      	"title": "",
+      	"first_name": "John",
+      	"middle_name": "",
+      	"last_name": "Smith",
+      	"alias": "Johnny",
+      	"date_of_birth": "1990-01-01",
+      	"adult_child": "adult",
+      	"sex": "Male",
+      	"gender_identity": "Male",
+      	"disability": [
+      		{
+      			"disability": "Vision"
+      		},
+      		{
+      			"disability": "Learning, understanding or concentrating"
+      		}
+      	],
+      	"address_1": "20 Somewhere Street",
+      	"address_2": "Nowhere City",
+      	"address_3": "Random County",
+      	"address_4": "United Kingdom",
+      	"address_post_code": "SW11 1NC",
+      	"secondary_address_1": "",
+      	"secondary_address_2": "",
+      	"secondary_address_3": "",
+      	"secondary_address_4": "",
+      	"secondary_address_post_code": "",
+      	"phone_number": "07401111111",
+      	"risk_serious_harm": "",
+      	"risk_self_harm": "",
+      	"risk_details": "Danger",
+      	"mappa": "MAAPA 1",
+      	"mappa_case_type": "CPPC (Critical Public Protection Case)",
+      	"risk_categories": [],
+      	"responsible_adult_required": "true",
+      	"parent": "Mark Smith",
+      	"guardian": "",
+      	"parent_address_1": "",
+      	"parent_address_2": "",
+      	"parent_address_3": "",
+      	"parent_address_4": "",
+      	"parent_address_post_code": "",
+      	"parent_phone_number": "07401111111",
+      	"parent_dob": "",
+      	"pnc_id": "pncId",
+      	"nomis_id": "nomisId",
+      	"delius_id": "deliusId",
+      	"prison_number": "prisonNumber",
+      	"home_office_case_reference_number": "homeOfficeReferenceNumber",
+      	"interpreter_required": "true",
+      	"language": "British Sign"
+      }
+      """.trimIndent()
+      val expectedOrderJson = """
+      {
+      	"case_id": "MockDeviceWearerId",
+      	"allday_lockdown": "",
+      	"atv_allowance": "",
+      	"condition_type": "Requirement of a Community Order",
+      	"court": "",
+      	"court_order_email": "",      	
+      	"device_type": "",
+      	"device_wearer": "John Smith",
+      	"enforceable_condition": [
+      		{
+      			"condition": "Curfew with EM",
+            "start_date": "${mockStartDate.format(dateTimeFormatter)}",
+            "end_date": "${mockEndDate.format(dateTimeFormatter)}"
+      		},
+      		{
+      			"condition": "Location Monitoring (Fitted Device)",
+            "start_date": "${mockStartDate.format(dateTimeFormatter)}",
+            "end_date": "${mockEndDate.format(dateTimeFormatter)}"
+      		},
+      		{
+      			"condition": "EM Exclusion / Inclusion Zone",
+            "start_date": "${mockStartDate.format(dateTimeFormatter)}",
+            "end_date": "${mockEndDate.format(dateTimeFormatter)}"
+      		},          
+      		{
+      			"condition": "AAMR",
+            "start_date": "${mockStartDate.format(dateTimeFormatter)}",
+            "end_date": "${mockEndDate.format(dateTimeFormatter)}"
+      		}
+      	],
+      	"exclusion_allday": "",
+      	"interim_court_date": "",
+      	"issuing_organisation": "",
+      	"media_interest": "",
+      	"new_order_received": "",
+      	"notifying_officer_email": "",
+      	"notifying_officer_name": "",
+      	"notifying_organization": "Mock Organisation",
+      	"no_post_code": "",
+      	"no_address_1": "",
+      	"no_address_2": "",
+      	"no_address_3": "",
+      	"no_address_4": "",
+      	"no_email": "",
+      	"no_name": "",
+      	"no_phone_number": "",
+      	"offence": "Fraud Offences",
+      	"offence_date": "",
+      	"order_end": "${mockEndDate.format(dateTimeFormatter)}",
+      	"order_id": "${order.id}",
+      	"order_request_type": "Variation",
+      	"order_start": "${mockStartDate.format(dateTimeFormatter)}",
+      	"order_type": "community",
+      	"order_type_description": "DAPOL",
+      	"order_type_detail": "",
+      	"order_variation_date": "${mockStartDate.format(dateTimeFormatter)}",
+      	"order_variation_details": "",
+      	"order_variation_req_received_date": "",
+      	"order_variation_type": "Change of address",
+      	"pdu_responsible": "",
+      	"pdu_responsible_email": "",
+      	"planned_order_end_date": "",
+      	"responsible_officer_details_received": "",
+      	"responsible_officer_email": "",
+      	"responsible_officer_phone": "07401111111",
+      	"responsible_officer_name": "John Smith",
+      	"responsible_organization": "Avon and Somerset Constabulary",
+      	"ro_post_code": "AB11 1CD",
+      	"ro_address_1": "Line 1",
+      	"ro_address_2": "Line 2",
+      	"ro_address_3": "",
+      	"ro_address_4": "",
+      	"ro_email": "abc@def.com",
+      	"ro_phone": "07401111111",
+      	"ro_region": "Mock Region",
+      	"sentence_date": "",
+      	"sentence_expiry": "",
+      	"tag_at_source": "",
+      	"tag_at_source_details": "",
+      	"technical_bail": "",
+      	"trial_date": "",
+      	"trial_outcome": "",
+      	"conditional_release_date": "${mockStartDate.format(formatter)}",
+      	"reason_for_order_ending_early": "",
+      	"business_unit": "",
+        "service_end_date": "${mockEndDate.format(formatter)}",
+        "curfew_description": "",
+      	"curfew_start": "${mockStartDate.format(dateTimeFormatter)}",
+      	"curfew_end": "${mockEndDate.format(dateTimeFormatter)}",
+      	"curfew_duration": [
+      		{
+      			"location": "primary",
+      			"allday": "",
+      			"schedule": [
+      				{
+      					"day": "Mo",
+      					"start": "17:00",
+      					"end": "09:00"
+      				},
+      				{
+      					"day": "Tu",
+      					"start": "17:00",
+      					"end": "09:00"
+      				},
+      				{
+      					"day": "Wed",
+      					"start": "17:00",
+      					"end": "09:00"
+      				},
+      				{
+      					"day": "Th",
+      					"start": "17:00",
+      					"end": "09:00"
+      				},
+      				{
+      					"day": "Fr",
+      					"start": "17:00",
+      					"end": "09:00"
+      				},
+      				{
+      					"day": "Sa",
+      					"start": "17:00",
+      					"end": "09:00"
+      				},
+      				{
+      					"day": "Su",
+      					"start": "17:00",
+      					"end": "09:00"
+      				}
+      			]
+      		},
+      		{
+      			"location": "secondary",
+      			"allday": "",
+      			"schedule": [
+      				{
+      					"day": "Mo",
+      					"start": "17:00",
+      					"end": "09:00"
+      				},
+      				{
+      					"day": "Tu",
+      					"start": "17:00",
+      					"end": "09:00"
+      				},
+      				{
+      					"day": "Wed",
+      					"start": "17:00",
+      					"end": "09:00"
+      				},
+      				{
+      					"day": "Th",
+      					"start": "17:00",
+      					"end": "09:00"
+      				},
+      				{
+      					"day": "Fr",
+      					"start": "17:00",
+      					"end": "09:00"
+      				},
+      				{
+      					"day": "Sa",
+      					"start": "17:00",
+      					"end": "09:00"
+      				},
+      				{
+      					"day": "Su",
+      					"start": "17:00",
+      					"end": "09:00"
+      				}
+      			]
+      		}
+      	],
+      	"trail_monitoring": "No",
+      	"exclusion_zones": [
+          {
+            "description": "Mock Exclusion Zone",
+            "duration": "Mock Exclusion Duration",
+            "start": "${mockStartDate.format(formatter)}",
+            "end": "${mockEndDate.format(formatter)}"
+          }
+          ],      	
+      	"inclusion_zones": [
+          {
+            "description": "Mock Inclusion Zone",
+            "duration": "Mock Inclusion Duration",
+            "start": "${mockStartDate.format(formatter)}",
+            "end": "${mockEndDate.format(formatter)}"
+          }
+          ],
+      	
+      	"abstinence": "Yes",
+      	"schedule": "",
+      	"checkin_schedule": [],
+      	"revocation_date": "",
+      	"revocation_type": "",
+        "installation_address_1": "24 Somewhere Street",
+        "installation_address_2": "Nowhere City",
+        "installation_address_3": "Random County",
+        "installation_address_4": "United Kingdom",
+        "installation_address_post_code": "SW11 1NC",
+        "crown_court_case_reference_number": "",
+        "magistrate_court_case_reference_number": "",
+      	"order_status": "Not Started"
+      }
+      """.trimIndent()
+
+      assertThat(submitResult!!.fmsDeviceWearerRequest).isEqualTo(expectedDWJson.removeWhitespaceAndNewlines())
+      assertThat(submitResult.fmsOrderRequest).isEqualTo(expectedOrderJson.removeWhitespaceAndNewlines())
+      val updatedOrder = repo.findById(order.id).get()
+      assertThat(updatedOrder.fmsResultId).isEqualTo(submitResult.id)
+      assertThat(updatedOrder.status).isEqualTo(OrderStatus.SUBMITTED)
+    }
+
+    @Test
     fun `It should map installation address if device wearer no fixed Abode is true`() {
       val order = createAndPersistReadyToSubmitOrder(true)
       sercoAuthApi.stubGrantToken()
@@ -846,7 +1123,7 @@ class OrderControllerTest : IntegrationTestBase() {
         HttpStatus.OK,
         FmsResponse(result = listOf(FmsResult(message = "", id = "MockDeviceWearerId"))),
       )
-      sercoApi.stubMonitoringOrder(
+      sercoApi.stubCreateMonitoringOrder(
         HttpStatus.OK,
         FmsResponse(result = listOf(FmsResult(message = "", id = "MockMonitoringOrderId"))),
       )
@@ -929,12 +1206,13 @@ class OrderControllerTest : IntegrationTestBase() {
     }
   }
 
-  fun createReadyToSubmitOrder(noFixedAddress: Boolean = false): Order {
+  fun createReadyToSubmitOrder(noFixedAddress: Boolean = false, orderType: OrderType = OrderType.REQUEST): Order {
     val order = Order(
       username = "AUTH_ADM",
       status = OrderStatus.IN_PROGRESS,
-      type = OrderType.REQUEST,
+      type = orderType,
     )
+
     order.deviceWearer = DeviceWearer(
       orderId = order.id,
       firstName = "John",
@@ -1023,6 +1301,7 @@ class OrderControllerTest : IntegrationTestBase() {
       orderId = order.id,
       contactNumber = "07401111111",
     )
+
     order.monitoringConditions = MonitoringConditions(
       orderId = order.id,
       orderType = "community",
@@ -1122,11 +1401,23 @@ class OrderControllerTest : IntegrationTestBase() {
       notifyingOrganisation = "Mock Organisation",
       notifyingOrganisationEmail = "",
     )
+
+    if (order.type === OrderType.VARIATION) {
+      order.variationDetails = VariationDetails(
+        orderId = order.id,
+        variationType = VariationType.ADDRESS,
+        variationDate = mockStartDate,
+      )
+    }
+
     return order
   }
 
-  fun createAndPersistReadyToSubmitOrder(noFixedAddress: Boolean = false): Order {
-    val order = createReadyToSubmitOrder(noFixedAddress)
+  fun createAndPersistReadyToSubmitOrder(
+    noFixedAddress: Boolean = false,
+    orderType: OrderType = OrderType.REQUEST,
+  ): Order {
+    val order = createReadyToSubmitOrder(noFixedAddress, orderType)
     repo.save(order)
     return order
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/wiremock/SercoMockApi.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/wiremock/SercoMockApi.kt
@@ -59,7 +59,7 @@ class SercoMockApiServer : WireMockServer(WIREMOCK_PORT) {
     )
   }
 
-  fun stubMonitoringOrder(status: HttpStatus, result: FmsResponse, errorResponse: FmsErrorResponse? = null) {
+  fun stubCreateMonitoringOrder(status: HttpStatus, result: FmsResponse, errorResponse: FmsErrorResponse? = null) {
     val body: String
     if (errorResponse != null) {
       body = objectMapper.writeValueAsString(errorResponse)
@@ -68,6 +68,26 @@ class SercoMockApiServer : WireMockServer(WIREMOCK_PORT) {
     }
     stubFor(
       post(urlPathTemplate("/monitoring_order/createMO"))
+        .willReturn(
+          aResponse()
+            .withHeader("Content-Type", "application/json")
+            .withBody(
+              body,
+            )
+            .withStatus(status.value()),
+        ),
+    )
+  }
+
+  fun stubUpdateMonitoringOrder(status: HttpStatus, result: FmsResponse, errorResponse: FmsErrorResponse? = null) {
+    val body: String
+    if (errorResponse != null) {
+      body = objectMapper.writeValueAsString(errorResponse)
+    } else {
+      body = objectMapper.writeValueAsString(result)
+    }
+    stubFor(
+      post(urlPathTemplate("/monitoring_order/updateMO"))
         .willReturn(
           aResponse()
             .withHeader("Content-Type", "application/json")

--- a/src/test/resources/json/CCIB_bail_curfew/expected_fms_order.json
+++ b/src/test/resources/json/CCIB_bail_curfew/expected_fms_order.json
@@ -34,7 +34,7 @@
   "offence_date": "",
   "order_end": "2024-10-25 10:00:00",
   "order_id": "{expectedOderId}",
-  "order_request_type": "",
+  "order_request_type": "New Order",
   "order_start": "2024-10-25 00:00:00",
   "order_type": "Pre-Trial",
   "order_type_description": null,

--- a/src/test/resources/json/CCIC_bail_curfew/expected_fms_order.json
+++ b/src/test/resources/json/CCIC_bail_curfew/expected_fms_order.json
@@ -34,7 +34,7 @@
   "offence_date": "",
   "order_end": "2024-10-25 10:00:00",
   "order_id": "{expectedOderId}",
-  "order_request_type": "",
+  "order_request_type": "New Order",
   "order_start": "2024-10-24 00:00:00",
   "order_type": "Pre-Trial",
   "order_type_description": null,

--- a/src/test/resources/json/CCSIB_bail_exclusion/expected_fms_order.json
+++ b/src/test/resources/json/CCSIB_bail_exclusion/expected_fms_order.json
@@ -34,7 +34,7 @@
   "offence_date": "",
   "order_end": "2024-10-29 10:00:00",
   "order_id": "{expectedOderId}",
-  "order_request_type": "",
+  "order_request_type": "New Order",
   "order_start": "2024-10-25 00:00:00",
   "order_type": "Pre-Trial",
   "order_type_description": null,

--- a/src/test/resources/json/CCSIB_crown_court_bail_exclusion/expected_fms_order.json
+++ b/src/test/resources/json/CCSIB_crown_court_bail_exclusion/expected_fms_order.json
@@ -34,7 +34,7 @@
   "offence_date": "",
   "order_end": "2024-10-29 10:00:00",
   "order_id": "{expectedOderId}",
-  "order_request_type": "",
+  "order_request_type": "New Order",
   "order_start": "2024-10-25 00:00:00",
   "order_type": "Pre-Trial",
   "order_type_description": null,

--- a/src/test/resources/json/CCSIB_crown_court_no_fixed_next_hearing_date/expected_fms_order.json
+++ b/src/test/resources/json/CCSIB_crown_court_no_fixed_next_hearing_date/expected_fms_order.json
@@ -34,7 +34,7 @@
   "offence_date": "",
   "order_end": "2024-10-29 10:00:00",
   "order_id": "{expectedOderId}",
-  "order_request_type": "",
+  "order_request_type": "New Order",
   "order_start": "2024-10-25 00:00:00",
   "order_type": "Pre-Trial",
   "order_type_description": null,

--- a/src/test/resources/json/CCSIB_crown_court_week_commencing_next_hearing_date/expected_fms_order.json
+++ b/src/test/resources/json/CCSIB_crown_court_week_commencing_next_hearing_date/expected_fms_order.json
@@ -34,7 +34,7 @@
   "offence_date": "",
   "order_end": "",
   "order_id": "{expectedOderId}",
-  "order_request_type": "",
+  "order_request_type": "New Order",
   "order_start": "2024-10-25 00:00:00",
   "order_type": "Pre-Trial",
   "order_type_description": null,

--- a/src/test/resources/json/COEW_community_order_alcohol/expected_fms_order.json
+++ b/src/test/resources/json/COEW_community_order_alcohol/expected_fms_order.json
@@ -34,7 +34,7 @@
   "offence_date": "",
   "order_end": "2025-05-17 00:00:00",
   "order_id": "{expectedOderId}",
-  "order_request_type": "",
+  "order_request_type": "New Order",
   "order_start": "2024-10-21 00:00:00",
   "order_type": "Community",
   "order_type_description": null,

--- a/src/test/resources/json/COEW_community_order_curfew/expected_fms_order.json
+++ b/src/test/resources/json/COEW_community_order_curfew/expected_fms_order.json
@@ -34,7 +34,7 @@
   "offence_date": "",
   "order_end": "2025-04-06 07:00:00",
   "order_id": "{expectedOderId}",
-  "order_request_type": "",
+  "order_request_type": "New Order",
   "order_start": "2024-12-04 00:00:00",
   "order_type": "Community",
   "order_type_description": null,

--- a/src/test/resources/json/COV_community_order_trail/expected_fms_order.json
+++ b/src/test/resources/json/COV_community_order_trail/expected_fms_order.json
@@ -34,7 +34,7 @@
   "offence_date": "",
   "order_end": "2025-05-18 10:00:00",
   "order_id": "{expectedOderId}",
-  "order_request_type": "",
+  "order_request_type": "New Order",
   "order_start": "2024-10-18 10:00:00",
   "order_type": "Community",
   "order_type_description": null,

--- a/src/test/resources/json/RCCLAB_bail_exclusion/expected_fms_order.json
+++ b/src/test/resources/json/RCCLAB_bail_exclusion/expected_fms_order.json
@@ -34,7 +34,7 @@
   "offence_date": "",
   "order_end": "2024-10-31 10:00:00",
   "order_id": "{expectedOderId}",
-  "order_request_type": "",
+  "order_request_type": "New Order",
   "order_start": "2024-10-25 00:00:00",
   "order_type": "Pre-Trial",
   "order_type_description": null,

--- a/src/test/resources/json/RC_bail_inclusion/expected_fms_order.json
+++ b/src/test/resources/json/RC_bail_inclusion/expected_fms_order.json
@@ -34,7 +34,7 @@
   "offence_date": "",
   "order_end": "2024-10-31 14:00:00",
   "order_id": "{expectedOderId}",
-  "order_request_type": "",
+  "order_request_type": "New Order",
   "order_start": "2024-10-25 00:00:00",
   "order_type": "Pre-Trial",
   "order_type_description": null,

--- a/src/test/resources/json/REMCB_bail_curfew/expected_fms_order.json
+++ b/src/test/resources/json/REMCB_bail_curfew/expected_fms_order.json
@@ -34,7 +34,7 @@
   "offence_date": "",
   "order_end": "2024-10-30 10:00:00",
   "order_id": "{expectedOderId}",
-  "order_request_type": "",
+  "order_request_type": "New Order",
   "order_start": "2024-10-25 00:00:00",
   "order_type": "Pre-Trial",
   "order_type_description": null,

--- a/src/test/resources/json/RIB_bail_exclusion_except_court_or_appointment/expected_fms_order.json
+++ b/src/test/resources/json/RIB_bail_exclusion_except_court_or_appointment/expected_fms_order.json
@@ -34,7 +34,7 @@
   "offence_date": "",
   "order_end": "2024-10-30 10:00:00",
   "order_id": "{expectedOderId}",
-  "order_request_type": "",
+  "order_request_type": "New Order",
   "order_start": "2024-10-25 00:00:00",
   "order_type": "Pre-Trial",
   "order_type_description": null,

--- a/src/test/resources/json/RILAB_bail_inclusion/expected_fms_order.json
+++ b/src/test/resources/json/RILAB_bail_inclusion/expected_fms_order.json
@@ -34,7 +34,7 @@
   "offence_date": "",
   "order_end": "2024-10-30 10:00:00",
   "order_id": "{expectedOderId}",
-  "order_request_type": "",
+  "order_request_type": "New Order",
   "order_start": "2024-10-25 00:00:00",
   "order_type": "Pre-Trial",
   "order_type_description": null,

--- a/src/test/resources/json/SDO_supervision_curfew/expected_fms_order.json
+++ b/src/test/resources/json/SDO_supervision_curfew/expected_fms_order.json
@@ -34,7 +34,7 @@
   "offence_date": "",
   "order_end": "2025-05-25 10:00:00",
   "order_id": "{expectedOderId}",
-  "order_request_type": "",
+  "order_request_type": "New Order",
   "order_start": "2024-10-15 00:00:00",
   "order_type": "Community",
   "order_type_description": null,

--- a/src/test/resources/json/SUSPSD_community_order_exclusion/expected_fms_order.json
+++ b/src/test/resources/json/SUSPSD_community_order_exclusion/expected_fms_order.json
@@ -34,7 +34,7 @@
   "offence_date": "",
   "order_end": "2025-11-10 10:00:00",
   "order_id": "{expectedOderId}",
-  "order_request_type": "",
+  "order_request_type": "New Order",
   "order_start": "2024-11-10 10:00:00",
   "order_type": "Community",
   "order_type_description": null,

--- a/src/test/resources/json/SUSPS_community_order_inclusion/expected_fms_order.json
+++ b/src/test/resources/json/SUSPS_community_order_inclusion/expected_fms_order.json
@@ -34,7 +34,7 @@
   "offence_date": "",
   "order_end": "2025-05-10 10:00:00",
   "order_id": "{expectedOderId}",
-  "order_request_type": "",
+  "order_request_type": "New Order",
   "order_start": "2024-11-10 10:00:00",
   "order_type": "Community",
   "order_type_description": null,

--- a/src/test/resources/json/YROEW_youth_curfew/expected_fms_order.json
+++ b/src/test/resources/json/YROEW_youth_curfew/expected_fms_order.json
@@ -34,7 +34,7 @@
   "offence_date": "",
   "order_end": "2025-11-10 10:00:00",
   "order_id": "{expectedOderId}",
-  "order_request_type": "",
+  "order_request_type": "New Order",
   "order_start": "2024-10-15 00:00:00",
   "order_type": "Community",
   "order_type_description": null,

--- a/src/test/resources/json/YROFEW_youth_trail/expected_fms_order.json
+++ b/src/test/resources/json/YROFEW_youth_trail/expected_fms_order.json
@@ -34,7 +34,7 @@
   "offence_date": "",
   "order_end": "2025-05-15 10:00:00",
   "order_id": "{expectedOderId}",
-  "order_request_type": "",
+  "order_request_type": "New Order",
   "order_start": "2024-11-15 10:00:00",
   "order_type": "Community",
   "order_type_description": null,

--- a/src/test/resources/json/YROISS_youth_exclusion/expected_fms_order.json
+++ b/src/test/resources/json/YROISS_youth_exclusion/expected_fms_order.json
@@ -34,7 +34,7 @@
   "offence_date": "",
   "order_end": "2025-05-10 10:00:00",
   "order_id": "{expectedOderId}",
-  "order_request_type": "",
+  "order_request_type": "New Order",
   "order_start": "2024-11-10 10:00:00",
   "order_type": "Community",
   "order_type_description": null,


### PR DESCRIPTION
Currently, we are not using the `updateDW` endpoint from Serco for variations because we do not link back to an original order and therefore do not know the device wearer id that we want to update.