### PR TITLE
Make sure that offence is optional i.e. an empty string

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/dto/UpdateInstallationAndRiskDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/dto/UpdateInstallationAndRiskDto.kt
@@ -18,7 +18,7 @@ data class UpdateInstallationAndRiskDto(
 ) {
   @AssertTrue(message = ValidationErrors.InstallationAndRisk.OFFENCE_VALID)
   fun isOffence(): Boolean {
-    if (offence == null) {
+    if (offence.isNullOrEmpty()) {
       return true
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/InstallationAndRiskControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/InstallationAndRiskControllerTest.kt
@@ -153,6 +153,36 @@ class InstallationAndRiskControllerTest : IntegrationTestBase() {
     }
 
     @Test
+    fun `it should update installation and risk with offence set to an empty string`() {
+      val order = createOrder()
+      val mockRisk = mockValidRequestBody(
+        offence = "",
+      )
+
+      webTestClient.put()
+        .uri("/api/orders/${order.id}/installation-and-risk")
+        .contentType(MediaType.APPLICATION_JSON)
+        .body(
+          BodyInserters.fromValue(
+            mockRisk,
+          ),
+        )
+        .headers(setAuthorisation())
+        .exchange()
+        .expectStatus()
+        .isOk
+
+      // Get updated order
+      val updatedOrder = getOrder(order.id)
+
+      Assertions.assertThat(updatedOrder.installationAndRisk?.offence).isEqualTo("")
+      Assertions.assertThat(updatedOrder.installationAndRisk?.riskCategory).isNull()
+      Assertions.assertThat(updatedOrder.installationAndRisk?.riskDetails).isNull()
+      Assertions.assertThat(updatedOrder.installationAndRisk?.mappaLevel).isNull()
+      Assertions.assertThat(updatedOrder.installationAndRisk?.mappaCaseType).isNull()
+    }
+
+    @Test
     fun `it should return an error if an invalid data is submitted`() {
       val order = createOrder()
 


### PR DESCRIPTION
#176 accidentally made the offence field mandatory in the UI as it sends an empty string if no option is selected. This ensures that offence is optional.