### PR TITLE
ELM-3431: Prevent identity numbers being overwritten when updating the device wearer

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/DeviceWearerService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/DeviceWearerService.kt
@@ -26,6 +26,11 @@ class DeviceWearerService : OrderSectionServiceBase() {
       disabilities = updateRecord.disabilities,
       language = updateRecord.language,
       interpreterRequired = updateRecord.interpreterRequired,
+      nomisId = order.deviceWearer?.nomisId,
+      deliusId = order.deviceWearer?.deliusId,
+      pncId = order.deviceWearer?.pncId,
+      prisonNumber = order.deviceWearer?.prisonNumber,
+      homeOfficeReferenceNumber = order.deviceWearer?.homeOfficeReferenceNumber,
     )
 
     return orderRepo.save(order).deviceWearer!!

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/DeviceWearerControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/DeviceWearerControllerTest.kt
@@ -2,6 +2,8 @@ package uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.i
 
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
@@ -55,15 +57,18 @@ class DeviceWearerControllerTest : IntegrationTestBase() {
     repo.deleteAll()
   }
 
-  @Test
-  fun `Update device wearer`() {
-    val order = createOrder()
-    val updateDeviceWearer = webTestClient.put()
-      .uri("/api/orders/${order.id}/device-wearer")
-      .contentType(MediaType.APPLICATION_JSON)
-      .body(
-        BodyInserters.fromValue(
-          """
+  @Nested
+  @DisplayName("PUT /api/orders/{orderId}/device-wearer")
+  inner class UpdateDeviceWearer {
+    @Test
+    fun `it should update the device wearer's personal details`() {
+      val order = createOrder()
+      val updateDeviceWearer = webTestClient.put()
+        .uri("/api/orders/${order.id}/device-wearer")
+        .contentType(MediaType.APPLICATION_JSON)
+        .body(
+          BodyInserters.fromValue(
+            """
             {
               "firstName": "$mockFirstName",
               "lastName": "$mockLastName",
@@ -76,38 +81,38 @@ class DeviceWearerControllerTest : IntegrationTestBase() {
               "interpreterRequired": true,
               "language": "$mockLanguage"
             }
-          """.trimIndent(),
-        ),
-      )
-      .headers(setAuthorisation("AUTH_ADM"))
-      .exchange()
-      .expectStatus()
-      .isOk
-      .expectBody(DeviceWearer::class.java)
-      .returnResult()
+            """.trimIndent(),
+          ),
+        )
+        .headers(setAuthorisation("AUTH_ADM"))
+        .exchange()
+        .expectStatus()
+        .isOk
+        .expectBody(DeviceWearer::class.java)
+        .returnResult()
 
-    Assertions.assertThat(updateDeviceWearer.responseBody?.firstName).isEqualTo(mockFirstName)
-    Assertions.assertThat(updateDeviceWearer.responseBody?.lastName).isEqualTo(mockLastName)
-    Assertions.assertThat(updateDeviceWearer.responseBody?.alias).isEqualTo(mockAlias)
-    Assertions.assertThat(
-      updateDeviceWearer.responseBody?.adultAtTimeOfInstallation,
-    ).isEqualTo(false)
-    Assertions.assertThat(updateDeviceWearer.responseBody?.sex).isEqualTo(mockSex)
-    Assertions.assertThat(updateDeviceWearer.responseBody?.gender).isEqualTo(mockGender)
-    Assertions.assertThat(updateDeviceWearer.responseBody?.dateOfBirth).isEqualTo(mockDateOfBirth)
-    Assertions.assertThat(updateDeviceWearer.responseBody?.disabilities).isEqualTo(mockDisabilities)
-    Assertions.assertThat(updateDeviceWearer.responseBody?.interpreterRequired).isEqualTo(true)
-    Assertions.assertThat(updateDeviceWearer.responseBody?.language).isEqualTo(mockLanguage)
-  }
+      Assertions.assertThat(updateDeviceWearer.responseBody?.firstName).isEqualTo(mockFirstName)
+      Assertions.assertThat(updateDeviceWearer.responseBody?.lastName).isEqualTo(mockLastName)
+      Assertions.assertThat(updateDeviceWearer.responseBody?.alias).isEqualTo(mockAlias)
+      Assertions.assertThat(
+        updateDeviceWearer.responseBody?.adultAtTimeOfInstallation,
+      ).isEqualTo(false)
+      Assertions.assertThat(updateDeviceWearer.responseBody?.sex).isEqualTo(mockSex)
+      Assertions.assertThat(updateDeviceWearer.responseBody?.gender).isEqualTo(mockGender)
+      Assertions.assertThat(updateDeviceWearer.responseBody?.dateOfBirth).isEqualTo(mockDateOfBirth)
+      Assertions.assertThat(updateDeviceWearer.responseBody?.disabilities).isEqualTo(mockDisabilities)
+      Assertions.assertThat(updateDeviceWearer.responseBody?.interpreterRequired).isEqualTo(true)
+      Assertions.assertThat(updateDeviceWearer.responseBody?.language).isEqualTo(mockLanguage)
+    }
 
