### PR TITLE
Validate offence

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/data/ValidationErrors.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/data/ValidationErrors.kt
@@ -66,6 +66,7 @@ object ValidationErrors {
   }
 
   object InstallationAndRisk {
+    const val OFFENCE_VALID: String = "Offence must be a valid offence"
     const val RISK_CATEGORY_VALID: String = "Risk categories must be a valid risk category"
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/dto/UpdateInstallationAndRiskDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/dto/UpdateInstallationAndRiskDto.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.m
 
 import jakarta.validation.constraints.AssertTrue
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.data.ValidationErrors
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.Offence
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.RiskCategory
 
 data class UpdateInstallationAndRiskDto(
@@ -15,6 +16,15 @@ data class UpdateInstallationAndRiskDto(
 
   val mappaCaseType: String? = "",
 ) {
+  @AssertTrue(message = ValidationErrors.InstallationAndRisk.OFFENCE_VALID)
+  fun isOffence(): Boolean {
+    if (offence == null) {
+      return true
+    }
+
+    return Offence.entries.any { it.name == offence }
+  }
+
   @AssertTrue(message = ValidationErrors.InstallationAndRisk.RISK_CATEGORY_VALID)
   fun isRiskCategory(): Boolean {
     if (riskCategory == null) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/enums/Offence.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/enums/Offence.kt
@@ -14,4 +14,11 @@ enum class Offence(val value: String) {
   SUMMARY_NON_MOTORING("Summary Non-Motoring"),
   SUMMARY_MOTORING("Summary motoring"),
   OFFENCE_NOT_RECORDED("Offence not recorded"),
+  ;
+
+  companion object {
+    fun from(value: String?): Offence? = Offence.entries.firstOrNull {
+      it.name == value
+    }
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/enums/Offence.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/enums/Offence.kt
@@ -1,0 +1,17 @@
+package uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums
+
+enum class Offence(val value: String) {
+  VIOLENCE_AGAINST_THE_PERSON("Violence against the person"),
+  SEXUAL_OFFENCES("Sexual offences"),
+  ROBBERY("Robbery"),
+  THEFT_OFFENCES("Theft Offences"),
+  CRIMINAL_DAMAGE_AND_ARSON("Criminal damage and arson"),
+  DRUG_OFFENCES("Drug offences"),
+  POSSESSION_OF_WEAPONS("Possession of weapons"),
+  PUBLIC_ORDER_OFFENCES("Public order offences"),
+  MISCELLANEOUS_CRIMES_AGAINST_SOCIETY("Miscellaneous crimes against society"),
+  FRAUD_OFFENCES("Fraud Offences"),
+  SUMMARY_NON_MOTORING("Summary Non-Motoring"),
+  SUMMARY_MOTORING("Summary motoring"),
+  OFFENCE_NOT_RECORDED("Offence not recorded"),
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/fms/MonitoringOrder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/fms/MonitoringOrder.kt
@@ -10,6 +10,7 @@ import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.mo
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.EnforcementZoneType
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.MagistrateCourt
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.NotifyingOrganisation
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.Offence
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.Prison
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.ProbationServiceRegion
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.RequestType
@@ -215,7 +216,7 @@ data class MonitoringOrder(
         conditionType = conditions.conditionType!!.value,
         orderId = order.id.toString(),
         orderStatus = "Not Started",
-        offence = order.installationAndRisk?.offence,
+        offence = getOffence(order),
       )
 
       monitoringOrder.sentenceType = conditions.sentenceType?.value ?: ""
@@ -415,6 +416,9 @@ data class MonitoringOrder(
         ?: YouthJusticeServiceRegions.from(order.interestedParties?.responsibleOrganisationRegion)?.value
         ?: order.interestedParties?.responsibleOrganisationRegion
         ?: ""
+
+    private fun getOffence(order: Order): String? = Offence.from(order.installationAndRisk?.offence)?.value
+      ?: order.installationAndRisk?.offence
   }
 }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/InstallationAndRiskControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/InstallationAndRiskControllerTest.kt
@@ -95,7 +95,7 @@ class InstallationAndRiskControllerTest : IntegrationTestBase() {
     fun `it should update installation and risk with valid request body`() {
       val order = createOrder()
       val mockRisk = mockValidRequestBody(
-        offence = "MockOffence",
+        offence = "VIOLENCE_AGAINST_THE_PERSON",
         riskCategory = arrayOf("SEXUAL_OFFENCES"),
         riskDetails = "mockRisk",
         mappaLevel = "mockMappaLevel",
@@ -117,7 +117,7 @@ class InstallationAndRiskControllerTest : IntegrationTestBase() {
       // Get updated order
       val updatedOrder = getOrder(order.id)
 
-      Assertions.assertThat(updatedOrder.installationAndRisk?.offence).isEqualTo("MockOffence")
+      Assertions.assertThat(updatedOrder.installationAndRisk?.offence).isEqualTo("VIOLENCE_AGAINST_THE_PERSON")
       Assertions.assertThat(updatedOrder.installationAndRisk?.riskCategory?.first()).isEqualTo("SEXUAL_OFFENCES")
       Assertions.assertThat(updatedOrder.installationAndRisk?.riskDetails).isEqualTo("mockRisk")
       Assertions.assertThat(updatedOrder.installationAndRisk?.mappaLevel).isEqualTo("mockMappaLevel")
@@ -153,7 +153,7 @@ class InstallationAndRiskControllerTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `it should return an error if an invalid risk category is submitted`() {
+    fun `it should return an error if an invalid data is submitted`() {
       val order = createOrder()
 
       val result = webTestClient.put()
@@ -163,7 +163,7 @@ class InstallationAndRiskControllerTest : IntegrationTestBase() {
           BodyInserters.fromValue(
             """
               {
-                "offence": "",
+                "offence": "INVALID",
                 "riskCategory": ["INVALID"],
                 "riskDetails": "",
                 "mappaLevel": "",
@@ -181,11 +181,17 @@ class InstallationAndRiskControllerTest : IntegrationTestBase() {
         .responseBody
 
       Assertions.assertThat(result).isNotNull
-      Assertions.assertThat(result).hasSize(1)
+      Assertions.assertThat(result).hasSize(2)
       Assertions.assertThat(result).contains(
         ValidationError(
           "riskCategory",
           ValidationErrors.InstallationAndRisk.RISK_CATEGORY_VALID,
+        ),
+      )
+      Assertions.assertThat(result).contains(
+        ValidationError(
+          "offence",
+          ValidationErrors.InstallationAndRisk.OFFENCE_VALID,
         ),
       )
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/OrderControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/OrderControllerTest.kt
@@ -1952,7 +1952,7 @@ class OrderControllerTest : IntegrationTestBase() {
 
     order.installationAndRisk = InstallationAndRisk(
       versionId = versionId,
-      offence = "Fraud Offences",
+      offence = "FRAUD_OFFENCES",
       riskDetails = "Danger",
       mappaLevel = "MAAPA 1",
       mappaCaseType = "CPPC (Critical Public Protection Case)",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/OrderServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/OrderServiceTest.kt
@@ -216,7 +216,7 @@ class OrderServiceTest {
 
     order.installationAndRisk = InstallationAndRisk(
       versionId = versionId,
-      offence = "Fraud Offences",
+      offence = "FRAUD_OFFENCES",
       riskDetails = "Danger",
       mappaLevel = "MAAPA 1",
       mappaCaseType = "CPPC (Critical Public Protection Case)",


### PR DESCRIPTION
- Ensure that we only capture valid offences as defined in DDv4.1
- Update the mapping of offences when sending to Serco