### PR TITLE
Make order type an enum with the correct values

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/MonitoringConditions.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/MonitoringConditions.kt
@@ -10,6 +10,7 @@ import jakarta.persistence.JoinColumn
 import jakarta.persistence.OneToOne
 import jakarta.persistence.Table
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.MonitoringConditionType
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.OrderType
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.OrderTypeDescription
 import java.time.ZonedDateTime
 import java.util.*
@@ -30,8 +31,9 @@ data class MonitoringConditions(
   @Column(name = "END_DATE", nullable = true)
   var endDate: ZonedDateTime? = null,
 
+  @Enumerated(EnumType.STRING)
   @Column(name = "ORDER_TYPE", nullable = true)
-  var orderType: String? = null,
+  var orderType: OrderType? = null,
 
   @Enumerated(EnumType.STRING)
   @Column(name = "ORDER_TYPE_DESCRIPTION", nullable = true)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/Order.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/Order.kt
@@ -12,7 +12,7 @@ import jakarta.persistence.OneToOne
 import jakarta.persistence.Table
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.AddressType
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.OrderStatus
-import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.OrderType
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.RequestType
 import java.util.UUID
 
 @Entity
@@ -32,7 +32,7 @@ data class Order(
 
   @Enumerated(EnumType.STRING)
   @Column(name = "TYPE", nullable = false)
-  var type: OrderType,
+  var type: RequestType,
 
   @Column(name = "FMS_RESULT_ID", nullable = true)
   var fmsResultId: UUID? = null,
@@ -146,7 +146,7 @@ data class Order(
 
   private val isOrderOrHasVariationDetails: Boolean
     get() = (
-      type === OrderType.REQUEST || variationDetails != null
+      type === RequestType.REQUEST || variationDetails != null
       )
 
   private val requiredDocuments: Boolean

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/dto/CreateOrderDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/dto/CreateOrderDto.kt
@@ -1,7 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.dto
 
-import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.OrderType
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.RequestType
 
 data class CreateOrderDto(
-  val type: OrderType = OrderType.REQUEST,
+  val type: RequestType = RequestType.REQUEST,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/dto/UpdateMonitoringConditionsDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/dto/UpdateMonitoringConditionsDto.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.m
 import jakarta.validation.constraints.AssertTrue
 import jakarta.validation.constraints.NotNull
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.MonitoringConditionType
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.OrderType
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.OrderTypeDescription
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.resource.validator.AtLeastOneSelected
 import java.time.ZonedDateTime
@@ -13,7 +14,7 @@ import java.time.ZonedDateTime
 )
 data class UpdateMonitoringConditionsDto(
   @field:NotNull(message = "Order type is required")
-  val orderType: String? = null,
+  val orderType: OrderType? = null,
 
   var curfew: Boolean? = null,
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/enums/OrderType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/enums/OrderType.kt
@@ -1,6 +1,10 @@
 package uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums
 
 enum class OrderType(val value: String) {
-  REQUEST("New Order"),
-  VARIATION("Variation"),
+  CIVIL("Civil"),
+  COMMUNITY("Community"),
+  IMMIGRATION("Immigration"),
+  POST_RELEASE("Post Release"),
+  PRE_TRIAL("Pre-Trial"),
+  SPECIAL("Special"),
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/enums/RequestType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/enums/RequestType.kt
@@ -1,0 +1,6 @@
+package uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums
+
+enum class RequestType(val value: String) {
+  REQUEST("New Order"),
+  VARIATION("Variation"),
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/fms/MonitoringOrder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/fms/MonitoringOrder.kt
@@ -7,7 +7,7 @@ import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.mo
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.AddressType
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.AlcoholMonitoringType
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.EnforcementZoneType
-import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.OrderType
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.RequestType
 import java.time.DayOfWeek
 import java.time.format.DateTimeFormatter
 
@@ -191,7 +191,7 @@ data class MonitoringOrder(
       val conditions = order.monitoringConditions!!
       val monitoringOrder = MonitoringOrder(
         deviceWearer = "${order.deviceWearer!!.firstName} ${order.deviceWearer!!.lastName}",
-        orderType = conditions.orderType,
+        orderType = conditions.orderType!!.value,
         orderRequestType = order.type.value,
         orderTypeDescription = conditions.orderTypeDescription?.value,
         orderStart = conditions.startDate?.format(dateTimeFormatter),
@@ -334,7 +334,7 @@ data class MonitoringOrder(
         monitoringOrder.installationAddressPostcode = it.postcode
       }
 
-      if (order.type === OrderType.VARIATION) {
+      if (order.type === RequestType.VARIATION) {
         monitoringOrder.orderVariationType = order.variationDetails!!.variationType.value
         monitoringOrder.orderVariationDate = order.variationDetails!!.variationDate.format(dateTimeFormatter)
       }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/FmsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/FmsService.kt
@@ -8,7 +8,7 @@ import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.cl
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.client.FmsClient
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.Order
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.FmsOrderSource
-import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.OrderType
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.RequestType
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.fms.FmsSubmissionResult
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.repository.FmsSubmissionResultRepository
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.service.strategy.FmsDummySubmissionStrategy
@@ -32,7 +32,7 @@ class FmsService(
     }
 
     if (orderSource === FmsOrderSource.CEMO && cemoFmsIntegrationEnabled) {
-      if (order.type === OrderType.VARIATION) {
+      if (order.type === RequestType.VARIATION) {
         return FmsVariationSubmissionStrategy(this.objectMapper, this.fmsClient)
       }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/courthearing/HearingEventHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/courthearing/HearingEventHandler.kt
@@ -27,6 +27,7 @@ import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.mo
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.MonitoringConditionType
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.OrderStatus
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.OrderType
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.RequestType
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.service.EventService
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.service.FmsService
 import java.time.LocalDate
@@ -142,7 +143,7 @@ class HearingEventHandler(
           eventService.recordEvent(
             "Common_Platform_Success_Request",
             mapOf(
-              "OrderType" to order.monitoringConditions!!.orderType!!,
+              "OrderType" to order.monitoringConditions!!.orderType!!.value,
               "Start Date And Time" to startDateTime.format(formatter),
             ),
             System.currentTimeMillis() - startTimeInMs,
@@ -173,7 +174,7 @@ class HearingEventHandler(
     val judicialResults = offences.flatMap { it.judicialResults }.toList()
 
     val prompts = judicialResults.flatMap { it.judicialResultPrompts }.toList()
-    val order = Order(username = commentPlatformUsername, status = OrderStatus.IN_PROGRESS, type = OrderType.REQUEST)
+    val order = Order(username = commentPlatformUsername, status = OrderStatus.IN_PROGRESS, type = RequestType.REQUEST)
 
     val monitoringConditions = MonitoringConditions(orderId = order.id)
     val orderedDate = judicialResults.first().orderedDate
@@ -514,17 +515,17 @@ class HearingEventHandler(
     return zone
   }
 
-  private fun getOrderType(results: List<JudicialResults>): String? {
+  private fun getOrderType(results: List<JudicialResults>): OrderType? {
     if (results.any {
         COMMUNITY_ORDER_UUIDS.contains(it.judicialResultTypeId)
       }
     ) {
-      return "Community"
+      return OrderType.COMMUNITY
     } else if (results.any {
         BAIL_CONDITION_UUIDs.contains(it.judicialResultTypeId)
       }
     ) {
-      return "Pre-Trial"
+      return OrderType.PRE_TRIAL
     }
     return null
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/AdditionalDocumentsControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/AdditionalDocumentsControllerTest.kt
@@ -23,7 +23,7 @@ import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.mo
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.documentmanagement.DocumentUploadResponse
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.DocumentType
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.OrderStatus
-import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.OrderType
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.RequestType
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.repository.AdditionalDocumentRepository
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.repository.OrderRepository
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
@@ -39,7 +39,7 @@ class AdditionalDocumentsControllerTest : IntegrationTestBase() {
 
   @SpyBean
   lateinit var apiCLient: DocumentApiClient
-  val order = Order(username = "mockUser", status = OrderStatus.IN_PROGRESS, type = OrderType.REQUEST)
+  val order = Order(username = "mockUser", status = OrderStatus.IN_PROGRESS, type = RequestType.REQUEST)
 
   @Suppress("ktlint:standard:max-line-length")
   private val filePath = "src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/assets/profile.jpeg"

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/EnforcementZoneControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/EnforcementZoneControllerTest.kt
@@ -22,7 +22,7 @@ import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.mo
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.documentmanagement.DocumentUploadResponse
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.EnforcementZoneType
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.OrderStatus
-import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.OrderType
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.RequestType
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.repository.EnforcementZoneRepository
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.repository.OrderRepository
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.resource.validator.ValidationError
@@ -52,7 +52,7 @@ class EnforcementZoneControllerTest : IntegrationTestBase() {
   )
   private val mockPastEndDate = mockPastStartDate.plusDays(1)
   private final val mockUser = "AUTH_ADM"
-  private final val mockOrder = Order(username = mockUser, status = OrderStatus.IN_PROGRESS, type = OrderType.REQUEST)
+  private final val mockOrder = Order(username = mockUser, status = OrderStatus.IN_PROGRESS, type = RequestType.REQUEST)
 
   @BeforeEach
   fun setup() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/MonitoringConditionsControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/MonitoringConditionsControllerTest.kt
@@ -10,6 +10,7 @@ import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.in
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.MonitoringConditions
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.MonitoringConditionType
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.OrderStatus
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.OrderType
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.OrderTypeDescription
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.repository.MonitoringConditionsRepository
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.repository.OrderRepository
@@ -25,7 +26,7 @@ class MonitoringConditionsControllerTest : IntegrationTestBase() {
   @Autowired
   lateinit var orderRepo: OrderRepository
 
-  private val mockOrderType: String = "mockOrderType"
+  private val mockOrderType = OrderType.COMMUNITY
   private val mockOrderTypeDescription = OrderTypeDescription.DAPOL
   private val mockConditionType = MonitoringConditionType.LICENSE_CONDITION_OF_A_CUSTODIAL_ORDER
   private val mockStartDate = ZonedDateTime.now(ZoneId.of("UTC")).plusMonths(1)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/OrderControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/OrderControllerTest.kt
@@ -39,6 +39,7 @@ import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.mo
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.OrderStatus
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.OrderType
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.OrderTypeDescription
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.RequestType
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.SubmissionStatus
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.VariationType
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.fms.FmsAttachmentResponse
@@ -92,7 +93,7 @@ class OrderControllerTest : IntegrationTestBase() {
       assertThat(orders).hasSize(1)
       assertThat(orders[0].username).isEqualTo("AUTH_ADM")
       assertThat(orders[0].status).isEqualTo(OrderStatus.IN_PROGRESS)
-      assertThat(orders[0].type).isEqualTo(OrderType.REQUEST)
+      assertThat(orders[0].type).isEqualTo(RequestType.REQUEST)
       assertThat(orders[0].id).isNotNull()
       assertThat(UUID.fromString(orders[0].id.toString())).isEqualTo(orders[0].id)
     }
@@ -121,7 +122,7 @@ class OrderControllerTest : IntegrationTestBase() {
       assertThat(orders).hasSize(1)
       assertThat(orders[0].username).isEqualTo("AUTH_ADM")
       assertThat(orders[0].status).isEqualTo(OrderStatus.IN_PROGRESS)
-      assertThat(orders[0].type).isEqualTo(OrderType.VARIATION)
+      assertThat(orders[0].type).isEqualTo(RequestType.VARIATION)
       assertThat(orders[0].id).isNotNull()
       assertThat(UUID.fromString(orders[0].id.toString())).isEqualTo(orders[0].id)
     }
@@ -725,7 +726,7 @@ class OrderControllerTest : IntegrationTestBase() {
       	"order_id": "${order.id}",
       	"order_request_type": "New Order",
       	"order_start": "${mockStartDate.format(dateTimeFormatter)}",
-      	"order_type": "community",
+      	"order_type": "Community",
       	"order_type_description": "DAPOL",
       	"order_type_detail": "",
       	"order_variation_date": "",
@@ -1087,7 +1088,7 @@ class OrderControllerTest : IntegrationTestBase() {
       	"order_id": "${order.id}",
       	"order_request_type": "New Order",
       	"order_start": "${mockStartDate.format(dateTimeFormatter)}",
-      	"order_type": "community",
+      	"order_type": "Community",
       	"order_type_description": "DAPOL",
       	"order_type_detail": "",
       	"order_variation_date": "",
@@ -1291,7 +1292,7 @@ class OrderControllerTest : IntegrationTestBase() {
 
     @Test
     fun `It should update order with device wearer id, monitoring id & order status, and return 200 for a variation`() {
-      val order = createAndPersistReadyToSubmitOrder(noFixedAddress = false, orderType = OrderType.VARIATION)
+      val order = createAndPersistReadyToSubmitOrder(noFixedAddress = false, requestType = RequestType.VARIATION)
       sercoAuthApi.stubGrantToken()
 
       sercoApi.stubCreateDeviceWearer(
@@ -1421,7 +1422,7 @@ class OrderControllerTest : IntegrationTestBase() {
       	"order_id": "${order.id}",
       	"order_request_type": "Variation",
       	"order_start": "${mockStartDate.format(dateTimeFormatter)}",
-      	"order_type": "community",
+      	"order_type": "Community",
       	"order_type_description": "DAPOL",
       	"order_type_detail": "",
       	"order_variation_date": "${mockStartDate.format(dateTimeFormatter)}",
@@ -1707,14 +1708,14 @@ class OrderControllerTest : IntegrationTestBase() {
   fun createReadyToSubmitOrder(
     id: UUID = UUID.randomUUID(),
     noFixedAddress: Boolean = false,
-    orderType: OrderType = OrderType.REQUEST,
+    requestType: RequestType = RequestType.REQUEST,
     documents: MutableList<AdditionalDocument> = mutableListOf(),
   ): Order {
     val order = Order(
       id = id,
       username = "AUTH_ADM",
       status = OrderStatus.IN_PROGRESS,
-      type = orderType,
+      type = requestType,
     )
 
     order.deviceWearer = DeviceWearer(
@@ -1808,7 +1809,7 @@ class OrderControllerTest : IntegrationTestBase() {
 
     order.monitoringConditions = MonitoringConditions(
       orderId = order.id,
-      orderType = "community",
+      orderType = OrderType.COMMUNITY,
       orderTypeDescription = OrderTypeDescription.DAPOL,
       startDate = mockStartDate,
       endDate = mockEndDate,
@@ -1910,7 +1911,7 @@ class OrderControllerTest : IntegrationTestBase() {
       notifyingOrganisationEmail = "",
     )
 
-    if (order.type === OrderType.VARIATION) {
+    if (order.type === RequestType.VARIATION) {
       order.variationDetails = VariationDetails(
         orderId = order.id,
         variationType = VariationType.ADDRESS,
@@ -1924,10 +1925,10 @@ class OrderControllerTest : IntegrationTestBase() {
   fun createAndPersistReadyToSubmitOrder(
     id: UUID = UUID.randomUUID(),
     noFixedAddress: Boolean = false,
-    orderType: OrderType = OrderType.REQUEST,
+    requestType: RequestType = RequestType.REQUEST,
     documents: MutableList<AdditionalDocument> = mutableListOf(),
   ): Order {
-    val order = createReadyToSubmitOrder(id, noFixedAddress, orderType, documents)
+    val order = createReadyToSubmitOrder(id, noFixedAddress, requestType, documents)
     repo.save(order)
     return order
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/repository/OrderRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/repository/OrderRepositoryTest.kt
@@ -13,7 +13,7 @@ import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.mo
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.AlcoholMonitoringType
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.DeviceWearerAddressUsage
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.OrderStatus
-import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.OrderType
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.RequestType
 import java.time.LocalDate
 import java.time.LocalTime
 import java.time.ZoneId
@@ -71,7 +71,7 @@ class OrderRepositoryTest {
     id = mockOrderId,
     username = mockUsername,
     status = OrderStatus.IN_PROGRESS,
-    type = OrderType.REQUEST,
+    type = RequestType.REQUEST,
     monitoringConditionsAlcohol = AlcoholMonitoringConditions(
       id = mockAlcoholMonitoringConditionsId,
       orderId = mockOrderId,
@@ -90,7 +90,7 @@ class OrderRepositoryTest {
     id = mockOrderId,
     username = mockUsername,
     status = OrderStatus.IN_PROGRESS,
-    type = OrderType.REQUEST,
+    type = RequestType.REQUEST,
     monitoringConditionsAlcohol = AlcoholMonitoringConditions(
       id = mockAlcoholMonitoringConditionsId,
       orderId = mockOrderId,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/resources/OrderControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/resources/OrderControllerTest.kt
@@ -12,7 +12,7 @@ import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.mo
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.criteria.OrderSearchCriteria
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.dto.CreateOrderDto
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.OrderStatus
-import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.OrderType
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.RequestType
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.resource.OrderController
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.service.OrderService
 import java.util.*
@@ -31,7 +31,7 @@ class OrderControllerTest {
 
   @Test
   fun `Create a new order and return`() {
-    val mockOrder = Order(username = "mockUser", status = OrderStatus.IN_PROGRESS, type = OrderType.REQUEST)
+    val mockOrder = Order(username = "mockUser", status = OrderStatus.IN_PROGRESS, type = RequestType.REQUEST)
     `when`(orderService.createOrder("mockUser", CreateOrderDto())).thenReturn(mockOrder)
     `when`(authentication.name).thenReturn("mockUser")
 
@@ -45,7 +45,7 @@ class OrderControllerTest {
 
   @Test
   fun `Query a single order and return`() {
-    val order = Order(username = "mockUser", status = OrderStatus.IN_PROGRESS, type = OrderType.REQUEST)
+    val order = Order(username = "mockUser", status = OrderStatus.IN_PROGRESS, type = RequestType.REQUEST)
 
     `when`(orderService.getOrder("mockUser", order.id)).thenReturn(order)
     `when`(authentication.name).thenReturn("mockUser")
@@ -57,8 +57,8 @@ class OrderControllerTest {
   @Test
   fun `Query orders for current user and return`() {
     val orders: List<Order> = listOf(
-      Order(username = "mockUser", status = OrderStatus.IN_PROGRESS, type = OrderType.REQUEST),
-      Order(username = "mockUser", status = OrderStatus.IN_PROGRESS, type = OrderType.REQUEST),
+      Order(username = "mockUser", status = OrderStatus.IN_PROGRESS, type = RequestType.REQUEST),
+      Order(username = "mockUser", status = OrderStatus.IN_PROGRESS, type = RequestType.REQUEST),
     )
 
     `when`(orderService.listOrders(OrderSearchCriteria(username = "mockUser"))).thenReturn(orders)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/AdditionalDocumentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/AdditionalDocumentServiceTest.kt
@@ -25,7 +25,7 @@ import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.mo
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.Order
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.DocumentType
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.OrderStatus
-import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.OrderType
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.RequestType
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.repository.AdditionalDocumentRepository
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.repository.OrderRepository
 import java.io.ByteArrayInputStream
@@ -40,7 +40,7 @@ class AdditionalDocumentServiceTest {
   private lateinit var orderRepop: OrderRepository
 
   val username: String = "username"
-  val order = Order(username = username, status = OrderStatus.IN_PROGRESS, type = OrderType.REQUEST)
+  val order = Order(username = username, status = OrderStatus.IN_PROGRESS, type = RequestType.REQUEST)
   val orderId = order.id
   val docType: DocumentType = DocumentType.LICENCE
   val doc: AdditionalDocument = AdditionalDocument(orderId = orderId, fileType = docType)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/AddressServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/AddressServiceTest.kt
@@ -19,7 +19,7 @@ import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.mo
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.AlcoholMonitoringType
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.DeviceWearerAddressUsage
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.OrderStatus
-import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.OrderType
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.RequestType
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.repository.OrderRepository
 import java.time.LocalDate
 import java.time.LocalTime
@@ -91,7 +91,7 @@ class AddressServiceTest {
     id = mockOrderId,
     username = mockUsername,
     status = OrderStatus.IN_PROGRESS,
-    type = OrderType.REQUEST,
+    type = RequestType.REQUEST,
     monitoringConditionsAlcohol = AlcoholMonitoringConditions(
       id = mockAlcoholMonitoringConditionsId,
       orderId = mockOrderId,
@@ -110,7 +110,7 @@ class AddressServiceTest {
     id = mockOrderId,
     username = mockUsername,
     status = OrderStatus.IN_PROGRESS,
-    type = OrderType.REQUEST,
+    type = RequestType.REQUEST,
     monitoringConditionsAlcohol = AlcoholMonitoringConditions(
       id = mockAlcoholMonitoringConditionsId,
       orderId = mockOrderId,
@@ -129,7 +129,7 @@ class AddressServiceTest {
     id = mockOrderId,
     username = mockUsername,
     status = OrderStatus.IN_PROGRESS,
-    type = OrderType.REQUEST,
+    type = RequestType.REQUEST,
     addresses = mutableListOf(),
   )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/MonitoringConditionsAlcoholServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/MonitoringConditionsAlcoholServiceTest.kt
@@ -17,7 +17,7 @@ import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.mo
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.AlcoholMonitoringType
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.DeviceWearerAddressUsage
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.OrderStatus
-import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.OrderType
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.RequestType
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.repository.MonitoringConditionsAlcoholRepository
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.repository.OrderRepository
 import java.time.LocalDate
@@ -97,7 +97,7 @@ class MonitoringConditionsAlcoholServiceTest {
             id = mockOrderId,
             username = mockUsername,
             status = OrderStatus.IN_PROGRESS,
-            type = OrderType.REQUEST,
+            type = RequestType.REQUEST,
             monitoringConditionsAlcohol = AlcoholMonitoringConditions(
               id = mockAlcoholMonitoringConditionsId,
               orderId = mockOrderId,
@@ -148,7 +148,7 @@ class MonitoringConditionsAlcoholServiceTest {
             id = mockOrderId,
             username = mockUsername,
             status = OrderStatus.IN_PROGRESS,
-            type = OrderType.REQUEST,
+            type = RequestType.REQUEST,
             monitoringConditionsAlcohol = AlcoholMonitoringConditions(
               id = mockAlcoholMonitoringConditionsId,
               orderId = mockOrderId,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/OrderServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/OrderServiceTest.kt
@@ -37,6 +37,7 @@ import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.mo
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.OrderStatus
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.OrderType
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.OrderTypeDescription
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.RequestType
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.SubmissionStatus
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.fms.FmsDeviceWearerSubmissionResult
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.fms.FmsMonitoringOrderSubmissionResult
@@ -112,7 +113,7 @@ class OrderServiceTest {
     val order = Order(
       username = "AUTH_ADM",
       status = OrderStatus.IN_PROGRESS,
-      type = OrderType.REQUEST,
+      type = RequestType.REQUEST,
     )
     order.deviceWearer = DeviceWearer(
       orderId = order.id,
@@ -204,7 +205,7 @@ class OrderServiceTest {
     )
     order.monitoringConditions = MonitoringConditions(
       orderId = order.id,
-      orderType = "community",
+      orderType = OrderType.COMMUNITY,
       orderTypeDescription = OrderTypeDescription.DAPOL,
       startDate = mockStartDate,
       endDate = mockEndDate,


### PR DESCRIPTION
- Changed `OrderType` enum-> `RequestType` to reflect it use internally within the system
- Add `OrderType` enum to ensure requests to Serco use the values specified in the JSON mapping spreadsheet