### PR TITLE
Update attendance monitoring mapping

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/fms/MonitoringOrder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/fms/MonitoringOrder.kt
@@ -19,8 +19,6 @@ import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.mo
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.YouthJusticeServiceRegions
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.fms.formatters.PhoneNumberFormatter
 import java.time.DayOfWeek
-import java.time.LocalDateTime
-import java.time.LocalTime
 import java.time.format.DateTimeFormatter
 
 data class MonitoringOrder(
@@ -451,22 +449,15 @@ data class MonitoringOrder(
     private fun getInclusionZones(order: Order): List<Zone> = order.mandatoryAttendanceConditions.map {
       Zone(
         description = it.purpose + "\n" +
-          it.appointmentDay + "\n" +
+          it.appointmentDay + " " + it.startTime + "-" + it.endTime + "\n" +
           it.addressLine1 + "\n" +
           it.addressLine2 + "\n" +
           it.addressLine3 + "\n" +
           it.addressLine4 + "\n" +
           it.postcode + "\n",
         duration = "",
-        start =
-        LocalDateTime.of(
-          it.startDate,
-          LocalTime.parse(it.startTime ?: ""),
-        ).format(dateTimeFormatter),
-        end = LocalDateTime.of(
-          it.endDate,
-          LocalTime.parse(it.endTime ?: ""),
-        ).format(dateTimeFormatter),
+        start = it.startDate?.format(dateFormatter),
+        end = it.endDate?.format(dateFormatter),
       )
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/model/fms/MonitoringOrderTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/model/fms/MonitoringOrderTest.kt
@@ -23,15 +23,17 @@ class MonitoringOrderTest : FmsTestBase() {
       listOf(
         Zone(
           description = order.mandatoryAttendanceConditions[0].purpose + "\n" +
-            order.mandatoryAttendanceConditions[0].appointmentDay + "\n" +
+            order.mandatoryAttendanceConditions[0].appointmentDay + " " +
+            order.mandatoryAttendanceConditions[0].startTime + "-" +
+            order.mandatoryAttendanceConditions[0].endTime + "\n" +
             order.mandatoryAttendanceConditions[0].addressLine1 + "\n" +
             order.mandatoryAttendanceConditions[0].addressLine2 + "\n" +
             order.mandatoryAttendanceConditions[0].addressLine3 + "\n" +
             order.mandatoryAttendanceConditions[0].addressLine4 + "\n" +
             order.mandatoryAttendanceConditions[0].postcode + "\n",
           duration = "",
-          start = "2025-01-01 12:00:00",
-          end = "2025-02-01 13:00:00",
+          start = "2025-01-01",
+          end = "2025-02-01",
         ),
       ),
     )


### PR DESCRIPTION
I misunderstood the purpose of the startTime and endTime properties of the attendance monitoring conditions. They indicate the start time and end time of the appointment rather than the start / end time of the attendance monitoring. i.e. the appointment is from 12:00 -> 1300 on a Monday but the appointment runs every monday from 01-01-2025 until 01-02-2025.

The start time / end time are now present in the description rather than the end and start fields.