### PR TITLE
Validate risk categories

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/data/ValidationErrors.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/data/ValidationErrors.kt
@@ -65,6 +65,10 @@ object ValidationErrors {
     const val TYPE_REQUIRED: String = "Enforcement Zone type is required"
   }
 
+  object InstallationAndRisk {
+    const val RISK_CATEGORY_VALID: String = "Risk categories must be a valid risk category"
+  }
+
   object MandatoryAttendance {
     const val START_DATE_REQUIRED: String = "Enter date mandatory attendance monitoring starts"
     const val PURPOSE_REQUIRED: String = "Enter what the appointment is for"

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/dto/UpdateInstallationAndRiskDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/dto/UpdateInstallationAndRiskDto.kt
@@ -1,5 +1,9 @@
 package uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.dto
 
+import jakarta.validation.constraints.AssertTrue
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.data.ValidationErrors
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.RiskCategory
+
 data class UpdateInstallationAndRiskDto(
   val offence: String? = "",
 
@@ -10,4 +14,15 @@ data class UpdateInstallationAndRiskDto(
   val mappaLevel: String? = "",
 
   val mappaCaseType: String? = "",
-)
+) {
+  @AssertTrue(message = ValidationErrors.InstallationAndRisk.RISK_CATEGORY_VALID)
+  fun isRiskCategory(): Boolean {
+    if (riskCategory == null) {
+      return true
+    }
+
+    return riskCategory.all {
+      RiskCategory.entries.any { riskCategory -> riskCategory.name == it }
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/enums/RiskCategory.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/enums/RiskCategory.kt
@@ -1,0 +1,4 @@
+package uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums
+
+enum class RiskCategory {
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/enums/RiskCategory.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/enums/RiskCategory.kt
@@ -13,5 +13,5 @@ enum class RiskCategory(val value: String) {
   OTHER_OCCUPANTS("Other occupants who pose a risk to staff"),
   OTHER_RISKS("Other known Risks"),
   HOMOPHOBIC_VIEWS("Is there evidence known to the subject having homophobic views"),
-  UNDER_18("Under 18 living at property")
+  UNDER_18("Under 18 living at property"),
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/enums/RiskCategory.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/enums/RiskCategory.kt
@@ -1,4 +1,18 @@
 package uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums
 
-enum class RiskCategory {
+enum class RiskCategory(val value: String) {
+  THREATS_OF_VIOLENCE("Threats of Violence"),
+  SEXUAL_OFFENCES("Sexual Offences"),
+  RISK_TO_GENDER("Risk to Specific Gender"),
+  RACIAL_ABUSE_OR_THREATS("Racial Abuse or Threats"),
+  HISTORY_OF_SUBSTANCE_ABUSE("History of Substance Abuse"),
+  DIVERSITY_CONCERNS("Diversity Concerns (mental health issues, learning difficulties etc.)"),
+  DANGEROUS_ANIMALS("Dangerous Dogs/Pets at Premises"),
+  IOM("Is the Subject managed through IOM?"),
+  SAFEGUARDING_ISSUE("Safeguarding Issues"),
+  OTHER_OCCUPANTS("Other occupants who pose a risk to staff"),
+  OTHER_RISKS("Other known Risks"),
+  HOMOPHOBIC_VIEWS("Is there evidence known to the subject having homophobic views"),
+  OFFENCE_RISK("Offence Risk"),
+  POSTCODE_RISK("Postcode Risk"),
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/enums/RiskCategory.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/enums/RiskCategory.kt
@@ -13,6 +13,5 @@ enum class RiskCategory(val value: String) {
   OTHER_OCCUPANTS("Other occupants who pose a risk to staff"),
   OTHER_RISKS("Other known Risks"),
   HOMOPHOBIC_VIEWS("Is there evidence known to the subject having homophobic views"),
-  OFFENCE_RISK("Offence Risk"),
-  POSTCODE_RISK("Postcode Risk"),
+  UNDER_18("Under 18 living at property")
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/InstallationAndRiskControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/InstallationAndRiskControllerTest.kt
@@ -3,12 +3,16 @@ package uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.i
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.MediaType
 import org.springframework.web.reactive.function.BodyInserters
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.data.ValidationErrors
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.dto.UpdateInstallationAndRiskDto
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.resource.validator.ValidationError
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 import java.util.*
 
@@ -21,127 +25,186 @@ class InstallationAndRiskControllerTest : IntegrationTestBase() {
     repo.deleteAll()
   }
 
-  @Test
-  fun `Installation and Risk for an order created by a different user are not update-able`() {
-    val order = createOrder()
-    val result = webTestClient.put()
-      .uri("/api/orders/${order.id}/installation-and-risk")
-      .contentType(MediaType.APPLICATION_JSON)
-      .body(
-        BodyInserters.fromValue(
-          mockValidRequestBody(),
+  @Nested
+  @DisplayName("PUT /api/orders/{orderId}/installation-and-risk")
+  inner class UpdateInstallationAndRisk {
+    @Test
+    fun `it should return an error if the order was not created by the user`() {
+      val order = createOrder()
+      val result = webTestClient.put()
+        .uri("/api/orders/${order.id}/installation-and-risk")
+        .contentType(MediaType.APPLICATION_JSON)
+        .body(
+          BodyInserters.fromValue(
+            mockValidRequestBody(),
+          ),
+        )
+        .headers(setAuthorisation("AUTH_ADM_2"))
+        .exchange()
+        .expectStatus()
+        .isNotFound
+        .expectBodyList(ErrorResponse::class.java)
+        .returnResult()
+      val error = result.responseBody!!.first()
+      Assertions.assertThat(
+        error.developerMessage,
+      ).isEqualTo("An editable order with ${order.id} does not exist")
+    }
+
+    @Test
+    fun `it should return not found if the order does not exist`() {
+      webTestClient.put()
+        .uri("/api/orders/${UUID.randomUUID()}/installation-and-risk")
+        .contentType(MediaType.APPLICATION_JSON)
+        .body(
+          BodyInserters.fromValue(
+            mockValidRequestBody(),
+          ),
+        )
+        .headers(setAuthorisation("AUTH_ADM"))
+        .exchange()
+        .expectStatus()
+        .isNotFound
+    }
+
+    @Test
+    fun `it should return an error if the order is in a submitted state`() {
+      val order = createSubmittedOrder()
+      val result = webTestClient.put()
+        .uri("/api/orders/${order.id}/installation-and-risk")
+        .contentType(MediaType.APPLICATION_JSON)
+        .body(
+          BodyInserters.fromValue(
+            mockValidRequestBody(),
+          ),
+        )
+        .headers(setAuthorisation())
+        .exchange()
+        .expectStatus()
+        .isNotFound
+        .expectBodyList(ErrorResponse::class.java)
+        .returnResult()
+
+      val error = result.responseBody!!.first()
+      Assertions.assertThat(
+        error.developerMessage,
+      ).isEqualTo("An editable order with ${order.id} does not exist")
+    }
+
+    @Test
+    fun `it should update installation and risk with valid request body`() {
+      val order = createOrder()
+      val mockRisk = mockValidRequestBody(
+        offence = "MockOffence",
+        riskCategory = arrayOf("SEXUAL_OFFENCES"),
+        riskDetails = "mockRisk",
+        mappaLevel = "mockMappaLevel",
+        mappaCaseType = "mockMappaType",
+      )
+      webTestClient.put()
+        .uri("/api/orders/${order.id}/installation-and-risk")
+        .contentType(MediaType.APPLICATION_JSON)
+        .body(
+          BodyInserters.fromValue(
+            mockRisk,
+          ),
+        )
+        .headers(setAuthorisation())
+        .exchange()
+        .expectStatus()
+        .isOk
+
+      // Get updated order
+      val updatedOrder = getOrder(order.id)
+
+      Assertions.assertThat(updatedOrder.installationAndRisk?.offence).isEqualTo("MockOffence")
+      Assertions.assertThat(updatedOrder.installationAndRisk?.riskCategory?.first()).isEqualTo("SEXUAL_OFFENCES")
+      Assertions.assertThat(updatedOrder.installationAndRisk?.riskDetails).isEqualTo("mockRisk")
+      Assertions.assertThat(updatedOrder.installationAndRisk?.mappaLevel).isEqualTo("mockMappaLevel")
+      Assertions.assertThat(updatedOrder.installationAndRisk?.mappaCaseType).isEqualTo("mockMappaType")
+    }
+
+    @Test
+    fun `it should update installation and risk with default values`() {
+      val order = createOrder()
+      val mockRisk = mockValidRequestBody()
+
+      webTestClient.put()
+        .uri("/api/orders/${order.id}/installation-and-risk")
+        .contentType(MediaType.APPLICATION_JSON)
+        .body(
+          BodyInserters.fromValue(
+            mockRisk,
+          ),
+        )
+        .headers(setAuthorisation())
+        .exchange()
+        .expectStatus()
+        .isOk
+
+      // Get updated order
+      val updatedOrder = getOrder(order.id)
+
+      Assertions.assertThat(updatedOrder.installationAndRisk?.offence).isNull()
+      Assertions.assertThat(updatedOrder.installationAndRisk?.riskCategory).isNull()
+      Assertions.assertThat(updatedOrder.installationAndRisk?.riskDetails).isNull()
+      Assertions.assertThat(updatedOrder.installationAndRisk?.mappaLevel).isNull()
+      Assertions.assertThat(updatedOrder.installationAndRisk?.mappaCaseType).isNull()
+    }
+
+    @Test
+    fun `it should return an error if an invalid risk category is submitted`() {
+      val order = createOrder()
+
+      val result = webTestClient.put()
+        .uri("/api/orders/${order.id}/installation-and-risk")
+        .contentType(MediaType.APPLICATION_JSON)
+        .body(
+          BodyInserters.fromValue(
+            """
+              {
+                "offence": "",
+                "riskCategory": ["INVALID"],
+                "riskDetails": "",
+                "mappaLevel": "",
+                "mappaCaseType": ""
+              }
+            """.trimIndent(),
+          ),
+        )
+        .headers(setAuthorisation())
+        .exchange()
+        .expectStatus()
+        .isBadRequest
+        .expectBodyList(ValidationError::class.java)
+        .returnResult()
+        .responseBody
+
+      Assertions.assertThat(result).isNotNull
+      Assertions.assertThat(result).hasSize(1)
+      Assertions.assertThat(result).contains(
+        ValidationError(
+          "riskCategory",
+          ValidationErrors.InstallationAndRisk.RISK_CATEGORY_VALID,
         ),
       )
-      .headers(setAuthorisation("AUTH_ADM_2"))
-      .exchange()
-      .expectStatus()
-      .isNotFound
-      .expectBodyList(ErrorResponse::class.java)
-      .returnResult()
-    val error = result.responseBody!!.first()
-    Assertions.assertThat(
-      error.developerMessage,
-    ).isEqualTo("An editable order with ${order.id} does not exist")
-  }
+    }
 
-  @Test
-  fun `Installation and Risk for an order already submitted are not update-able`() {
-    val order = createSubmittedOrder()
-    val result = webTestClient.put()
-      .uri("/api/orders/${order.id}/installation-and-risk")
-      .contentType(MediaType.APPLICATION_JSON)
-      .body(
-        BodyInserters.fromValue(
-          mockValidRequestBody(),
-        ),
+    fun mockValidRequestBody(
+      offence: String? = null,
+      riskCategory: Array<String>? = null,
+      riskDetails: String? = null,
+      mappaLevel: String? = null,
+      mappaCaseType: String? = null,
+    ): String {
+      val condition = UpdateInstallationAndRiskDto(
+        offence = offence,
+        riskCategory = riskCategory,
+        riskDetails = riskDetails,
+        mappaLevel = mappaLevel,
+        mappaCaseType = mappaCaseType,
       )
-      .headers(setAuthorisation())
-      .exchange()
-      .expectStatus()
-      .isNotFound
-      .expectBodyList(ErrorResponse::class.java)
-      .returnResult()
-    val error = result.responseBody!!.first()
-    Assertions.assertThat(
-      error.developerMessage,
-    ).isEqualTo("An editable order with ${order.id} does not exist")
-  }
-
-  @Test
-  fun `Should save order with updated installation and risk`() {
-    val order = createOrder()
-    val mockRisk = mockValidRequestBody(
-      offence = "MockOffence",
-      riskCategory = arrayOf("MockCategory"),
-      riskDetails = "mockRisk",
-      mappaLevel = "mockMappaLevel",
-      mappaCaseType = "mockMappaType",
-    )
-    webTestClient.put()
-      .uri("/api/orders/${order.id}/installation-and-risk")
-      .contentType(MediaType.APPLICATION_JSON)
-      .body(
-        BodyInserters.fromValue(
-          mockRisk,
-        ),
-      )
-      .headers(setAuthorisation())
-      .exchange()
-      .expectStatus()
-      .isOk
-
-    // Get updated order
-    val updatedOrder = getOrder(order.id)
-
-    Assertions.assertThat(updatedOrder.installationAndRisk?.offence).isEqualTo("MockOffence")
-    Assertions.assertThat(updatedOrder.installationAndRisk?.riskCategory?.first()).isEqualTo("MockCategory")
-    Assertions.assertThat(updatedOrder.installationAndRisk?.riskDetails).isEqualTo("mockRisk")
-    Assertions.assertThat(updatedOrder.installationAndRisk?.mappaLevel).isEqualTo("mockMappaLevel")
-    Assertions.assertThat(updatedOrder.installationAndRisk?.mappaCaseType).isEqualTo("mockMappaType")
-  }
-
-  @Test
-  fun `Should save order with updated installation and risk will all default value`() {
-    val order = createOrder()
-    val mockRisk = mockValidRequestBody()
-
-    webTestClient.put()
-      .uri("/api/orders/${order.id}/installation-and-risk")
-      .contentType(MediaType.APPLICATION_JSON)
-      .body(
-        BodyInserters.fromValue(
-          mockRisk,
-        ),
-      )
-      .headers(setAuthorisation())
-      .exchange()
-      .expectStatus()
-      .isOk
-
-    // Get updated order
-    val updatedOrder = getOrder(order.id)
-
-    Assertions.assertThat(updatedOrder.installationAndRisk?.offence).isNull()
-    Assertions.assertThat(updatedOrder.installationAndRisk?.riskCategory).isNull()
-    Assertions.assertThat(updatedOrder.installationAndRisk?.riskDetails).isNull()
-    Assertions.assertThat(updatedOrder.installationAndRisk?.mappaLevel).isNull()
-    Assertions.assertThat(updatedOrder.installationAndRisk?.mappaCaseType).isNull()
-  }
-
-  fun mockValidRequestBody(
-    offence: String? = null,
-    riskCategory: Array<String>? = null,
-    riskDetails: String? = null,
-    mappaLevel: String? = null,
-    mappaCaseType: String? = null,
-  ): String {
-    val condition = UpdateInstallationAndRiskDto(
-      offence = offence,
-      riskCategory = riskCategory,
-      riskDetails = riskDetails,
-      mappaLevel = mappaLevel,
-      mappaCaseType = mappaCaseType,
-    )
-    return objectMapper.writeValueAsString(condition)
+      return objectMapper.writeValueAsString(condition)
+    }
   }
 }


### PR DESCRIPTION
- Ensure that we only capture valid risk categories as defined in DDv4.1
- Two options will not be captured by the CEMO API:
  - "Offence Risk"
  - "Postcode Risk"