-  @Test
-  fun `Update device wearer returns 404 status if a device wearer can't be found`() {
-    webTestClient.put()
-      .uri("/api/orders/${UUID.randomUUID()}/device-wearer")
-      .contentType(MediaType.APPLICATION_JSON)
-      .body(
-        BodyInserters.fromValue(
-          """
+    @Test
+    fun `it should return not found if the order does not exist`() {
+      webTestClient.put()
+        .uri("/api/orders/${UUID.randomUUID()}/device-wearer")
+        .contentType(MediaType.APPLICATION_JSON)
+        .body(
+          BodyInserters.fromValue(
+            """
             {
               "firstName": "$mockFirstName",
               "lastName": "$mockLastName",
@@ -119,24 +124,24 @@ class DeviceWearerControllerTest : IntegrationTestBase() {
               "interpreterRequired": true,
               "language": "$mockLanguage"
             }
-          """.trimIndent(),
-        ),
-      )
-      .headers(setAuthorisation("AUTH_ADM"))
-      .exchange()
-      .expectStatus()
-      .isNotFound()
-  }
+            """.trimIndent(),
+          ),
+        )
+        .headers(setAuthorisation("AUTH_ADM"))
+        .exchange()
+        .expectStatus()
+        .isNotFound()
+    }
 
-  @Test
-  fun `Update device wearer returns 404 status if the order belongs to another user`() {
-    val order = createOrder()
-    webTestClient.put()
-      .uri("/api/orders/${order.id}/device-wearer")
-      .contentType(MediaType.APPLICATION_JSON)
-      .body(
-        BodyInserters.fromValue(
-          """
+    @Test
+    fun `it should return an error if the order was not created by the user`() {
+      val order = createOrder()
+      webTestClient.put()
+        .uri("/api/orders/${order.id}/device-wearer")
+        .contentType(MediaType.APPLICATION_JSON)
+        .body(
+          BodyInserters.fromValue(
+            """
             {
               "firstName": "$mockFirstName",
               "lastName": "$mockLastName",
@@ -148,24 +153,24 @@ class DeviceWearerControllerTest : IntegrationTestBase() {
               "interpreterRequired": true,
               "language": "$mockLanguage"
             }
-          """.trimIndent(),
-        ),
-      )
-      .headers(setAuthorisation("AUTH_ADM_2"))
-      .exchange()
-      .expectStatus()
-      .isNotFound()
-  }
+            """.trimIndent(),
+          ),
+        )
+        .headers(setAuthorisation("AUTH_ADM_2"))
+        .exchange()
+        .expectStatus()
+        .isNotFound()
+    }
 
-  @Test
-  fun `Update device wearer returns 400 if invalid data`() {
-    val order = createOrder()
-    val result = webTestClient.put()
-      .uri("/api/orders/${order.id}/device-wearer")
-      .contentType(MediaType.APPLICATION_JSON)
-      .body(
-        BodyInserters.fromValue(
-          """
+    @Test
+    fun `it should return an error if an invalid data is submitted`() {
+      val order = createOrder()
+      val result = webTestClient.put()
+        .uri("/api/orders/${order.id}/device-wearer")
+        .contentType(MediaType.APPLICATION_JSON)
+        .body(
+          BodyInserters.fromValue(
+            """
             {
               "firstName": "",
               "lastName": "",
@@ -176,57 +181,57 @@ class DeviceWearerControllerTest : IntegrationTestBase() {
               "dateOfBirth": "",
               "interpreterRequired": ""
             }
-          """.trimIndent(),
+            """.trimIndent(),
+          ),
+        )
+        .headers(setAuthorisation("AUTH_ADM_2"))
+        .exchange()
+        .expectStatus()
+        .isBadRequest
+        .expectBodyList(ValidationError::class.java)
+        .returnResult()
+
+      Assertions.assertThat(result.responseBody).isNotNull
+      Assertions.assertThat(result.responseBody).hasSize(7)
+      Assertions.assertThat(result.responseBody!!).contains(
+        ValidationError("firstName", ErrorMessages.FIRST_NAME_REQUIRED),
+      )
+      Assertions.assertThat(result.responseBody!!).contains(
+        ValidationError("lastName", ErrorMessages.LAST_NAME_REQUIRED),
+      )
+      Assertions.assertThat(result.responseBody!!).contains(
+        ValidationError(
+          "adultAtTimeOfInstallation",
+          ErrorMessages.IS_ADULT_REQUIRED,
         ),
       )
-      .headers(setAuthorisation("AUTH_ADM_2"))
-      .exchange()
-      .expectStatus()
-      .isBadRequest
-      .expectBodyList(ValidationError::class.java)
-      .returnResult()
+      Assertions.assertThat(result.responseBody!!).contains(
+        ValidationError("sex", ErrorMessages.SEX_REQUIRED),
+      )
+      Assertions.assertThat(result.responseBody!!).contains(
+        ValidationError("gender", ErrorMessages.GENDER_REQUIRED),
+      )
+      Assertions.assertThat(result.responseBody!!).contains(
+        ValidationError("dateOfBirth", ErrorMessages.DOB_REQUIRED),
+      )
 
-    Assertions.assertThat(result.responseBody).isNotNull
-    Assertions.assertThat(result.responseBody).hasSize(7)
-    Assertions.assertThat(result.responseBody!!).contains(
-      ValidationError("firstName", ErrorMessages.FIRST_NAME_REQUIRED),
-    )
-    Assertions.assertThat(result.responseBody!!).contains(
-      ValidationError("lastName", ErrorMessages.LAST_NAME_REQUIRED),
-    )
-    Assertions.assertThat(result.responseBody!!).contains(
-      ValidationError(
-        "adultAtTimeOfInstallation",
-        ErrorMessages.IS_ADULT_REQUIRED,
-      ),
-    )
-    Assertions.assertThat(result.responseBody!!).contains(
-      ValidationError("sex", ErrorMessages.SEX_REQUIRED),
-    )
-    Assertions.assertThat(result.responseBody!!).contains(
-      ValidationError("gender", ErrorMessages.GENDER_REQUIRED),
-    )
-    Assertions.assertThat(result.responseBody!!).contains(
-      ValidationError("dateOfBirth", ErrorMessages.DOB_REQUIRED),
-    )
+      Assertions.assertThat(result.responseBody!!).contains(
+        ValidationError(
+          "interpreterRequired",
+          ErrorMessages.INTERPRETER_REQUIRED,
+        ),
+      )
+    }
 
-    Assertions.assertThat(result.responseBody!!).contains(
-      ValidationError(
-        "interpreterRequired",
-        ErrorMessages.INTERPRETER_REQUIRED,
-      ),
-    )
-  }
-
-  @Test
-  fun `Update device wearer returns 400 if dateOfBirth is in the future`() {
-    val order = createOrder()
-    val result = webTestClient.put()
-      .uri("/api/orders/${order.id}/device-wearer")
-      .contentType(MediaType.APPLICATION_JSON)
-      .body(
-        BodyInserters.fromValue(
-          """
+    @Test
+    fun `it should return an error if dateOfBirth is in the future`() {
+      val order = createOrder()
+      val result = webTestClient.put()
+        .uri("/api/orders/${order.id}/device-wearer")
+        .contentType(MediaType.APPLICATION_JSON)
+        .body(
+          BodyInserters.fromValue(
+            """
             {
               "firstName": "$mockFirstName",
               "lastName": "$mockLastName",
@@ -238,32 +243,32 @@ class DeviceWearerControllerTest : IntegrationTestBase() {
               "interpreterRequired": true,
               "language": "$mockLanguage"
             }
-          """.trimIndent(),
-        ),
+            """.trimIndent(),
+          ),
+        )
+        .headers(setAuthorisation("AUTH_ADM_2"))
+        .exchange()
+        .expectStatus()
+        .isBadRequest
+        .expectBodyList(ValidationError::class.java)
+        .returnResult()
+
+      Assertions.assertThat(result.responseBody).isNotNull
+      Assertions.assertThat(result.responseBody).hasSize(1)
+      Assertions.assertThat(result.responseBody!!).contains(
+        ValidationError("dateOfBirth", ErrorMessages.DOB_MUST_BE_IN_PAST),
       )
-      .headers(setAuthorisation("AUTH_ADM_2"))
-      .exchange()
-      .expectStatus()
-      .isBadRequest
-      .expectBodyList(ValidationError::class.java)
-      .returnResult()
+    }
 
-    Assertions.assertThat(result.responseBody).isNotNull
-    Assertions.assertThat(result.responseBody).hasSize(1)
-    Assertions.assertThat(result.responseBody!!).contains(
-      ValidationError("dateOfBirth", ErrorMessages.DOB_MUST_BE_IN_PAST),
-    )
-  }
-
-  @Test
-  fun `Update device wearer returns 400 if language is not set when interpreterRequired is true`() {
-    val order = createOrder()
-    val result = webTestClient.put()
-      .uri("/api/orders/${order.id}/device-wearer")
-      .contentType(MediaType.APPLICATION_JSON)
-      .body(
-        BodyInserters.fromValue(
-          """
+    @Test
+    fun `it should return an error if language is not set when interpreterRequired is true`() {
+      val order = createOrder()
+      val result = webTestClient.put()
+        .uri("/api/orders/${order.id}/device-wearer")
+        .contentType(MediaType.APPLICATION_JSON)
+        .body(
+          BodyInserters.fromValue(
+            """
             {
               "firstName": "$mockFirstName",
               "lastName": "$mockLastName",
@@ -275,170 +280,175 @@ class DeviceWearerControllerTest : IntegrationTestBase() {
               "interpreterRequired": true,
               "language": ""
             }
-          """.trimIndent(),
-        ),
-      )
-      .headers(setAuthorisation("AUTH_ADM"))
-      .exchange()
-      .expectStatus()
-      .isBadRequest
-      .expectBodyList(ValidationError::class.java)
-      .returnResult()
+            """.trimIndent(),
+          ),
+        )
+        .headers(setAuthorisation("AUTH_ADM"))
+        .exchange()
+        .expectStatus()
+        .isBadRequest
+        .expectBodyList(ValidationError::class.java)
+        .returnResult()
 
-    Assertions.assertThat(result.responseBody).isNotNull
-    Assertions.assertThat(result.responseBody).hasSize(1)
-    Assertions.assertThat(result.responseBody!!).contains(
-      ValidationError("language", ErrorMessages.LANGUAGE_REQUIRED),
-    )
+      Assertions.assertThat(result.responseBody).isNotNull
+      Assertions.assertThat(result.responseBody).hasSize(1)
+      Assertions.assertThat(result.responseBody!!).contains(
+        ValidationError("language", ErrorMessages.LANGUAGE_REQUIRED),
+      )
+    }
   }
 
-  @Test
-  fun `NoFixedAbode cannot be updated if the order doesn't exist`() {
-    webTestClient.put()
-      .uri("/api/orders/${UUID.randomUUID()}/device-wearer/no-fixed-abode")
-      .contentType(MediaType.APPLICATION_JSON)
-      .body(
-        BodyInserters.fromValue(
-          """
+  @Nested
+  @DisplayName("PUT /api/orders/{orderId}/device-wearer/no-fixed-abode")
+  inner class UpdateNoFixedAbode {
+    @Test
+    fun `it should return not found if the order does not exist`() {
+      webTestClient.put()
+        .uri("/api/orders/${UUID.randomUUID()}/device-wearer/no-fixed-abode")
+        .contentType(MediaType.APPLICATION_JSON)
+        .body(
+          BodyInserters.fromValue(
+            """
             {
               "noFixedAbode": true
             }
-          """.trimIndent(),
-        ),
-      )
-      .headers(setAuthorisation("AUTH_ADM"))
-      .exchange()
-      .expectStatus()
-      .isNotFound()
-  }
+            """.trimIndent(),
+          ),
+        )
+        .headers(setAuthorisation("AUTH_ADM"))
+        .exchange()
+        .expectStatus()
+        .isNotFound()
+    }
 
-  @Test
-  fun `NoFixedAbode cannot be updated if the order is submitted`() {
-    val order = createSubmittedOrder()
+    @Test
+    fun `it should return an error if the order is in a submitted state`() {
+      val order = createSubmittedOrder()
 
-    webTestClient.put()
-      .uri("/api/orders/${order.id}/device-wearer/no-fixed-abode")
-      .contentType(MediaType.APPLICATION_JSON)
-      .body(
-        BodyInserters.fromValue(
-          """
+      webTestClient.put()
+        .uri("/api/orders/${order.id}/device-wearer/no-fixed-abode")
+        .contentType(MediaType.APPLICATION_JSON)
+        .body(
+          BodyInserters.fromValue(
+            """
             {
               "noFixedAbode": true
             }
-          """.trimIndent(),
-        ),
-      )
-      .headers(setAuthorisation("AUTH_ADM"))
-      .exchange()
-      .expectStatus()
-      .isNotFound()
-  }
+            """.trimIndent(),
+          ),
+        )
+        .headers(setAuthorisation("AUTH_ADM"))
+        .exchange()
+        .expectStatus()
+        .isNotFound()
+    }
 
-  @Test
-  fun `NoFixedAbode cannot be updated if the order belongs to another user`() {
-    val order = createOrder()
-    webTestClient.put()
-      .uri("/api/orders/${order.id}/device-wearer/no-fixed-abode")
-      .contentType(MediaType.APPLICATION_JSON)
-      .body(
-        BodyInserters.fromValue(
-          """
+    @Test
+    fun `it should return an error if the order was not created by the user`() {
+      val order = createOrder()
+      webTestClient.put()
+        .uri("/api/orders/${order.id}/device-wearer/no-fixed-abode")
+        .contentType(MediaType.APPLICATION_JSON)
+        .body(
+          BodyInserters.fromValue(
+            """
             {
               "noFixedAbode": true
             }
-          """.trimIndent(),
-        ),
-      )
-      .headers(setAuthorisation("AUTH_ADM_2"))
-      .exchange()
-      .expectStatus()
-      .isNotFound()
-  }
+            """.trimIndent(),
+          ),
+        )
+        .headers(setAuthorisation("AUTH_ADM_2"))
+        .exchange()
+        .expectStatus()
+        .isNotFound()
+    }
 
-  @ParameterizedTest(name = "NoFixedAbode can be updated with valid string - {0}")
-  @ValueSource(strings = ["true", "false"])
-  fun `NoFixedAbode can be updated with string values`(value: String) {
-    val order = createOrder()
-    val result = webTestClient.put()
-      .uri("/api/orders/${order.id}/device-wearer/no-fixed-abode")
-      .contentType(MediaType.APPLICATION_JSON)
-      .body(
-        BodyInserters.fromValue(
-          """
+    @ParameterizedTest(name = "it should update noFixedAbode with valid string - {0}")
+    @ValueSource(strings = ["true", "false"])
+    fun `it should update noFixedAbode with string values`(value: String) {
+      val order = createOrder()
+      val result = webTestClient.put()
+        .uri("/api/orders/${order.id}/device-wearer/no-fixed-abode")
+        .contentType(MediaType.APPLICATION_JSON)
+        .body(
+          BodyInserters.fromValue(
+            """
             {
               "noFixedAbode": "$value"
             }
-          """.trimIndent(),
-        ),
-      )
-      .headers(setAuthorisation("AUTH_ADM"))
-      .exchange()
-      .expectStatus()
-      .isOk
-      .expectBody(DeviceWearer::class.java)
-      .returnResult()
+            """.trimIndent(),
+          ),
+        )
+        .headers(setAuthorisation("AUTH_ADM"))
+        .exchange()
+        .expectStatus()
+        .isOk
+        .expectBody(DeviceWearer::class.java)
+        .returnResult()
 
-    val deviceWearer = result.responseBody!!
-    Assertions.assertThat(deviceWearer.noFixedAbode).isEqualTo(value.toBoolean())
-  }
+      val deviceWearer = result.responseBody!!
+      Assertions.assertThat(deviceWearer.noFixedAbode).isEqualTo(value.toBoolean())
+    }
 
-  @ParameterizedTest(name = "NoFixedAbode can be updated with valid boolean - {0}")
-  @ValueSource(booleans = [true, false])
-  fun `NoFixedAbode can be updated with boolean values`(value: Boolean) {
-    val order = createOrder()
-    val result = webTestClient.put()
-      .uri("/api/orders/${order.id}/device-wearer/no-fixed-abode")
-      .contentType(MediaType.APPLICATION_JSON)
-      .body(
-        BodyInserters.fromValue(
-          """
+    @ParameterizedTest(name = "it should update noFixedAbode with valid boolean - {0}")
+    @ValueSource(booleans = [true, false])
+    fun `it should update noFixedAbode with boolean values`(value: Boolean) {
+      val order = createOrder()
+      val result = webTestClient.put()
+        .uri("/api/orders/${order.id}/device-wearer/no-fixed-abode")
+        .contentType(MediaType.APPLICATION_JSON)
+        .body(
+          BodyInserters.fromValue(
+            """
             {
               "noFixedAbode": $value
             }
-          """.trimIndent(),
-        ),
-      )
-      .headers(setAuthorisation("AUTH_ADM"))
-      .exchange()
-      .expectStatus()
-      .isOk
-      .expectBody(DeviceWearer::class.java)
-      .returnResult()
+            """.trimIndent(),
+          ),
+        )
+        .headers(setAuthorisation("AUTH_ADM"))
+        .exchange()
+        .expectStatus()
+        .isOk
+        .expectBody(DeviceWearer::class.java)
+        .returnResult()
 
-    val deviceWearer = result.responseBody!!
-    Assertions.assertThat(deviceWearer.noFixedAbode).isEqualTo(value)
-  }
+      val deviceWearer = result.responseBody!!
+      Assertions.assertThat(deviceWearer.noFixedAbode).isEqualTo(value)
+    }
 
-  @Test
-  fun `NoFixedAbode is mandatory`() {
-    val order = createOrder()
-    val result = webTestClient.put()
-      .uri("/api/orders/${order.id}/device-wearer/no-fixed-abode")
-      .contentType(MediaType.APPLICATION_JSON)
-      .body(
-        BodyInserters.fromValue(
-          """
+    @Test
+    fun `it should return an error if an invalid data is submitted`() {
+      val order = createOrder()
+      val result = webTestClient.put()
+        .uri("/api/orders/${order.id}/device-wearer/no-fixed-abode")
+        .contentType(MediaType.APPLICATION_JSON)
+        .body(
+          BodyInserters.fromValue(
+            """
             {
               "noFixedAbode": null
             }
-          """.trimIndent(),
+            """.trimIndent(),
+          ),
+        )
+        .headers(setAuthorisation("AUTH_ADM"))
+        .exchange()
+        .expectStatus()
+        .isBadRequest
+        .expectBodyList(ValidationError::class.java)
+        .returnResult()
+
+      Assertions.assertThat(result.responseBody).isNotNull
+      Assertions.assertThat(result.responseBody).hasSize(1)
+      Assertions.assertThat(result.responseBody!!).contains(
+        ValidationError(
+          "noFixedAbode",
+          ErrorMessages.NO_FIXED_ABODE_REQUIRED,
         ),
       )
-      .headers(setAuthorisation("AUTH_ADM"))
-      .exchange()
-      .expectStatus()
-      .isBadRequest
-      .expectBodyList(ValidationError::class.java)
-      .returnResult()
-
-    Assertions.assertThat(result.responseBody).isNotNull
-    Assertions.assertThat(result.responseBody).hasSize(1)
-    Assertions.assertThat(result.responseBody!!).contains(
-      ValidationError(
-        "noFixedAbode",
-        ErrorMessages.NO_FIXED_ABODE_REQUIRED,
-      ),
-    )
+    }
   }
 
   @Test
