### PR TITLE
Disable modesecurity waf

### DIFF
--- a/helm_deploy/hmpps-electronic-monitoring-create-an-order-api/values.yaml
+++ b/helm_deploy/hmpps-electronic-monitoring-create-an-order-api/values.yaml
@@ -14,7 +14,7 @@ generic-service:
     enabled: true
     host: app-hostname.local # override per environment
     tlsSecretName: hmpps-ems-cemo-ui-cert
-    modsecurity_enabled: true
+    modsecurity_enabled: false
     modsecurity_github_team: "hmpps-electronic-monitoring"
     nginx.ingress.kubernetes.io/server-snippet: |
       server_tokens off;


### PR DESCRIPTION
The default modsecurity policy blocks `PUT` and `DELETE` requests that are used in the API. This is preventing the UI from sending requests.

For future reference the default snippet is here: https://github.com/ministryofjustice/hmpps-helm-charts/blob/9b8a897760449cc2f97b7d6f662c0e77c4e34a8f/charts/generic-service/values.yaml#L69

Other services have faced the same problem and overriden the default snippet: https://github.com/ministryofjustice/hmpps-prisoner-location-api/blob/306c51d780001aeff3b61ec268b78eeab253a861/helm_deploy/hmpps-prisoner-location-api/values.yaml#L23

This requires more thinking time than I have now, so needs to be revisited.