### PR TITLE
Update the paths used in integrations with Serco

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/client/FmsClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/client/FmsClient.kt
@@ -27,7 +27,7 @@ class FmsClient(
 
   fun createDeviceWearer(deviceWearer: DeviceWearer, orderId: UUID): FmsResponse {
     val token = fmsAuthClient.getClientToken()
-    val result = webClient.post().uri("/device_wearer/createDW")
+    val result = webClient.post().uri("/x_seem_cemo/device_wearer/createDW")
       .header(HttpHeaders.AUTHORIZATION, "Bearer $token")
       .contentType(MediaType.APPLICATION_JSON)
       .bodyValue(deviceWearer)
@@ -49,7 +49,7 @@ class FmsClient(
 
   fun createMonitoringOrder(order: MonitoringOrder, orderId: UUID): FmsResponse {
     val token = fmsAuthClient.getClientToken()
-    val result = webClient.post().uri("/monitoring_order/createMO")
+    val result = webClient.post().uri("/x_seem_cemo/monitoring_order/createMO")
       .header(HttpHeaders.AUTHORIZATION, "Bearer $token")
       .contentType(MediaType.APPLICATION_JSON)
       .bodyValue(order)
@@ -71,7 +71,7 @@ class FmsClient(
 
   fun updateMonitoringOrder(order: MonitoringOrder, orderId: UUID): FmsResponse {
     val token = fmsAuthClient.getClientToken()
-    val result = webClient.post().uri("/monitoring_order/updateMO")
+    val result = webClient.post().uri("/x_seem_cemo/monitoring_order/updateMO")
       .header(HttpHeaders.AUTHORIZATION, "Bearer $token")
       .contentType(MediaType.APPLICATION_JSON)
       .bodyValue(order)
@@ -103,7 +103,7 @@ class FmsClient(
     val result = webClient.post()
       .uri { uriBuilder ->
         uriBuilder
-          .path("/attachment_csm/file")
+          .path("/now/v1/attachment_csm/file")
           .queryParam("table_name", tableName)
           .queryParam("table_sys_id", caseId)
           .queryParam("file_name", fileName)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/wiremock/SercoMockApi.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/wiremock/SercoMockApi.kt
@@ -49,7 +49,7 @@ class SercoMockApiServer : WireMockServer(WIREMOCK_PORT) {
       body = objectMapper.writeValueAsString(result)
     }
     stubFor(
-      post(urlPathTemplate("/device_wearer/createDW"))
+      post(urlPathTemplate("/x_seem_cemo/device_wearer/createDW"))
         .willReturn(
           aResponse()
             .withHeader("Content-Type", "application/json")
@@ -69,7 +69,7 @@ class SercoMockApiServer : WireMockServer(WIREMOCK_PORT) {
       body = objectMapper.writeValueAsString(result)
     }
     stubFor(
-      post(urlPathTemplate("/monitoring_order/createMO"))
+      post(urlPathTemplate("/x_seem_cemo/monitoring_order/createMO"))
         .willReturn(
           aResponse()
             .withHeader("Content-Type", "application/json")
@@ -89,7 +89,7 @@ class SercoMockApiServer : WireMockServer(WIREMOCK_PORT) {
       body = objectMapper.writeValueAsString(result)
     }
     stubFor(
-      post(urlPathTemplate("/monitoring_order/updateMO"))
+      post(urlPathTemplate("/x_seem_cemo/monitoring_order/updateMO"))
         .willReturn(
           aResponse()
             .withHeader("Content-Type", "application/json")
@@ -111,7 +111,7 @@ class SercoMockApiServer : WireMockServer(WIREMOCK_PORT) {
     }
 
     stubFor(
-      post(urlPathTemplate("/attachment_csm/file"))
+      post(urlPathTemplate("/now/v1/attachment_csm/file"))
         .withQueryParam("table_name", equalTo(result.result.tableName))
         .withQueryParam("table_sys_id", equalTo(result.result.tableSysId))
         .withQueryParam("file_name", equalTo(result.result.fileName))


### PR DESCRIPTION
The current serco url secret contains the path `api/x_seem_cemo/`. This change adds the `x_seem_cemo/` to the createDeviceWearer, createMonitoringOrder, updateMonitoringOrder endpoints and adds `now/v1/` to the attachments endpoint so that the secret can be used for all integration endpoints.

The secret has been updated in dev to remove `x_seem_cemo/`