### PR TITLE
Make submission errors observable

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/OrderService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/OrderService.kt
@@ -89,7 +89,7 @@ class OrderService(val repo: OrderRepository, val fmsService: FmsService) {
         if (!submitResult.partialSuccess) {
           order.status = OrderStatus.ERROR
           repo.save(order)
-          throw SubmitOrderException("The order could not be submitted to Serco")
+          throw Exception(submitResult.error)
         } else if (!submitResult.attachmentSuccess) {
           order.status = OrderStatus.ERROR
           repo.save(order)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/strategy/FmsOrderSubmissionStrategy.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/strategy/FmsOrderSubmissionStrategy.kt
@@ -32,7 +32,7 @@ class FmsOrderSubmissionStrategy(
   } catch (e: Exception) {
     Result(
       success = false,
-      error = Exception("Failed to submit FMS Device Wearer", e),
+      error = e,
     )
   }
 
@@ -45,7 +45,7 @@ class FmsOrderSubmissionStrategy(
     } catch (e: Exception) {
       Result(
         success = false,
-        error = Exception("Failed to submit FMS Monitoring Order", e),
+        error = e,
       )
     }
 
@@ -122,7 +122,7 @@ class FmsOrderSubmissionStrategy(
     if (!submissionResult.success) {
       return FmsDeviceWearerSubmissionResult(
         status = SubmissionStatus.FAILURE,
-        error = submissionResult.error.toString(),
+        error = submissionResult.error?.message ?: "",
         payload = serialiseResult.data!!,
       )
     }
@@ -159,7 +159,7 @@ class FmsOrderSubmissionStrategy(
     if (!submissionResult.success) {
       return FmsMonitoringOrderSubmissionResult(
         status = SubmissionStatus.FAILURE,
-        error = submissionResult.error.toString(),
+        error = submissionResult.error?.message ?: "",
         payload = serialiseResult.data!!,
       )
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/OrderControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/OrderControllerTest.kt
@@ -590,6 +590,10 @@ class OrderControllerTest : IntegrationTestBase() {
       val error = result.responseBody!!
       assertThat(error.userMessage)
         .isEqualTo("Error submitting order: The order could not be submitted to Serco")
+
+      val submitResult = fmsResultRepository.findAll().firstOrNull()
+      assertThat(submitResult).isNotNull
+      assertThat(submitResult!!.deviceWearerResult.error).isEqualTo("Error creating FMS Device Wearer for order: ${order.id} with error: Mock Create DW Error")
     }
 
     @Test
@@ -621,11 +625,12 @@ class OrderControllerTest : IntegrationTestBase() {
 
       val submitResult = fmsResultRepository.findAll().firstOrNull()
       assertThat(submitResult).isNotNull
+      assertThat(submitResult!!.monitoringOrderResult.error).isEqualTo("Error creating FMS Monitoring Order for order: ${order.id} with error: Mock Create MO Error")
 
       // Get updated order
       val updatedOrder = getOrder(order.id)
 
-      assertThat(updatedOrder.fmsResultId).isEqualTo(submitResult!!.id)
+      assertThat(updatedOrder.fmsResultId).isEqualTo(submitResult.id)
       assertThat(updatedOrder.status).isEqualTo(OrderStatus.ERROR)
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/OrderControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/OrderControllerTest.kt
@@ -593,7 +593,9 @@ class OrderControllerTest : IntegrationTestBase() {
 
       val submitResult = fmsResultRepository.findAll().firstOrNull()
       assertThat(submitResult).isNotNull
-      assertThat(submitResult!!.deviceWearerResult.error).isEqualTo("Error creating FMS Device Wearer for order: ${order.id} with error: Mock Create DW Error")
+      assertThat(
+        submitResult!!.deviceWearerResult.error,
+      ).isEqualTo("Error creating FMS Device Wearer for order: ${order.id} with error: Mock Create DW Error")
     }
 
     @Test
@@ -625,7 +627,9 @@ class OrderControllerTest : IntegrationTestBase() {
 
       val submitResult = fmsResultRepository.findAll().firstOrNull()
       assertThat(submitResult).isNotNull
-      assertThat(submitResult!!.monitoringOrderResult.error).isEqualTo("Error creating FMS Monitoring Order for order: ${order.id} with error: Mock Create MO Error")
+      assertThat(
+        submitResult!!.monitoringOrderResult.error,
+      ).isEqualTo("Error creating FMS Monitoring Order for order: ${order.id} with error: Mock Create MO Error")
 
       // Get updated order
       val updatedOrder = getOrder(order.id)


### PR DESCRIPTION
When an order fails to be submitted to Serco, we create a submission result entry in the database. Unfortunately, the error messages that we record, always end up being:

```text
java.lang.Exception: Failed to submit FMS Device Wearer
``` 

or 
```text
java.lang.Exception: Failed to submit FMS Monitoring Order
```

This makes them essentially useless for investigating why an order was rejected. For example, as part of testing whether a phone number was mandatory, the only way to observe the error message was to add a breakpoint in the submission strategy. This won't be possible in a production environment so we need some way of making those errors more observable.

This change ensures that the value written to the database contains the value that Serco/ServiceNow returns.
e.g.

```text
Error creating FMS Device Wearer for order: 0363ee21-f09a-4f33-af53-d0a8a771dc9a with error: Phone number is mandatory.
```

It also makes sense to make sure these message are logged so that we can also observe them in the application logs. Previously we would just get a log message that looked like:

```text
uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.exception.SubmitOrderException: The order could not be submitted to Serco
...
...
```

Now we will get logs that look like:

```text
uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.exception.SubmitOrderException: The order could not be submitted to Serco
...
...
Caused by: java.lang.Exception: Error creating FMS Device Wearer for order: c15bccc9-b7aa-4a77-9620-67759ed003f6 with error: Phone number is mandatory.
```

