### PR TITLE
Map attendance in monitoring order requests to Serco

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/fms/MonitoringOrder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/fms/MonitoringOrder.kt
@@ -295,10 +295,15 @@ data class MonitoringOrder(
         monitoringOrder.trailMonitoring = "No"
       }
 
-      // TODO: wait for confirmation if mandatory attendance is required
       if (conditions.mandatoryAttendance != null && conditions.mandatoryAttendance!!) {
+        monitoringOrder.enforceableCondition!!.add(
+          EnforceableCondition(
+            "Attendance Monitoring",
+            startDate = conditions.startDate?.format(dateTimeFormatter) ?: "",
+            endDate = conditions.endDate?.format(dateTimeFormatter) ?: "",
+          ),
+        )
         monitoringOrder.inclusionZones.addAll(getInclusionZones(order))
-//        mo.enforceableCondition!!.add(EnforceableCondition("Attendance requirement"))
       }
 
       if (conditions.alcohol != null && conditions.alcohol!!) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/fms/MonitoringOrder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/fms/MonitoringOrder.kt
@@ -19,6 +19,8 @@ import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.mo
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.YouthJusticeServiceRegions
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.fms.formatters.PhoneNumberFormatter
 import java.time.DayOfWeek
+import java.time.LocalDateTime
+import java.time.LocalTime
 import java.time.format.DateTimeFormatter
 
 data class MonitoringOrder(
@@ -294,9 +296,10 @@ data class MonitoringOrder(
       }
 
       // TODO: wait for confirmation if mandatory attendance is required
-//      if(conditions.mandatoryAttendance!=null && conditions.mandatoryAttendance!!){
+      if (conditions.mandatoryAttendance != null && conditions.mandatoryAttendance!!) {
+        monitoringOrder.inclusionZones.addAll(getInclusionZones(order))
 //        mo.enforceableCondition!!.add(EnforceableCondition("Attendance requirement"))
-//      }
+      }
 
       if (conditions.alcohol != null && conditions.alcohol!!) {
         val condition = order.monitoringConditionsAlcohol!!
@@ -437,6 +440,28 @@ data class MonitoringOrder(
 
       return PhoneNumberFormatter.formatAsInternationalDirectDialingNumber(
         order.interestedParties!!.responsibleOrganisationPhoneNumber!!,
+      )
+    }
+
+    private fun getInclusionZones(order: Order): List<Zone> = order.mandatoryAttendanceConditions.map {
+      Zone(
+        description = it.purpose + "\n" +
+          it.appointmentDay + "\n" +
+          it.addressLine1 + "\n" +
+          it.addressLine2 + "\n" +
+          it.addressLine3 + "\n" +
+          it.addressLine4 + "\n" +
+          it.postcode + "\n",
+        duration = "",
+        start =
+        LocalDateTime.of(
+          it.startDate,
+          LocalTime.parse(it.startTime ?: ""),
+        ).format(dateTimeFormatter),
+        end = LocalDateTime.of(
+          it.endDate,
+          LocalTime.parse(it.endTime ?: ""),
+        ).format(dateTimeFormatter),
       )
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/model/fms/DeviceWearerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/model/fms/DeviceWearerTest.kt
@@ -5,22 +5,10 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import org.springframework.test.context.ActiveProfiles
-import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.Address
-import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.DeviceWearer
-import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.InstallationAndRisk
-import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.Order
-import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.OrderVersion
-import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.ResponsibleAdult
-import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.AddressType
-import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.OrderStatus
-import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.RequestType
-import java.time.ZoneId
-import java.time.ZonedDateTime
-import java.util.*
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.fms.DeviceWearer as FmsDeviceWearer
 
 @ActiveProfiles("test")
-class DeviceWearerTest {
+class DeviceWearerTest : FmsTestBase() {
 
   @ParameterizedTest(name = "it should map saved sex values to Serco - {0} -> {1}")
   @MethodSource("sexValues")
@@ -62,110 +50,4 @@ class DeviceWearerTest {
       Arguments.of("NOT_ABLE_TO_PROVIDE_THIS_INFORMATION", ""),
     )
   }
-
-  private fun createOrder(
-    deviceWearer: DeviceWearer = createDeviceWearer(),
-    addresses: List<Address> = listOf(createAddress()),
-    responsibleAdult: ResponsibleAdult? = null,
-    installationAndRisk: InstallationAndRisk = createInstallationAndRisk(),
-  ): Order {
-    val orderId = UUID.randomUUID()
-    val versionId = UUID.randomUUID()
-    val order = Order(
-      id = UUID.randomUUID(),
-      versions = mutableListOf(
-        OrderVersion(
-          id = versionId,
-          username = "",
-          status = OrderStatus.IN_PROGRESS,
-          type = RequestType.REQUEST,
-          orderId = orderId,
-        ),
-      ),
-    )
-
-    order.deviceWearer = deviceWearer
-    order.addresses.addAll(addresses)
-    order.installationAndRisk = installationAndRisk
-
-    if (responsibleAdult != null) {
-      order.deviceWearerResponsibleAdult = responsibleAdult
-    }
-
-    return order
-  }
-
-  private fun createDeviceWearer(
-    firstName: String = "John",
-    lastName: String = "Smith",
-    alias: String = "Johnny",
-    dateOfBirth: ZonedDateTime = ZonedDateTime.of(1990, 1, 1, 1, 1, 1, 1, ZoneId.systemDefault()),
-    adultAtTimeOfInstallation: Boolean = true,
-    sex: String = "MALE",
-    gender: String = "Male",
-    disabilities: String = "VISION,LEARNING_UNDERSTANDING_CONCENTRATING",
-    interpreterRequired: Boolean = true,
-    language: String = "British Sign",
-    pncId: String = "pncId",
-    deliusId: String = "deliusId",
-    nomisId: String = "nomisId",
-    prisonNumber: String = "prisonNumber",
-    homeOfficeReferenceNumber: String = "homeOfficeReferenceNumber",
-    noFixedAbode: Boolean = false,
-  ): DeviceWearer = DeviceWearer(
-    versionId = UUID.randomUUID(),
-    firstName = firstName,
-    lastName = lastName,
-    alias = alias,
-    dateOfBirth = dateOfBirth,
-    adultAtTimeOfInstallation = adultAtTimeOfInstallation,
-    sex = sex,
-    gender = gender,
-    disabilities = disabilities,
-    interpreterRequired = interpreterRequired,
-    language = language,
-    pncId = pncId,
-    deliusId = deliusId,
-    nomisId = nomisId,
-    prisonNumber = prisonNumber,
-    homeOfficeReferenceNumber = homeOfficeReferenceNumber,
-    noFixedAbode = noFixedAbode,
-  )
-
-  private fun createAddress(
-    addressLine1: String = "Line 1",
-    addressLine2: String = "Line 2",
-    addressLine3: String = "",
-    addressLine4: String = "",
-    postcode: String = "AB11 1CD",
-    addressType: AddressType = AddressType.PRIMARY,
-  ) = Address(
-    versionId = UUID.randomUUID(),
-    addressLine1 = addressLine1,
-    addressLine2 = addressLine2,
-    addressLine3 = addressLine3,
-    addressLine4 = addressLine4,
-    postcode = postcode,
-    addressType = addressType,
-  )
-
-  private fun createResponsibleAdult(fullName: String = "Mark Smith", contactNumber: String = "+447401111111") =
-    ResponsibleAdult(
-      versionId = UUID.randomUUID(),
-      fullName = fullName,
-      contactNumber = contactNumber,
-    )
-
-  private fun createInstallationAndRisk(
-    offence: String = "FRAUD_OFFENCES",
-    riskDetails: String = "Danger",
-    mappaLevel: String = "MAAPA 1",
-    mappaCaseType: String = "CPPC (Critical Public Protection Case)",
-  ) = InstallationAndRisk(
-    versionId = UUID.randomUUID(),
-    offence = offence,
-    riskDetails = riskDetails,
-    mappaLevel = mappaLevel,
-    mappaCaseType = mappaCaseType,
-  )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/model/fms/FmsTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/model/fms/FmsTestBase.kt
@@ -1,0 +1,200 @@
+package uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.model.fms
+
+import org.springframework.test.context.ActiveProfiles
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.Address
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.DeviceWearer
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.InstallationAndRisk
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.MandatoryAttendanceConditions
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.MonitoringConditions
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.Order
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.OrderVersion
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.ResponsibleAdult
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.AddressType
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.MonitoringConditionType
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.OrderStatus
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.OrderType
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.OrderTypeDescription
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.RequestType
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.SentenceType
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.YesNoUnknown
+import java.time.LocalDate
+import java.time.ZoneId
+import java.time.ZonedDateTime
+import java.util.*
+
+@ActiveProfiles("test")
+abstract class FmsTestBase {
+  protected fun createOrder(
+    deviceWearer: DeviceWearer = createDeviceWearer(),
+    addresses: List<Address> = listOf(createAddress()),
+    responsibleAdult: ResponsibleAdult? = null,
+    installationAndRisk: InstallationAndRisk = createInstallationAndRisk(),
+    monitoringConditions: MonitoringConditions = createMonitoringConditions(),
+    mandatoryAttendanceConditions: List<MandatoryAttendanceConditions> = listOf(),
+  ): Order {
+    val orderId = UUID.randomUUID()
+    val versionId = UUID.randomUUID()
+    val order = Order(
+      id = UUID.randomUUID(),
+      versions = mutableListOf(
+        OrderVersion(
+          id = versionId,
+          username = "",
+          status = OrderStatus.IN_PROGRESS,
+          type = RequestType.REQUEST,
+          orderId = orderId,
+        ),
+      ),
+    )
+
+    order.deviceWearer = deviceWearer
+    order.addresses.addAll(addresses)
+    order.installationAndRisk = installationAndRisk
+    order.monitoringConditions = monitoringConditions
+    order.mandatoryAttendanceConditions.addAll(mandatoryAttendanceConditions)
+
+    if (responsibleAdult != null) {
+      order.deviceWearerResponsibleAdult = responsibleAdult
+    }
+
+    if (mandatoryAttendanceConditions.isNotEmpty()) {
+      order.monitoringConditions?.mandatoryAttendance = true
+    }
+
+    return order
+  }
+
+  protected fun createDeviceWearer(
+    firstName: String = "John",
+    lastName: String = "Smith",
+    alias: String = "Johnny",
+    dateOfBirth: ZonedDateTime = ZonedDateTime.of(1990, 1, 1, 1, 1, 1, 1, ZoneId.systemDefault()),
+    adultAtTimeOfInstallation: Boolean = true,
+    sex: String = "MALE",
+    gender: String = "Male",
+    disabilities: String = "VISION,LEARNING_UNDERSTANDING_CONCENTRATING",
+    interpreterRequired: Boolean = true,
+    language: String = "British Sign",
+    pncId: String = "pncId",
+    deliusId: String = "deliusId",
+    nomisId: String = "nomisId",
+    prisonNumber: String = "prisonNumber",
+    homeOfficeReferenceNumber: String = "homeOfficeReferenceNumber",
+    noFixedAbode: Boolean = false,
+  ): DeviceWearer = DeviceWearer(
+    versionId = UUID.randomUUID(),
+    firstName = firstName,
+    lastName = lastName,
+    alias = alias,
+    dateOfBirth = dateOfBirth,
+    adultAtTimeOfInstallation = adultAtTimeOfInstallation,
+    sex = sex,
+    gender = gender,
+    disabilities = disabilities,
+    interpreterRequired = interpreterRequired,
+    language = language,
+    pncId = pncId,
+    deliusId = deliusId,
+    nomisId = nomisId,
+    prisonNumber = prisonNumber,
+    homeOfficeReferenceNumber = homeOfficeReferenceNumber,
+    noFixedAbode = noFixedAbode,
+  )
+
+  protected fun createAddress(
+    addressLine1: String = "Line 1",
+    addressLine2: String = "Line 2",
+    addressLine3: String = "",
+    addressLine4: String = "",
+    postcode: String = "AB11 1CD",
+    addressType: AddressType = AddressType.PRIMARY,
+  ) = Address(
+    versionId = UUID.randomUUID(),
+    addressLine1 = addressLine1,
+    addressLine2 = addressLine2,
+    addressLine3 = addressLine3,
+    addressLine4 = addressLine4,
+    postcode = postcode,
+    addressType = addressType,
+  )
+
+  protected fun createResponsibleAdult(fullName: String = "Mark Smith", contactNumber: String = "+447401111111") =
+    ResponsibleAdult(
+      versionId = UUID.randomUUID(),
+      fullName = fullName,
+      contactNumber = contactNumber,
+    )
+
+  protected fun createInstallationAndRisk(
+    offence: String = "FRAUD_OFFENCES",
+    riskDetails: String = "Danger",
+    mappaLevel: String = "MAAPA 1",
+    mappaCaseType: String = "CPPC (Critical Public Protection Case)",
+  ) = InstallationAndRisk(
+    versionId = UUID.randomUUID(),
+    offence = offence,
+    riskDetails = riskDetails,
+    mappaLevel = mappaLevel,
+    mappaCaseType = mappaCaseType,
+  )
+
+  protected fun createMonitoringConditions(
+    orderType: OrderType = OrderType.POST_RELEASE,
+    issp: YesNoUnknown = YesNoUnknown.YES,
+    hdc: YesNoUnknown = YesNoUnknown.YES,
+    prarr: YesNoUnknown = YesNoUnknown.YES,
+    startDate: ZonedDateTime = ZonedDateTime.of(2025, 1, 1, 1, 1, 1, 1, ZoneId.of("UTC")),
+    endDate: ZonedDateTime = ZonedDateTime.of(2025, 2, 1, 1, 1, 1, 1, ZoneId.of("UTC")),
+    sentenceType: SentenceType = SentenceType.LIFE_SENTENCE,
+    conditionType: MonitoringConditionType = MonitoringConditionType.BAIL_ORDER,
+    orderTypeDescription: OrderTypeDescription = OrderTypeDescription.DAPO,
+    trail: Boolean = false,
+    curfew: Boolean = false,
+    alcohol: Boolean = false,
+    mandatoryAttendance: Boolean = false,
+    exclusionZone: Boolean = false,
+  ): MonitoringConditions = MonitoringConditions(
+    versionId = UUID.randomUUID(),
+    orderType = orderType,
+    issp = issp,
+    hdc = hdc,
+    prarr = prarr,
+    startDate = startDate,
+    endDate = endDate,
+    sentenceType = sentenceType,
+    conditionType = conditionType,
+    orderTypeDescription = orderTypeDescription,
+    trail = trail,
+    curfew = curfew,
+    alcohol = alcohol,
+    mandatoryAttendance = mandatoryAttendance,
+    exclusionZone = exclusionZone,
+  )
+
+  protected fun createMandatoryAttendanceCondition(
+    endDate: LocalDate = LocalDate.of(2025, 1, 1),
+    startDate: LocalDate = LocalDate.of(2025, 2, 1),
+    postcode: String = "AB11 1CD",
+    addressLine1: String = "Line 1",
+    addressLine2: String = "Line 2",
+    addressLine3: String = "",
+    addressLine4: String = "",
+    endTime: String = "13:00",
+    purpose: String = "The appointment purpose",
+    appointmentDay: String = "Monday",
+    startTime: String = "12:00",
+  ): MandatoryAttendanceConditions = MandatoryAttendanceConditions(
+    versionId = UUID.randomUUID(),
+    endDate = endDate,
+    startDate = startDate,
+    postcode = postcode,
+    addressLine1 = addressLine1,
+    addressLine2 = addressLine2,
+    addressLine3 = addressLine3,
+    addressLine4 = addressLine4,
+    endTime = endTime,
+    purpose = purpose,
+    appointmentDay = appointmentDay,
+    startTime = startTime,
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/model/fms/FmsTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/model/fms/FmsTestBase.kt
@@ -172,8 +172,8 @@ abstract class FmsTestBase {
   )
 
   protected fun createMandatoryAttendanceCondition(
-    endDate: LocalDate = LocalDate.of(2025, 1, 1),
-    startDate: LocalDate = LocalDate.of(2025, 2, 1),
+    endDate: LocalDate = LocalDate.of(2025, 2, 1),
+    startDate: LocalDate = LocalDate.of(2025, 1, 1),
     postcode: String = "AB11 1CD",
     addressLine1: String = "Line 1",
     addressLine2: String = "Line 2",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/model/fms/MonitoringOrderTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/model/fms/MonitoringOrderTest.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.m
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.test.context.ActiveProfiles
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.fms.EnforceableCondition
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.fms.MonitoringOrder
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.fms.Zone
 
@@ -32,6 +33,13 @@ class MonitoringOrderTest : FmsTestBase() {
           start = "2025-01-01 12:00:00",
           end = "2025-02-01 13:00:00",
         ),
+      ),
+    )
+    assertThat(fmsMonitoringOrder.enforceableCondition).contains(
+      EnforceableCondition(
+        condition = "Attendance Monitoring",
+        startDate = "2025-01-01 01:01:01",
+        endDate = "2025-02-01 01:01:01",
       ),
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/model/fms/MonitoringOrderTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/model/fms/MonitoringOrderTest.kt
@@ -21,18 +21,13 @@ class MonitoringOrderTest : FmsTestBase() {
     assertThat(fmsMonitoringOrder.inclusionZones).isEqualTo(
       listOf(
         Zone(
-          description =
-          order.mandatoryAttendanceConditions[0].purpose + "\n" +
-            order.mandatoryAttendanceConditions[0].appointmentDay +
-            "\n" + order.mandatoryAttendanceConditions[0].addressLine1 + "\n" +
-            order.mandatoryAttendanceConditions[0].addressLine2 +
-            "\n" +
-            order.mandatoryAttendanceConditions[0].addressLine3 +
-            "\n" +
-            order.mandatoryAttendanceConditions[0].addressLine4 +
-            "\n" +
-            order.mandatoryAttendanceConditions[0].postcode +
-            "\n",
+          description = order.mandatoryAttendanceConditions[0].purpose + "\n" +
+            order.mandatoryAttendanceConditions[0].appointmentDay + "\n" +
+            order.mandatoryAttendanceConditions[0].addressLine1 + "\n" +
+            order.mandatoryAttendanceConditions[0].addressLine2 + "\n" +
+            order.mandatoryAttendanceConditions[0].addressLine3 + "\n" +
+            order.mandatoryAttendanceConditions[0].addressLine4 + "\n" +
+            order.mandatoryAttendanceConditions[0].postcode + "\n",
           duration = "",
           start = "2025-01-01 12:00:00",
           end = "2025-02-01 13:00:00",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/model/fms/MonitoringOrderTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/model/fms/MonitoringOrderTest.kt
@@ -1,0 +1,43 @@
+package uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.model.fms
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.test.context.ActiveProfiles
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.fms.MonitoringOrder
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.fms.Zone
+
+@ActiveProfiles("test")
+class MonitoringOrderTest : FmsTestBase() {
+
+  @Test
+  fun `It should map attendance monitoring to an FMS Monitoring Order`() {
+    val order = createOrder(
+      mandatoryAttendanceConditions = listOf(
+        createMandatoryAttendanceCondition(),
+      ),
+    )
+    val fmsMonitoringOrder = MonitoringOrder.fromOrder(order = order, caseId = "")
+
+    assertThat(fmsMonitoringOrder.inclusionZones).isEqualTo(
+      listOf(
+        Zone(
+          description =
+          order.mandatoryAttendanceConditions[0].purpose + "\n" +
+            order.mandatoryAttendanceConditions[0].appointmentDay +
+            "\n" + order.mandatoryAttendanceConditions[0].addressLine1 + "\n" +
+            order.mandatoryAttendanceConditions[0].addressLine2 +
+            "\n" +
+            order.mandatoryAttendanceConditions[0].addressLine3 +
+            "\n" +
+            order.mandatoryAttendanceConditions[0].addressLine4 +
+            "\n" +
+            order.mandatoryAttendanceConditions[0].postcode +
+            "\n",
+          duration = "",
+          start = "2025-01-01 12:00:00",
+          end = "2025-02-01 13:00:00",
+        ),
+      ),
+    )
+  }
+}


### PR DESCRIPTION
There are little / no instructions of how to map the attendance monitoring data to Serco. We've been told to send it in the inclusion zone fields but this presents a problem. The form captures a lot more data points than the Serco API allows us to send. 

An inclusion zone is made up of:
- a description
- a duration
- a start date time
- an end date time

The form captures:
- the appointment purpose
- the appointment day
- the appointment address
  - line 1, line 2, line 3, line 4, postcode
- start date
- start time
- end date
- end time

In order to get something to work, I've mapped the purpose, day and address to a multiline string that will be sent in the description field. The duration is left empty as I don't know what format (hours / minutes / seconds) to send it in and it duplicates data they already have from the start / end dates. Start date / time are combined into a single timestamp to send them that uses the same format used elsewhere. The same applies for end date / time.

The enforceable condition for attendance monitoring has also been added.

## Changes
- Created a base test class for the DeviceWearerTest and MonitoringOrderTest to make it easier to create orders for testing mapping.
- Added the MonitoringOrderTest class with a simple test for a single attendance monitoring appointment.