### PR TITLE
Add partial success check for fms submit result

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/fms/FmsSubmissionResult.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/fms/FmsSubmissionResult.kt
@@ -47,13 +47,19 @@ data class FmsSubmissionResult(
 ) {
   val success: Boolean
     get() {
+      return partialSuccess && attachmentSuccess
+    }
+  val attachmentSuccess: Boolean
+    get() {
+      return attachmentResults.all { it.status == SubmissionStatus.SUCCESS }
+    }
+  val partialSuccess: Boolean
+    get() {
       val deviceWearerSuccess = deviceWearerResult.status == SubmissionStatus.SUCCESS
       val monitoringOrderSuccess = monitoringOrderResult.status == SubmissionStatus.SUCCESS
-      val attachmentsSuccess = attachmentResults.all { it.status == SubmissionStatus.SUCCESS }
 
-      return deviceWearerSuccess && monitoringOrderSuccess && attachmentsSuccess
+      return deviceWearerSuccess && monitoringOrderSuccess
     }
-
   val error: String
     get() {
       if (deviceWearerResult.status == SubmissionStatus.FAILURE) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/OrderControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/OrderControllerTest.kt
@@ -631,7 +631,20 @@ class OrderControllerTest : IntegrationTestBase() {
 
     @Test
     fun `It should return an error if submit attachment to serco returned error`() {
-      val order = createAndPersistReadyToSubmitOrder()
+      val orderId = UUID.randomUUID()
+      val versionId = UUID.randomUUID()
+      val order = createAndPersistReadyToSubmitOrder(
+        id = orderId,
+        versionId = versionId,
+        documents = mutableListOf(
+          AdditionalDocument(
+            id = UUID.fromString("550e8400-e29b-41d4-a716-446655440000"),
+            versionId = versionId,
+            fileType = DocumentType.LICENCE,
+            fileName = "mockLicense.jpg",
+          ),
+        ),
+      )
       sercoAuthApi.stubGrantToken()
       sercoApi.stubCreateDeviceWearer(
         HttpStatus.OK,
@@ -649,6 +662,8 @@ class OrderControllerTest : IntegrationTestBase() {
         ),
         FmsErrorResponse(error = FmsErrorResponseDetails("", "Mock Create Attachment Error")),
       )
+
+      documentApi.stubGetDocument(order.additionalDocuments[0].id.toString())
       val result = webTestClient.post()
         .uri("/api/orders/${order.id}/submit")
         .headers(setAuthorisation())


### PR DESCRIPTION
Update API to return additional error message when partially successful creating Serco request( successful create Device Wearer and Monitoring order, but failed to create attachments)