### PR TITLE
Add P-RARR field to monitoring conditions

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/MonitoringConditions.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/MonitoringConditions.kt
@@ -75,6 +75,10 @@ data class MonitoringConditions(
   @Column(name = "HDC", nullable = true)
   var hdc: YesNoUnknown? = null,
 
+  @Enumerated(EnumType.STRING)
+  @Column(name = "PRARR", nullable = true)
+  var prarr: YesNoUnknown? = null,
+
   @Schema(hidden = true)
   @OneToOne
   @JoinColumn(name = "VERSION_ID", updatable = false, insertable = false)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/dto/UpdateMonitoringConditionsDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/dto/UpdateMonitoringConditionsDto.kt
@@ -43,6 +43,8 @@ data class UpdateMonitoringConditionsDto(
   val issp: YesNoUnknown = YesNoUnknown.UNKNOWN,
 
   val hdc: YesNoUnknown = YesNoUnknown.UNKNOWN,
+
+  val prarr: YesNoUnknown = YesNoUnknown.UNKNOWN,
 ) {
   @AssertTrue(message = "End date must be after start date")
   fun isEndDate(): Boolean {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/MonitoringConditionsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/MonitoringConditionsService.kt
@@ -30,6 +30,7 @@ class MonitoringConditionsService : OrderSectionServiceBase() {
       sentenceType = updateRecord.sentenceType,
       issp = updateRecord.issp,
       hdc = updateRecord.hdc,
+      prarr = updateRecord.prarr,
     )
 
     return orderRepo.save(order).monitoringConditions!!

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/MonitoringConditionsControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/MonitoringConditionsControllerTest.kt
@@ -54,6 +54,7 @@ class MonitoringConditionsControllerTest : IntegrationTestBase() {
               "endDate": "$mockEndDate",
               "issp": "YES",
               "hdc": "NO",
+              "prarr": "UNKNOWN",
               "sentenceType": "LIFE_SENTENCE"
             }
           """.trimIndent(),
@@ -83,6 +84,7 @@ class MonitoringConditionsControllerTest : IntegrationTestBase() {
     Assertions.assertThat(updateMonitoringConditions.responseBody?.alcohol).isTrue()
     Assertions.assertThat(updateMonitoringConditions.responseBody?.issp).isEqualTo(YesNoUnknown.YES)
     Assertions.assertThat(updateMonitoringConditions.responseBody?.hdc).isEqualTo(YesNoUnknown.NO)
+    Assertions.assertThat(updateMonitoringConditions.responseBody?.prarr).isEqualTo(YesNoUnknown.UNKNOWN)
     Assertions.assertThat(updateMonitoringConditions.responseBody?.sentenceType).isEqualTo(SentenceType.LIFE_SENTENCE)
   }
 


### PR DESCRIPTION
P-RARR will be added in a future version of the DD(v5) so is not currently mapped to FMS requests. However, we can still start to capture this information from users.