### PR TITLE
Update variations to send requests to updateDW

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/strategy/FmsVariationSubmissionStrategy.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/strategy/FmsVariationSubmissionStrategy.kt
@@ -18,10 +18,9 @@ class FmsVariationSubmissionStrategy(objectMapper: ObjectMapper, val fmsClient: 
   FmsSubmissionStrategyBase(objectMapper) {
 
   private fun submitUpdateDeviceWearerRequest(deviceWearer: DeviceWearer, orderId: UUID): Result<String> = try {
-    // TODO: Should call updateDeviceWearer endpoint, but not currently possible
     Result(
       success = true,
-      data = fmsClient.createDeviceWearer(deviceWearer, orderId).result.first().id,
+      data = fmsClient.updateDeviceWearer(deviceWearer, orderId).result.first().id,
     )
   } catch (e: Exception) {
     Result(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/OrderControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/OrderControllerTest.kt
@@ -1439,7 +1439,7 @@ class OrderControllerTest : IntegrationTestBase() {
       val order = createAndPersistReadyToSubmitOrder(noFixedAddress = false, requestType = RequestType.VARIATION)
       sercoAuthApi.stubGrantToken()
 
-      sercoApi.stubCreateDeviceWearer(
+      sercoApi.stubUpdateDeviceWearer(
         HttpStatus.OK,
         FmsResponse(result = listOf(FmsResult(message = "", id = "MockDeviceWearerId"))),
       )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/wiremock/SercoMockApi.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/wiremock/SercoMockApi.kt
@@ -84,6 +84,26 @@ class SercoMockApiServer : WireMockServer(WIREMOCK_PORT) {
     )
   }
 
+  fun stubUpdateDeviceWearer(status: HttpStatus, result: FmsResponse, errorResponse: FmsErrorResponse? = null) {
+    val body: String
+    if (errorResponse != null) {
+      body = objectMapper.writeValueAsString(errorResponse)
+    } else {
+      body = objectMapper.writeValueAsString(result)
+    }
+    stubFor(
+      post(urlPathTemplate("/x_seem_cemo/device_wearer/updateDW"))
+        .willReturn(
+          aResponse()
+            .withHeader("Content-Type", "application/json")
+            .withBody(
+              body,
+            )
+            .withStatus(status.value()),
+        ),
+    )
+  }
+
   fun stubUpdateMonitoringOrder(status: HttpStatus, result: FmsResponse, errorResponse: FmsErrorResponse? = null) {
     val body: String
     if (errorResponse != null) {


### PR DESCRIPTION
Serco have updated their guidance for creating variations. Any variation to an order should use the updateDW endpoint. This tells Serco that it is a service request to an existing order and will trigger the appropriate operational processes. 

Because the service allows a user to create a variation "from scratch" (i.e. not linked to an order created through the CEMO service), we have concerns that a user could create a variation for an order that does not exist in the CEMO service and also Service Now. Serco have assured us this is not a problem and to send all variations to the updateDW endpoint.