@@ -496,14 +506,17 @@ class DeviceWearerControllerTest : IntegrationTestBase() {
     Assertions.assertThat(updatedOrder.responseBody?.isValid).isTrue()
   }
 
-  @Test
-  fun `Identity numbers cannot be updated if the order doesn't exist`() {
-    webTestClient.put()
-      .uri("/api/orders/${UUID.randomUUID()}/device-wearer/identity-numbers")
-      .contentType(MediaType.APPLICATION_JSON)
-      .body(
-        BodyInserters.fromValue(
-          """
+  @Nested
+  @DisplayName("PUT /api/orders/{orderId}/device-wearer/identity-numbers")
+  inner class UpdateIdentityNumbers {
+    @Test
+    fun `it should return not found if the order does not exist`() {
+      webTestClient.put()
+        .uri("/api/orders/${UUID.randomUUID()}/device-wearer/identity-numbers")
+        .contentType(MediaType.APPLICATION_JSON)
+        .body(
+          BodyInserters.fromValue(
+            """
             {
               "nomisId": "$mockNomisId",
               "pncId": "$mockPncId",
@@ -511,25 +524,25 @@ class DeviceWearerControllerTest : IntegrationTestBase() {
               "prisonNumber": "$mockPrisonNumber",
               "homeOfficeReferenceNumber": "$mockHomeOfficeReferenceNumber"
             }
-          """.trimIndent(),
-        ),
-      )
-      .headers(setAuthorisation("AUTH_ADM"))
-      .exchange()
-      .expectStatus()
-      .isNotFound()
-  }
+            """.trimIndent(),
+          ),
+        )
+        .headers(setAuthorisation("AUTH_ADM"))
+        .exchange()
+        .expectStatus()
+        .isNotFound()
+    }
 
-  @Test
-  fun `Identity numbers cannot be updated if the order is submitted`() {
-    val order = createSubmittedOrder()
+    @Test
+    fun `it should return an error if the order is in a submitted state`() {
+      val order = createSubmittedOrder()
 
-    webTestClient.put()
-      .uri("/api/orders/${order.id}/device-wearer/identity-numbers")
-      .contentType(MediaType.APPLICATION_JSON)
-      .body(
-        BodyInserters.fromValue(
-          """
+      webTestClient.put()
+        .uri("/api/orders/${order.id}/device-wearer/identity-numbers")
+        .contentType(MediaType.APPLICATION_JSON)
+        .body(
+          BodyInserters.fromValue(
+            """
             {
               "nomisId": "$mockNomisId",
               "pncId": "$mockPncId",
@@ -537,24 +550,24 @@ class DeviceWearerControllerTest : IntegrationTestBase() {
               "prisonNumber": "$mockPrisonNumber",
               "homeOfficeReferenceNumber": "$mockHomeOfficeReferenceNumber"
             }
-          """.trimIndent(),
-        ),
-      )
-      .headers(setAuthorisation("AUTH_ADM"))
-      .exchange()
-      .expectStatus()
-      .isNotFound()
-  }
+            """.trimIndent(),
+          ),
+        )
+        .headers(setAuthorisation("AUTH_ADM"))
+        .exchange()
+        .expectStatus()
+        .isNotFound()
+    }
 
-  @Test
-  fun `Identity numbers cannot be updated if the order belongs to another user`() {
-    val order = createOrder()
-    webTestClient.put()
-      .uri("/api/orders/${order.id}/device-wearer/identity-numbers")
-      .contentType(MediaType.APPLICATION_JSON)
-      .body(
-        BodyInserters.fromValue(
-          """
+    @Test
+    fun `it should return an error if the order was not created by the user`() {
+      val order = createOrder()
+      webTestClient.put()
+        .uri("/api/orders/${order.id}/device-wearer/identity-numbers")
+        .contentType(MediaType.APPLICATION_JSON)
+        .body(
+          BodyInserters.fromValue(
+            """
             {
               "nomisId": "$mockNomisId",
               "pncId": "$mockPncId",
@@ -562,24 +575,24 @@ class DeviceWearerControllerTest : IntegrationTestBase() {
               "prisonNumber": "$mockPrisonNumber",
               "homeOfficeReferenceNumber": "$mockHomeOfficeReferenceNumber"
             }
-          """.trimIndent(),
-        ),
-      )
-      .headers(setAuthorisation("AUTH_ADM_2"))
-      .exchange()
-      .expectStatus()
-      .isNotFound()
-  }
+            """.trimIndent(),
+          ),
+        )
+        .headers(setAuthorisation("AUTH_ADM_2"))
+        .exchange()
+        .expectStatus()
+        .isNotFound()
+    }
 
-  @Test
-  fun `Identity numbers can be updated`() {
-    val order = createOrder()
-    val result = webTestClient.put()
-      .uri("/api/orders/${order.id}/device-wearer/identity-numbers")
-      .contentType(MediaType.APPLICATION_JSON)
-      .body(
-        BodyInserters.fromValue(
-          """
+    @Test
+    fun `it should update the identity numbers`() {
+      val order = createOrder()
+      val result = webTestClient.put()
+        .uri("/api/orders/${order.id}/device-wearer/identity-numbers")
+        .contentType(MediaType.APPLICATION_JSON)
+        .body(
+          BodyInserters.fromValue(
+            """
             {
               "nomisId": "$mockNomisId",
               "pncId": "$mockPncId",
@@ -587,21 +600,22 @@ class DeviceWearerControllerTest : IntegrationTestBase() {
               "prisonNumber": "$mockPrisonNumber",
               "homeOfficeReferenceNumber": "$mockHomeOfficeReferenceNumber"
             }
-          """.trimIndent(),
-        ),
-      )
-      .headers(setAuthorisation("AUTH_ADM"))
-      .exchange()
-      .expectStatus()
-      .isOk
-      .expectBody(DeviceWearer::class.java)
-      .returnResult()
+            """.trimIndent(),
+          ),
+        )
+        .headers(setAuthorisation("AUTH_ADM"))
+        .exchange()
+        .expectStatus()
+        .isOk
+        .expectBody(DeviceWearer::class.java)
+        .returnResult()
 
-    val deviceWearer = result.responseBody!!
-    Assertions.assertThat(deviceWearer.nomisId).isEqualTo(mockNomisId)
-    Assertions.assertThat(deviceWearer.deliusId).isEqualTo(mockDeliusId)
-    Assertions.assertThat(deviceWearer.pncId).isEqualTo(mockPncId)
-    Assertions.assertThat(deviceWearer.prisonNumber).isEqualTo(mockPrisonNumber)
-    Assertions.assertThat(deviceWearer.homeOfficeReferenceNumber).isEqualTo(mockHomeOfficeReferenceNumber)
+      val deviceWearer = result.responseBody!!
+      Assertions.assertThat(deviceWearer.nomisId).isEqualTo(mockNomisId)
+      Assertions.assertThat(deviceWearer.deliusId).isEqualTo(mockDeliusId)
+      Assertions.assertThat(deviceWearer.pncId).isEqualTo(mockPncId)
+      Assertions.assertThat(deviceWearer.prisonNumber).isEqualTo(mockPrisonNumber)
+      Assertions.assertThat(deviceWearer.homeOfficeReferenceNumber).isEqualTo(mockHomeOfficeReferenceNumber)
+    }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/DeviceWearerControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/DeviceWearerControllerTest.kt
@@ -617,5 +617,71 @@ class DeviceWearerControllerTest : IntegrationTestBase() {
       Assertions.assertThat(deviceWearer.prisonNumber).isEqualTo(mockPrisonNumber)
       Assertions.assertThat(deviceWearer.homeOfficeReferenceNumber).isEqualTo(mockHomeOfficeReferenceNumber)
     }
+
+    @Test
+    fun `it should retain the identity numbers when updating the device wearer's personal details`() {
+      // Set up a new order
+      val order = createOrder()
+
+      // Save some identity numbers
+      webTestClient.put()
+        .uri("/api/orders/${order.id}/device-wearer/identity-numbers")
+        .contentType(MediaType.APPLICATION_JSON)
+        .body(
+          BodyInserters.fromValue(
+            """
+            {
+              "nomisId": "$mockNomisId",
+              "pncId": "$mockPncId",
+              "deliusId": "$mockDeliusId",
+              "prisonNumber": "$mockPrisonNumber",
+              "homeOfficeReferenceNumber": "$mockHomeOfficeReferenceNumber"
+            }
+            """.trimIndent(),
+          ),
+        )
+        .headers(setAuthorisation("AUTH_ADM"))
+        .exchange()
+        .expectStatus()
+        .isOk
+
+      // Update the device wearer's personal details
+      webTestClient.put()
+        .uri("/api/orders/${order.id}/device-wearer")
+        .contentType(MediaType.APPLICATION_JSON)
+        .body(
+          BodyInserters.fromValue(
+            """
+            {
+              "firstName": "$mockFirstName",
+              "lastName": "$mockLastName",
+              "alias": "$mockAlias",
+              "adultAtTimeOfInstallation": "false",
+              "sex": "$mockSex",
+              "gender": "$mockGender",
+              "dateOfBirth": "$mockDateOfBirth",
+              "disabilities": "$mockDisabilities",
+              "interpreterRequired": true,
+              "language": "$mockLanguage"
+            }
+            """.trimIndent(),
+          ),
+        )
+        .headers(setAuthorisation("AUTH_ADM"))
+        .exchange()
+        .expectStatus()
+        .isOk
+
+      // Ensure that the identity numbers have not been overwritten
+      val updatedOrder = getOrder(order.id)
+
+      Assertions.assertThat(updatedOrder.deviceWearer!!.nomisId).isEqualTo(mockNomisId)
+      Assertions.assertThat(updatedOrder.deviceWearer!!.deliusId).isEqualTo(mockDeliusId)
+      Assertions.assertThat(updatedOrder.deviceWearer!!.pncId).isEqualTo(mockPncId)
+      Assertions.assertThat(updatedOrder.deviceWearer!!.prisonNumber).isEqualTo(mockPrisonNumber)
+      Assertions.assertThat(
+        updatedOrder.deviceWearer!!.homeOfficeReferenceNumber,
+      ).isEqualTo(mockHomeOfficeReferenceNumber)
+    }
   }
 }


### PR DESCRIPTION
Bug description in ticket.

- Test added to replicate observed behaviour and prevent regressions