### PR TITLE
Fix problems with mutating the order during submission

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/strategy/FmsOrderSubmissionStrategy.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/strategy/FmsOrderSubmissionStrategy.kt
@@ -80,7 +80,7 @@ class FmsOrderSubmissionStrategy(
   }
 
   private fun createAttachments(order: Order, deviceWearerId: String): List<FmsAttachmentSubmissionResult> {
-    val documents = order.additionalDocuments
+    val documents = order.additionalDocuments.toMutableList()
 
     if (order.enforcementZoneConditions.isNotEmpty()) {
       documents.addAll(


### PR DESCRIPTION
When setting up the cypress tests for CEMO014 which sends enforcement zone documents to the Field Monitoring Service, the resulting order could not be parsed by the front end.

The implementation for sending enforcement zone documents to Serco involved adding the enforcement zone documents to the list of additional documents. This accidentally mutated the order which was then saved creating an order that could not be parsed by the front end. 

This change forces a shallow copy of the `additionalDocuments` rather than using the reference to the existing object, thus solving the mutation problem.