### PR TITLE
Handle 4xx errors when sending requests to Serco

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/client/FmsClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/client/FmsClient.kt
@@ -33,19 +33,7 @@ class FmsClient(
       .bodyValue(deviceWearer)
       .retrieve()
       .onStatus(
-        { t -> t.is5xxServerError },
-        {
-          it.bodyToMono(FmsErrorResponse::class.java).flatMap { error ->
-            Mono.error(
-              CreateSercoEntityException(
-                "Error creating FMS Device Wearer for order: $orderId with error: ${error?.error?.detail}",
-              ),
-            )
-          }
-        },
-      )
-      .onStatus(
-        { t -> t.is4xxClientError },
+        { t -> t.isError },
         {
           it.bodyToMono(FmsErrorResponse::class.java).flatMap { error ->
             Mono.error(
@@ -70,19 +58,7 @@ class FmsClient(
       .bodyValue(order)
       .retrieve()
       .onStatus(
-        { t -> t.is5xxServerError },
-        {
-          it.bodyToMono(FmsErrorResponse::class.java).flatMap { error ->
-            Mono.error(
-              CreateSercoEntityException(
-                "Error creating FMS Monitoring Order for order: $orderId with error: ${error?.error?.detail}",
-              ),
-            )
-          }
-        },
-      )
-      .onStatus(
-        { t -> t.is4xxClientError },
+        { t -> t.isError },
         {
           it.bodyToMono(FmsErrorResponse::class.java).flatMap { error ->
             Mono.error(
@@ -107,19 +83,7 @@ class FmsClient(
       .bodyValue(deviceWearer)
       .retrieve()
       .onStatus(
-        { t -> t.is5xxServerError },
-        {
-          it.bodyToMono(FmsErrorResponse::class.java).flatMap { error ->
-            Mono.error(
-              CreateSercoEntityException(
-                "Error updating FMS Device Wearer for order: $orderId with error: ${error?.error?.detail}",
-              ),
-            )
-          }
-        },
-      )
-      .onStatus(
-        { t -> t.is4xxClientError },
+        { t -> t.isError },
         {
           it.bodyToMono(FmsErrorResponse::class.java).flatMap { error ->
             Mono.error(
@@ -144,19 +108,7 @@ class FmsClient(
       .bodyValue(order)
       .retrieve()
       .onStatus(
-        { t -> t.is5xxServerError },
-        {
-          it.bodyToMono(FmsErrorResponse::class.java).flatMap { error ->
-            Mono.error(
-              CreateSercoEntityException(
-                "Error updating FMS Monitoring Order for order: $orderId with error: ${error?.error?.detail}",
-              ),
-            )
-          }
-        },
-      )
-      .onStatus(
-        { t -> t.is4xxClientError },
+        { t -> t.isError },
         {
           it.bodyToMono(FmsErrorResponse::class.java).flatMap { error ->
             Mono.error(
@@ -196,19 +148,7 @@ class FmsClient(
       .bodyValue(file)
       .retrieve()
       .onStatus(
-        { t -> t.is5xxServerError },
-        {
-          it.bodyToMono(FmsErrorResponse::class.java).flatMap { error ->
-            Mono.error(
-              CreateSercoEntityException(
-                "Error creating $documentType attachment for order: $caseId with error: ${error?.error?.detail}",
-              ),
-            )
-          }
-        },
-      )
-      .onStatus(
-        { t -> t.is4xxClientError },
+        { t -> t.isError },
         {
           it.bodyToMono(FmsErrorResponse::class.java).flatMap { error ->
             Mono.error(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/client/FmsClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/client/FmsClient.kt
@@ -6,10 +6,6 @@ import org.springframework.core.io.InputStreamResource
 import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
 import org.springframework.stereotype.Service
-import org.springframework.web.reactive.function.client.ClientRequest
-import org.springframework.web.reactive.function.client.ClientResponse
-import org.springframework.web.reactive.function.client.ExchangeFilterFunction
-import org.springframework.web.reactive.function.client.ExchangeFunction
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.WebClientResponseException
 import reactor.core.publisher.Mono
@@ -20,10 +16,6 @@ import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.mo
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.fms.FmsResponse
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.fms.MonitoringOrder
 import java.util.*
-import java.util.function.Consumer
-import org.slf4j.LoggerFactory
-
-
 
 @Service
 class FmsClient(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/client/FmsClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/client/FmsClient.kt
@@ -6,6 +6,10 @@ import org.springframework.core.io.InputStreamResource
 import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
 import org.springframework.stereotype.Service
+import org.springframework.web.reactive.function.client.ClientRequest
+import org.springframework.web.reactive.function.client.ClientResponse
+import org.springframework.web.reactive.function.client.ExchangeFilterFunction
+import org.springframework.web.reactive.function.client.ExchangeFunction
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.WebClientResponseException
 import reactor.core.publisher.Mono
@@ -15,7 +19,11 @@ import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.mo
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.fms.FmsErrorResponse
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.fms.FmsResponse
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.fms.MonitoringOrder
-import java.util.UUID
+import java.util.*
+import java.util.function.Consumer
+import org.slf4j.LoggerFactory
+
+
 
 @Service
 class FmsClient(
@@ -32,15 +40,30 @@ class FmsClient(
       .contentType(MediaType.APPLICATION_JSON)
       .bodyValue(deviceWearer)
       .retrieve()
-      .onStatus({ t -> t.is5xxServerError }, {
-        it.bodyToMono(FmsErrorResponse::class.java).flatMap { error ->
-          Mono.error(
-            CreateSercoEntityException(
-              "Error creating FMS Device Wearer for order: $orderId with error: ${error?.error?.detail}",
-            ),
-          )
-        }
-      })
+      .onStatus(
+        { t -> t.is5xxServerError },
+        {
+          it.bodyToMono(FmsErrorResponse::class.java).flatMap { error ->
+            Mono.error(
+              CreateSercoEntityException(
+                "Error creating FMS Device Wearer for order: $orderId with error: ${error?.error?.detail}",
+              ),
+            )
+          }
+        },
+      )
+      .onStatus(
+        { t -> t.is4xxClientError },
+        {
+          it.bodyToMono(FmsErrorResponse::class.java).flatMap { error ->
+            Mono.error(
+              CreateSercoEntityException(
+                "Error creating FMS Device Wearer for order: $orderId with error: ${error?.error?.detail}",
+              ),
+            )
+          }
+        },
+      )
       .bodyToMono(FmsResponse::class.java)
       .onErrorResume(WebClientResponseException::class.java) { Mono.empty() }
       .block()!!
@@ -54,15 +77,30 @@ class FmsClient(
       .contentType(MediaType.APPLICATION_JSON)
       .bodyValue(order)
       .retrieve()
-      .onStatus({ t -> t.is5xxServerError }, {
-        it.bodyToMono(FmsErrorResponse::class.java).flatMap { error ->
-          Mono.error(
-            CreateSercoEntityException(
-              "Error creating FMS Monitoring Order for order: $orderId with error: ${error?.error?.detail}",
-            ),
-          )
-        }
-      })
+      .onStatus(
+        { t -> t.is5xxServerError },
+        {
+          it.bodyToMono(FmsErrorResponse::class.java).flatMap { error ->
+            Mono.error(
+              CreateSercoEntityException(
+                "Error creating FMS Monitoring Order for order: $orderId with error: ${error?.error?.detail}",
+              ),
+            )
+          }
+        },
+      )
+      .onStatus(
+        { t -> t.is4xxClientError },
+        {
+          it.bodyToMono(FmsErrorResponse::class.java).flatMap { error ->
+            Mono.error(
+              CreateSercoEntityException(
+                "Error creating FMS Monitoring Order for order: $orderId with error: ${error?.error?.detail}",
+              ),
+            )
+          }
+        },
+      )
       .bodyToMono(FmsResponse::class.java)
       .onErrorResume(WebClientResponseException::class.java) { Mono.empty() }
       .block()!!
@@ -76,15 +114,30 @@ class FmsClient(
       .contentType(MediaType.APPLICATION_JSON)
       .bodyValue(deviceWearer)
       .retrieve()
-      .onStatus({ t -> t.is5xxServerError }, {
-        it.bodyToMono(FmsErrorResponse::class.java).flatMap { error ->
-          Mono.error(
-            CreateSercoEntityException(
-              "Error updating FMS Device Wearer for order: $orderId with error: ${error?.error?.detail}",
-            ),
-          )
-        }
-      })
+      .onStatus(
+        { t -> t.is5xxServerError },
+        {
+          it.bodyToMono(FmsErrorResponse::class.java).flatMap { error ->
+            Mono.error(
+              CreateSercoEntityException(
+                "Error updating FMS Device Wearer for order: $orderId with error: ${error?.error?.detail}",
+              ),
+            )
+          }
+        },
+      )
+      .onStatus(
+        { t -> t.is4xxClientError },
+        {
+          it.bodyToMono(FmsErrorResponse::class.java).flatMap { error ->
+            Mono.error(
+              CreateSercoEntityException(
+                "Error updating FMS Device Wearer for order: $orderId with error: ${error?.error?.detail}",
+              ),
+            )
+          }
+        },
+      )
       .bodyToMono(FmsResponse::class.java)
       .onErrorResume(WebClientResponseException::class.java) { Mono.empty() }
       .block()!!
@@ -98,15 +151,30 @@ class FmsClient(
       .contentType(MediaType.APPLICATION_JSON)
       .bodyValue(order)
       .retrieve()
-      .onStatus({ t -> t.is5xxServerError }, {
-        it.bodyToMono(FmsErrorResponse::class.java).flatMap { error ->
-          Mono.error(
-            CreateSercoEntityException(
-              "Error updating FMS Monitoring Order for order: $orderId with error: ${error?.error?.detail}",
-            ),
-          )
-        }
-      })
+      .onStatus(
+        { t -> t.is5xxServerError },
+        {
+          it.bodyToMono(FmsErrorResponse::class.java).flatMap { error ->
+            Mono.error(
+              CreateSercoEntityException(
+                "Error updating FMS Monitoring Order for order: $orderId with error: ${error?.error?.detail}",
+              ),
+            )
+          }
+        },
+      )
+      .onStatus(
+        { t -> t.is4xxClientError },
+        {
+          it.bodyToMono(FmsErrorResponse::class.java).flatMap { error ->
+            Mono.error(
+              CreateSercoEntityException(
+                "Error updating FMS Monitoring Order for order: $orderId with error: ${error?.error?.detail}",
+              ),
+            )
+          }
+        },
+      )
       .bodyToMono(FmsResponse::class.java)
       .onErrorResume(WebClientResponseException::class.java) { Mono.empty() }
       .block()!!
@@ -135,15 +203,30 @@ class FmsClient(
       .contentType(MediaType.APPLICATION_OCTET_STREAM) // turns into binary
       .bodyValue(file)
       .retrieve()
-      .onStatus({ t -> t.is5xxServerError }, {
-        it.bodyToMono(FmsErrorResponse::class.java).flatMap { error ->
-          Mono.error(
-            CreateSercoEntityException(
-              "Error creating $documentType attachment for order: $caseId with error: ${error?.error?.detail}",
-            ),
-          )
-        }
-      })
+      .onStatus(
+        { t -> t.is5xxServerError },
+        {
+          it.bodyToMono(FmsErrorResponse::class.java).flatMap { error ->
+            Mono.error(
+              CreateSercoEntityException(
+                "Error creating $documentType attachment for order: $caseId with error: ${error?.error?.detail}",
+              ),
+            )
+          }
+        },
+      )
+      .onStatus(
+        { t -> t.is4xxClientError },
+        {
+          it.bodyToMono(FmsErrorResponse::class.java).flatMap { error ->
+            Mono.error(
+              CreateSercoEntityException(
+                "Error creating $documentType attachment for order: $caseId with error: ${error?.error?.detail}",
+              ),
+            )
+          }
+        },
+      )
       .bodyToMono(FmsAttachmentResponse::class.java)
       .onErrorResume(WebClientResponseException::class.java) { Mono.empty() }
       .block()!!

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/client/FmsClientTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/client/FmsClientTest.kt
@@ -1,0 +1,321 @@
+package uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.client
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.core.io.InputStreamResource
+import org.springframework.http.HttpStatus
+import org.springframework.test.context.ActiveProfiles
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.exception.CreateSercoEntityException
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.integration.wiremock.SercoAuthMockServerExtension.Companion.sercoAuthApi
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.integration.wiremock.SercoMockApiExtension.Companion.sercoApi
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.fms.DeviceWearer
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.fms.ErrorResponse
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.fms.FmsAttachmentResponse
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.fms.FmsAttachmentResult
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.fms.FmsErrorResponse
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.fms.FmsResponse
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.fms.MonitoringOrder
+import java.io.ByteArrayInputStream
+import java.util.*
+
+@ActiveProfiles("test")
+class FmsClientTest : IntegrationTestBase() {
+
+  @Autowired
+  lateinit var fmsClient: FmsClient
+
+  @Nested
+  @DisplayName("POST /api/x_seem_cemo/device_wearer/createDW")
+  inner class CreateDeviceWearer {
+    @Test
+    fun `it should handle 403 responses`() {
+      // Given
+      val orderId = UUID.randomUUID()
+      sercoAuthApi.stubGrantToken()
+      sercoApi.stubCreateDeviceWearer(
+        status = HttpStatus.UNAUTHORIZED,
+        result = FmsResponse(),
+        errorResponse = FmsErrorResponse(
+          error = ErrorResponse(message = "User not authorised", detail = "User is unauthorised"),
+        ),
+      )
+
+      // When
+      val exception = assertThrows<CreateSercoEntityException> {
+        fmsClient.createDeviceWearer(DeviceWearer(), orderId)
+      }
+
+      // Then
+      assertThat(
+        exception.message,
+      ).isEqualTo("Error creating FMS Device Wearer for order: $orderId with error: User is unauthorised")
+    }
+
+    @Test
+    fun `it should handle 500 responses`() {
+      // Given
+      val orderId = UUID.randomUUID()
+      sercoAuthApi.stubGrantToken()
+      sercoApi.stubCreateDeviceWearer(
+        status = HttpStatus.INTERNAL_SERVER_ERROR,
+        result = FmsResponse(),
+        errorResponse = FmsErrorResponse(
+          error = ErrorResponse(message = "An error message", detail = "Error detail"),
+        ),
+      )
+
+      // When
+      val exception = assertThrows<CreateSercoEntityException> {
+        fmsClient.createDeviceWearer(DeviceWearer(), orderId)
+      }
+
+      // Then
+      assertThat(
+        exception.message,
+      ).isEqualTo("Error creating FMS Device Wearer for order: $orderId with error: Error detail")
+    }
+  }
+
+  @Nested
+  @DisplayName("POST /api/x_seem_cemo/monitoring_order/createMO")
+  inner class CreateMonitoringOrder {
+    @Test
+    fun `it should handle 403 responses`() {
+      // Given
+      val orderId = UUID.randomUUID()
+      sercoAuthApi.stubGrantToken()
+      sercoApi.stubCreateMonitoringOrder(
+        status = HttpStatus.UNAUTHORIZED,
+        result = FmsResponse(),
+        errorResponse = FmsErrorResponse(
+          error = ErrorResponse(message = "User not authorised", detail = "User is unauthorised"),
+        ),
+      )
+
+      // When
+      val exception = assertThrows<CreateSercoEntityException> {
+        fmsClient.createMonitoringOrder(MonitoringOrder(), orderId)
+      }
+
+      // Then
+      assertThat(
+        exception.message,
+      ).isEqualTo("Error creating FMS Monitoring Order for order: $orderId with error: User is unauthorised")
+    }
+
+    @Test
+    fun `it should handle 500 responses`() {
+      // Given
+      val orderId = UUID.randomUUID()
+      sercoAuthApi.stubGrantToken()
+      sercoApi.stubCreateMonitoringOrder(
+        status = HttpStatus.INTERNAL_SERVER_ERROR,
+        result = FmsResponse(),
+        errorResponse = FmsErrorResponse(
+          error = ErrorResponse(message = "An error message", detail = "Error detail"),
+        ),
+      )
+
+      // When
+      val exception = assertThrows<CreateSercoEntityException> {
+        fmsClient.createMonitoringOrder(MonitoringOrder(), orderId)
+      }
+
+      // Then
+      assertThat(
+        exception.message,
+      ).isEqualTo("Error creating FMS Monitoring Order for order: $orderId with error: Error detail")
+    }
+  }
+
+  @Nested
+  @DisplayName("POST /api/x_seem_cemo/device_wearer/updateDW")
+  inner class UpdateDeviceWearer {
+    @Test
+    fun `it should handle 403 responses`() {
+      // Given
+      val orderId = UUID.randomUUID()
+      sercoAuthApi.stubGrantToken()
+      sercoApi.stubUpdateDeviceWearer(
+        status = HttpStatus.UNAUTHORIZED,
+        result = FmsResponse(),
+        errorResponse = FmsErrorResponse(
+          error = ErrorResponse(message = "User not authorised", detail = "User is unauthorised"),
+        ),
+      )
+
+      // When
+      val exception = assertThrows<CreateSercoEntityException> {
+        fmsClient.updateDeviceWearer(DeviceWearer(), orderId)
+      }
+
+      // Then
+      assertThat(
+        exception.message,
+      ).isEqualTo("Error updating FMS Device Wearer for order: $orderId with error: User is unauthorised")
+    }
+
+    @Test
+    fun `it should handle 500 responses`() {
+      // Given
+      val orderId = UUID.randomUUID()
+      sercoAuthApi.stubGrantToken()
+      sercoApi.stubUpdateDeviceWearer(
+        status = HttpStatus.INTERNAL_SERVER_ERROR,
+        result = FmsResponse(),
+        errorResponse = FmsErrorResponse(
+          error = ErrorResponse(message = "An error message", detail = "Error detail"),
+        ),
+      )
+
+      // When
+      val exception = assertThrows<CreateSercoEntityException> {
+        fmsClient.updateDeviceWearer(DeviceWearer(), orderId)
+      }
+
+      // Then
+      assertThat(
+        exception.message,
+      ).isEqualTo("Error updating FMS Device Wearer for order: $orderId with error: Error detail")
+    }
+  }
+
+  @Nested
+  @DisplayName("POST /api/x_seem_cemo/monitoring_order/updateMO")
+  inner class UpdateMonitoringOrder {
+    @Test
+    fun `it should handle 403 responses`() {
+      // Given
+      val orderId = UUID.randomUUID()
+      sercoAuthApi.stubGrantToken()
+      sercoApi.stubUpdateMonitoringOrder(
+        status = HttpStatus.UNAUTHORIZED,
+        result = FmsResponse(),
+        errorResponse = FmsErrorResponse(
+          error = ErrorResponse(message = "User not authorised", detail = "User is unauthorised"),
+        ),
+      )
+
+      // When
+      val exception = assertThrows<CreateSercoEntityException> {
+        fmsClient.updateMonitoringOrder(MonitoringOrder(), orderId)
+      }
+
+      // Then
+      assertThat(
+        exception.message,
+      ).isEqualTo("Error updating FMS Monitoring Order for order: $orderId with error: User is unauthorised")
+    }
+
+    @Test
+    fun `it should handle 500 responses`() {
+      // Given
+      val orderId = UUID.randomUUID()
+      sercoAuthApi.stubGrantToken()
+      sercoApi.stubUpdateMonitoringOrder(
+        status = HttpStatus.INTERNAL_SERVER_ERROR,
+        result = FmsResponse(),
+        errorResponse = FmsErrorResponse(
+          error = ErrorResponse(message = "An error message", detail = "Error detail"),
+        ),
+      )
+
+      // When
+      val exception = assertThrows<CreateSercoEntityException> {
+        fmsClient.updateMonitoringOrder(MonitoringOrder(), orderId)
+      }
+
+      // Then
+      assertThat(
+        exception.message,
+      ).isEqualTo("Error updating FMS Monitoring Order for order: $orderId with error: Error detail")
+    }
+  }
+
+  @Nested
+  @DisplayName("POST /api/now/v1/attachment_csm/file")
+  inner class CreateAttachment {
+    @Test
+    fun `it should handle 403 responses`() {
+      // Given
+      val documentType = "image"
+      val caseId = "123456789"
+      val fileName = "profile.jpeg"
+      sercoAuthApi.stubGrantToken()
+      sercoApi.stubSubmitAttachment(
+        status = HttpStatus.UNAUTHORIZED,
+        result = FmsAttachmentResponse(
+          FmsAttachmentResult(
+            tableName = "x_serg2_ems_csm_sr_mo_new",
+            tableSysId = caseId,
+            fileName = fileName,
+          ),
+        ),
+        errorResponse = FmsErrorResponse(
+          error = ErrorResponse(message = "User not authorised", detail = "User is unauthorised"),
+        ),
+      )
+
+      // When
+      val exception = assertThrows<CreateSercoEntityException> {
+        fmsClient.createAttachment(
+          fileName = fileName,
+          caseId = caseId,
+          file = InputStreamResource(
+            ByteArrayInputStream("".toByteArray()),
+          ),
+          documentType = documentType,
+        )
+      }
+
+      // Then
+      assertThat(
+        exception.message,
+      ).isEqualTo("Error creating $documentType attachment for order: $caseId with error: User is unauthorised")
+    }
+
+    @Test
+    fun `it should handle 500 responses`() {
+      // Given
+      val documentType = "image"
+      val caseId = "123456789"
+      val fileName = "profile.jpeg"
+      sercoAuthApi.stubGrantToken()
+      sercoApi.stubSubmitAttachment(
+        status = HttpStatus.INTERNAL_SERVER_ERROR,
+        result = FmsAttachmentResponse(
+          FmsAttachmentResult(
+            tableName = "x_serg2_ems_csm_sr_mo_new",
+            tableSysId = caseId,
+            fileName = fileName,
+          ),
+        ),
+        errorResponse = FmsErrorResponse(
+          error = ErrorResponse(message = "An error message", detail = "Error detail"),
+        ),
+      )
+
+      // When
+      val exception = assertThrows<CreateSercoEntityException> {
+        fmsClient.createAttachment(
+          fileName = fileName,
+          caseId = caseId,
+          file = InputStreamResource(
+            ByteArrayInputStream("".toByteArray()),
+          ),
+          documentType = documentType,
+        )
+      }
+
+      // Then
+      assertThat(
+        exception.message,
+      ).isEqualTo("Error creating $documentType attachment for order: $caseId with error: Error detail")
+    }
+  }
+}


### PR DESCRIPTION
Based on observations from integration testing with Serco, the ServiceNow api returns errors with bodies that look like:

```json
{
  "error": {
    "message": "",
    "detail": ""
  },
  "status": ""
}
```

Its very likely that not all errors will look the same, i.e. a 503 is likely to have a different body from a 500. We don't have examples of all responses at the moment so handling everything the same. Tests added for the two error responses we have observed (403/500). 