### PR TITLE
ELM-3733: Step 1 rollback start date defaulting and default end date to Europe/London timezone

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/fms/MonitoringOrder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/fms/MonitoringOrder.kt
@@ -210,6 +210,9 @@ data class MonitoringOrder(
     private fun getBritishDateAndTime(dateTime: ZonedDateTime?): String? =
       dateTime?.toInstant()?.atZone(londonTimeZone)?.format(dateTimeFormatter)
 
+    private fun getBritishDate(dateTime: ZonedDateTime?): String? =
+      dateTime?.toInstant()?.atZone(londonTimeZone)?.format(dateFormatter)
+
     fun fromOrder(order: Order, caseId: String?): MonitoringOrder {
       val conditions = order.monitoringConditions!!
       val monitoringOrder = MonitoringOrder(
@@ -245,13 +248,13 @@ data class MonitoringOrder(
           EnforceableCondition(
             "Curfew with EM",
             startDate = curfew.startDate?.format(dateTimeFormatter),
-            endDate = curfew.endDate?.format(dateTimeFormatter) ?: "",
+            endDate = getBritishDateAndTime(curfew.endDate) ?: "",
           ),
         )
         monitoringOrder.curfewDescription = curfew.curfewDescription
         monitoringOrder.conditionalReleaseDate = order.curfewReleaseDateConditions?.releaseDate?.format(dateFormatter)
         monitoringOrder.curfewStart = curfew.startDate!!.format(dateTimeFormatter)
-        monitoringOrder.curfewEnd = curfew.endDate?.format(dateTimeFormatter)
+        monitoringOrder.curfewEnd = getBritishDateAndTime(curfew.endDate)
         monitoringOrder.curfewDuration = getCurfewSchedules(order, curfew)
       }
 
@@ -260,7 +263,7 @@ data class MonitoringOrder(
           EnforceableCondition(
             "Location Monitoring (Fitted Device)",
             startDate = order.monitoringConditionsTrail!!.startDate?.format(dateTimeFormatter),
-            endDate = order.monitoringConditionsTrail!!.endDate?.format(dateTimeFormatter),
+            endDate = getBritishDateAndTime(order.monitoringConditionsTrail!!.endDate),
           ),
 
         )
@@ -282,7 +285,7 @@ data class MonitoringOrder(
                 description = it.description,
                 duration = it.duration,
                 start = it.startDate?.format(dateFormatter),
-                end = it.endDate?.format(dateFormatter) ?: "",
+                end = getBritishDate(it.endDate) ?: "",
               ),
             )
           } else if (it.zoneType == EnforcementZoneType.INCLUSION) {
@@ -291,7 +294,7 @@ data class MonitoringOrder(
                 description = it.description,
                 duration = it.duration,
                 start = it.startDate?.format(dateFormatter),
-                end = it.endDate?.format(dateFormatter) ?: "",
+                end = getBritishDate(it.endDate) ?: "",
               ),
             )
           }
@@ -318,7 +321,7 @@ data class MonitoringOrder(
             EnforceableCondition(
               "AAMR",
               startDate = condition.startDate?.format(dateTimeFormatter),
-              endDate = condition.endDate?.format(dateTimeFormatter) ?: "",
+              endDate = getBritishDateAndTime(conditions.endDate) ?: "",
             ),
           )
           monitoringOrder.abstinence = "Yes"
@@ -327,7 +330,7 @@ data class MonitoringOrder(
             EnforceableCondition(
               "AML",
               startDate = condition.startDate?.format(dateTimeFormatter),
-              endDate = condition.endDate?.format(dateTimeFormatter) ?: "",
+              endDate = getBritishDateAndTime(conditions.endDate) ?: "",
             ),
           )
           monitoringOrder.abstinence = "No"

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/CurfewConditionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/CurfewConditionService.kt
@@ -18,7 +18,7 @@ class CurfewConditionService : OrderSectionServiceBase() {
       versionId = order.getCurrentVersion().id,
       curfewAddress = updateRecord.curfewAddress,
       endDate = getDefaultZonedDateTime(updateRecord.endDate, 23, 59),
-      startDate = getDefaultZonedDateTime(updateRecord.startDate, 0, 0),
+      startDate = updateRecord.startDate,
     )
 
     return orderRepo.save(order).curfewConditions!!

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/EnforcementZoneService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/EnforcementZoneService.kt
@@ -39,7 +39,7 @@ class EnforcementZoneService(val webClient: DocumentApiClient) : OrderSectionSer
         description = updateRecord.description,
         duration = updateRecord.duration,
         endDate = getDefaultZonedDateTime(updateRecord.endDate, 23, 59),
-        startDate = getDefaultZonedDateTime(updateRecord.startDate, 0, 0),
+        startDate = updateRecord.startDate,
         zoneId = updateRecord.zoneId,
         zoneType = updateRecord.zoneType,
       ),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/MonitoringConditionsAlcoholService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/MonitoringConditionsAlcoholService.kt
@@ -34,7 +34,7 @@ class MonitoringConditionsAlcoholService : OrderSectionServiceBase() {
 
     with(alcoholMonitoringConditionsUpdateRecord) {
       alcoholMonitoringConditions.monitoringType = monitoringType
-      alcoholMonitoringConditions.startDate = getDefaultZonedDateTime(startDate, 0, 0)
+      alcoholMonitoringConditions.startDate = startDate
       alcoholMonitoringConditions.endDate = getDefaultZonedDateTime(endDate, 23, 59)
       alcoholMonitoringConditions.installationLocation = installationLocation
       alcoholMonitoringConditions.prisonName = prisonName

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/MonitoringConditionsTrailService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/MonitoringConditionsTrailService.kt
@@ -17,7 +17,7 @@ class MonitoringConditionsTrailService : OrderSectionServiceBase() {
     order.monitoringConditionsTrail = TrailMonitoringConditions(
       versionId = order.getCurrentVersion().id,
       endDate = getDefaultZonedDateTime(updateRecord.endDate, 23, 59),
-      startDate = getDefaultZonedDateTime(updateRecord.startDate, 0, 0),
+      startDate = updateRecord.startDate,
     )
 
     return orderRepo.save(order).monitoringConditionsTrail!!

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/OrderSectionServiceBase.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/OrderSectionServiceBase.kt
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.Order
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.OrderStatus
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.repository.OrderRepository
+import java.time.ZoneId
 import java.time.ZonedDateTime
 import java.util.*
 
@@ -40,7 +41,7 @@ abstract class OrderSectionServiceBase {
         minutes,
         0,
         0,
-        date.zone,
+        ZoneId.of("Europe/London"),
       )
     }
     return null

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/CurfewConditionControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/CurfewConditionControllerTest.kt
@@ -224,15 +224,13 @@ class CurfewConditionControllerTest : IntegrationTestBase() {
     // Get updated order
     val updatedOrder = getOrder(order.id)
 
-    Assertions.assertThat(updatedOrder.curfewConditions).isNotNull()
+    Assertions.assertThat(updatedOrder.curfewConditions?.startDate).isEqualTo(mockStartDate)
+    val britishEndDate = updatedOrder.curfewConditions?.endDate!!.toInstant().atZone(ZoneId.of("Europe/London"))
     Assertions.assertThat(
-      updatedOrder.curfewConditions?.startDate!!.toLocalDate(),
-    ).isEqualTo(mockStartDate.toLocalDate())
-    Assertions.assertThat(updatedOrder.curfewConditions?.startDate!!.hour).isEqualTo(0)
-    Assertions.assertThat(updatedOrder.curfewConditions?.startDate!!.minute).isEqualTo(0)
-    Assertions.assertThat(updatedOrder.curfewConditions?.endDate!!.toLocalDate()).isEqualTo(mockEndDate.toLocalDate())
-    Assertions.assertThat(updatedOrder.curfewConditions?.endDate!!.hour).isEqualTo(23)
-    Assertions.assertThat(updatedOrder.curfewConditions?.endDate!!.minute).isEqualTo(59)
+      britishEndDate.toLocalDate(),
+    ).isEqualTo(mockEndDate.toLocalDate())
+    Assertions.assertThat(britishEndDate.hour).isEqualTo(23)
+    Assertions.assertThat(britishEndDate.minute).isEqualTo(59)
     Assertions.assertThat(updatedOrder.curfewConditions?.curfewAddress).isEqualTo("PRIMARY,SECONDARY")
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/EnforcementZoneControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/EnforcementZoneControllerTest.kt
@@ -27,7 +27,7 @@ class EnforcementZoneControllerTest : IntegrationTestBase() {
 
   private val mockStartDate = ZonedDateTime.of(
     LocalDate.now(ZoneId.of("UTC")),
-    LocalTime.NOON,
+    LocalTime.MIDNIGHT,
     ZoneId.of("UTC"),
   ).plusMonths(1)
   private val mockEndDate = ZonedDateTime.of(
@@ -37,7 +37,7 @@ class EnforcementZoneControllerTest : IntegrationTestBase() {
   ).plusMonths(2)
   private val mockPastStartDate = ZonedDateTime.of(
     LocalDate.of(1970, 2, 1),
-    LocalTime.NOON,
+    LocalTime.MIDNIGHT,
     ZoneId.of("UTC"),
   )
   private val mockPastEndDate = mockPastStartDate.plusDays(1)
@@ -275,29 +275,27 @@ class EnforcementZoneControllerTest : IntegrationTestBase() {
 
       // Verify order state matches expected state
       Assertions.assertThat(updatedOrder.enforcementZoneConditions).hasSize(2)
+      Assertions.assertThat(updatedOrder.enforcementZoneConditions!![0].startDate).isEqualTo(mockStartDate)
+      val condition0BritishEndDate = updatedOrder.enforcementZoneConditions!![0].endDate!!.toInstant().atZone(
+        ZoneId.of("Europe/London"),
+      )
       Assertions.assertThat(
-        updatedOrder.enforcementZoneConditions!![0].startDate!!.toLocalDate(),
-      ).isEqualTo(mockStartDate.toLocalDate())
-      Assertions.assertThat(updatedOrder.enforcementZoneConditions!![0].startDate!!.hour).isEqualTo(0)
-      Assertions.assertThat(updatedOrder.enforcementZoneConditions!![0].startDate!!.minute).isEqualTo(0)
-      Assertions.assertThat(
-        updatedOrder.enforcementZoneConditions!![0].endDate!!.toLocalDate(),
+        condition0BritishEndDate.toLocalDate(),
       ).isEqualTo(mockEndDate.toLocalDate())
-      Assertions.assertThat(updatedOrder.enforcementZoneConditions!![0].endDate!!.hour).isEqualTo(23)
-      Assertions.assertThat(updatedOrder.enforcementZoneConditions!![0].endDate!!.minute).isEqualTo(59)
+      Assertions.assertThat(condition0BritishEndDate.hour).isEqualTo(23)
+      Assertions.assertThat(condition0BritishEndDate.minute).isEqualTo(59)
       Assertions.assertThat(updatedOrder.enforcementZoneConditions!![0].description).isEqualTo("MockDescription")
       Assertions.assertThat(updatedOrder.enforcementZoneConditions!![0].duration).isEqualTo("MockDuration")
       Assertions.assertThat(updatedOrder.enforcementZoneConditions!![0].zoneId).isEqualTo(0)
+      Assertions.assertThat(updatedOrder.enforcementZoneConditions!![1].startDate).isEqualTo(mockStartDate)
+      val condition1BritishEndDate = updatedOrder.enforcementZoneConditions!![1].endDate!!.toInstant().atZone(
+        ZoneId.of("Europe/London"),
+      )
       Assertions.assertThat(
-        updatedOrder.enforcementZoneConditions!![1].startDate!!.toLocalDate(),
-      ).isEqualTo(mockStartDate.toLocalDate())
-      Assertions.assertThat(updatedOrder.enforcementZoneConditions!![1].startDate!!.hour).isEqualTo(0)
-      Assertions.assertThat(updatedOrder.enforcementZoneConditions!![1].startDate!!.minute).isEqualTo(0)
-      Assertions.assertThat(
-        updatedOrder.enforcementZoneConditions!![1].endDate!!.toLocalDate(),
+        condition0BritishEndDate.toLocalDate(),
       ).isEqualTo(mockEndDate.toLocalDate())
-      Assertions.assertThat(updatedOrder.enforcementZoneConditions!![1].endDate!!.hour).isEqualTo(23)
-      Assertions.assertThat(updatedOrder.enforcementZoneConditions!![1].endDate!!.minute).isEqualTo(59)
+      Assertions.assertThat(condition0BritishEndDate.hour).isEqualTo(23)
+      Assertions.assertThat(condition0BritishEndDate.minute).isEqualTo(59)
       Assertions.assertThat(updatedOrder.enforcementZoneConditions!![1].description).isEqualTo("MockDescription")
       Assertions.assertThat(updatedOrder.enforcementZoneConditions!![1].duration).isEqualTo("MockDuration")
       Assertions.assertThat(updatedOrder.enforcementZoneConditions!![1].zoneId).isEqualTo(1)
@@ -348,16 +346,15 @@ class EnforcementZoneControllerTest : IntegrationTestBase() {
       Assertions.assertThat(updatedOrder.enforcementZoneConditions!![0].duration).isEqualTo("MockDuration")
       Assertions.assertThat(updatedOrder.enforcementZoneConditions!![0].zoneId).isEqualTo(0)
 
+      Assertions.assertThat(updatedOrder.enforcementZoneConditions!![0].startDate).isEqualTo(mockStartDate)
+      val britishEndDate = updatedOrder.enforcementZoneConditions!![0].endDate!!.toInstant().atZone(
+        ZoneId.of("Europe/London"),
+      )
       Assertions.assertThat(
-        updatedOrder.enforcementZoneConditions!![0].startDate!!.toLocalDate(),
-      ).isEqualTo(mockStartDate.toLocalDate())
-      Assertions.assertThat(updatedOrder.enforcementZoneConditions!![0].startDate!!.hour).isEqualTo(0)
-      Assertions.assertThat(updatedOrder.enforcementZoneConditions!![0].startDate!!.minute).isEqualTo(0)
-      Assertions.assertThat(
-        updatedOrder.enforcementZoneConditions!![0].endDate!!.toLocalDate(),
+        britishEndDate.toLocalDate(),
       ).isEqualTo(mockEndDate.toLocalDate())
-      Assertions.assertThat(updatedOrder.enforcementZoneConditions!![0].endDate!!.hour).isEqualTo(23)
-      Assertions.assertThat(updatedOrder.enforcementZoneConditions!![0].endDate!!.minute).isEqualTo(59)
+      Assertions.assertThat(britishEndDate.hour).isEqualTo(23)
+      Assertions.assertThat(britishEndDate.minute).isEqualTo(59)
     }
   }
 
@@ -507,16 +504,15 @@ class EnforcementZoneControllerTest : IntegrationTestBase() {
 
       // Verify order state matches expected state
       Assertions.assertThat(updatedOrder.enforcementZoneConditions).hasSize(1)
+      Assertions.assertThat(updatedOrder.enforcementZoneConditions!![0].startDate).isEqualTo(mockStartDate)
+      val britishEndDate = updatedOrder.enforcementZoneConditions!![0].endDate!!.toInstant().atZone(
+        ZoneId.of("Europe/London"),
+      )
       Assertions.assertThat(
-        updatedOrder.enforcementZoneConditions!![0].startDate!!.toLocalDate(),
-      ).isEqualTo(mockStartDate.toLocalDate())
-      Assertions.assertThat(updatedOrder.enforcementZoneConditions!![0].startDate!!.hour).isEqualTo(0)
-      Assertions.assertThat(updatedOrder.enforcementZoneConditions!![0].startDate!!.minute).isEqualTo(0)
-      Assertions.assertThat(
-        updatedOrder.enforcementZoneConditions!![0].endDate!!.toLocalDate(),
+        britishEndDate.toLocalDate(),
       ).isEqualTo(mockEndDate.toLocalDate())
-      Assertions.assertThat(updatedOrder.enforcementZoneConditions!![0].endDate!!.hour).isEqualTo(23)
-      Assertions.assertThat(updatedOrder.enforcementZoneConditions!![0].endDate!!.minute).isEqualTo(59)
+      Assertions.assertThat(britishEndDate.hour).isEqualTo(23)
+      Assertions.assertThat(britishEndDate.minute).isEqualTo(59)
       Assertions.assertThat(updatedOrder.enforcementZoneConditions!![0].description).isEqualTo("MockDescription")
       Assertions.assertThat(updatedOrder.enforcementZoneConditions!![0].duration).isEqualTo("MockDuration")
       Assertions.assertThat(updatedOrder.enforcementZoneConditions!![0].zoneId).isEqualTo(0)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/MonitoringConditionsAlcoholControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/MonitoringConditionsAlcoholControllerTest.kt
@@ -128,10 +128,13 @@ class MonitoringConditionsAlcoholControllerTest : IntegrationTestBase() {
 
     val alcoholConditions = result.responseBody!!
 
-    Assertions.assertThat(alcoholConditions.startDate!!.toLocalDate()).isEqualTo(mockStartDate.toLocalDate())
-    Assertions.assertThat(alcoholConditions.startDate!!.hour).isEqualTo(0)
-    Assertions.assertThat(alcoholConditions.startDate!!.minute).isEqualTo(0)
-    Assertions.assertThat(alcoholConditions.endDate!!.toLocalDate()).isEqualTo(mockEndDate.toLocalDate())
+    Assertions.assertThat(alcoholConditions.startDate).isEqualTo(mockStartDate)
+    val britishEndDate = alcoholConditions.endDate!!.toInstant().atZone(ZoneId.of("Europe/London"))
+    Assertions.assertThat(
+      britishEndDate.toLocalDate(),
+    ).isEqualTo(mockEndDate.toLocalDate())
+    Assertions.assertThat(britishEndDate.hour).isEqualTo(23)
+    Assertions.assertThat(britishEndDate.minute).isEqualTo(59)
     Assertions.assertThat(alcoholConditions.endDate!!.hour).isEqualTo(23)
     Assertions.assertThat(alcoholConditions.endDate!!.minute).isEqualTo(59)
     Assertions.assertThat(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/MonitoringConditionsTrailControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/MonitoringConditionsTrailControllerTest.kt
@@ -130,10 +130,13 @@ class MonitoringConditionsTrailControllerTest : IntegrationTestBase() {
 
     val trailConditions = result.responseBody!!
 
-    Assertions.assertThat(trailConditions.startDate!!.toLocalDate()).isEqualTo(mockStartDate.toLocalDate())
-    Assertions.assertThat(trailConditions.startDate!!.hour).isEqualTo(0)
-    Assertions.assertThat(trailConditions.startDate!!.minute).isEqualTo(0)
-    Assertions.assertThat(trailConditions.endDate!!.toLocalDate()).isEqualTo(mockEndDate.toLocalDate())
+    Assertions.assertThat(trailConditions.startDate).isEqualTo(mockStartDate)
+    val britishEndDate = trailConditions.endDate!!.toInstant().atZone(ZoneId.of("Europe/London"))
+    Assertions.assertThat(
+      britishEndDate.toLocalDate(),
+    ).isEqualTo(mockEndDate.toLocalDate())
+    Assertions.assertThat(britishEndDate.hour).isEqualTo(23)
+    Assertions.assertThat(britishEndDate.minute).isEqualTo(59)
     Assertions.assertThat(trailConditions.endDate!!.hour).isEqualTo(23)
     Assertions.assertThat(trailConditions.endDate!!.minute).isEqualTo(59)
   }
@@ -199,12 +202,13 @@ class MonitoringConditionsTrailControllerTest : IntegrationTestBase() {
       .returnResult()
     val trailConditions = result.responseBody!!
 
-    Assertions.assertThat(trailConditions.startDate!!.toLocalDate()).isEqualTo(mockPastStartDate.toLocalDate())
-    Assertions.assertThat(trailConditions.startDate!!.hour).isEqualTo(0)
-    Assertions.assertThat(trailConditions.startDate!!.minute).isEqualTo(0)
-    Assertions.assertThat(trailConditions.endDate!!.toLocalDate()).isEqualTo(mockEndDate.toLocalDate())
-    Assertions.assertThat(trailConditions.endDate!!.hour).isEqualTo(23)
-    Assertions.assertThat(trailConditions.endDate!!.minute).isEqualTo(59)
+    Assertions.assertThat(trailConditions.startDate).isEqualTo(mockPastStartDate)
+    val britishEndDate = trailConditions.endDate!!.toInstant().atZone(ZoneId.of("Europe/London"))
+    Assertions.assertThat(
+      britishEndDate.toLocalDate(),
+    ).isEqualTo(mockEndDate.toLocalDate())
+    Assertions.assertThat(britishEndDate.hour).isEqualTo(23)
+    Assertions.assertThat(britishEndDate.minute).isEqualTo(59)
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/OrderControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/OrderControllerTest.kt
@@ -838,12 +838,12 @@ class OrderControllerTest : IntegrationTestBase() {
       		{
       			"condition": "Curfew with EM",
             "start_date": "${mockStartDate.format(dateTimeFormatter)}",
-            "end_date": "${mockEndDate.format(dateTimeFormatter)}"
+            "end_date": "$mockEndDateInBritishTime"
       		},
       		{
       			"condition": "Location Monitoring (Fitted Device)",
             "start_date": "${mockStartDate.format(dateTimeFormatter)}",
-            "end_date": "${mockEndDate.format(dateTimeFormatter)}"
+            "end_date": "$mockEndDateInBritishTime"
       		},
       		{
       			"condition": "EM Exclusion / Inclusion Zone",
@@ -853,7 +853,7 @@ class OrderControllerTest : IntegrationTestBase() {
       		{
       			"condition": "AAMR",
             "start_date": "${mockStartDate.format(dateTimeFormatter)}",
-            "end_date": "${mockEndDate.format(dateTimeFormatter)}"
+            "end_date": "$mockEndDateInBritishTime"
       		}
       	],
       	"exclusion_allday": "",
@@ -915,7 +915,7 @@ class OrderControllerTest : IntegrationTestBase() {
         "service_end_date": "${mockEndDate.format(formatter)}",
         "curfew_description": "",
       	"curfew_start": "${mockStartDate.format(dateTimeFormatter)}",
-      	"curfew_end": "${mockEndDate.format(dateTimeFormatter)}",
+      	"curfew_end": "$mockEndDateInBritishTime",
       	"curfew_duration": [
       		{
       			"location": "primary",
@@ -1204,12 +1204,12 @@ class OrderControllerTest : IntegrationTestBase() {
       		{
       			"condition": "Curfew with EM",
             "start_date": "${mockStartDate.format(dateTimeFormatter)}",
-            "end_date": "${mockEndDate.format(dateTimeFormatter)}"
+            "end_date": "$mockEndDateInBritishTime"
       		},
       		{
       			"condition": "Location Monitoring (Fitted Device)",
             "start_date": "${mockStartDate.format(dateTimeFormatter)}",
-            "end_date": "${mockEndDate.format(dateTimeFormatter)}"
+            "end_date": "$mockEndDateInBritishTime"
       		},
       		{
       			"condition": "EM Exclusion / Inclusion Zone",
@@ -1219,7 +1219,7 @@ class OrderControllerTest : IntegrationTestBase() {
       		{
       			"condition": "AAMR",
             "start_date": "${mockStartDate.format(dateTimeFormatter)}",
-            "end_date": "${mockEndDate.format(dateTimeFormatter)}"
+           "end_date": "$mockEndDateInBritishTime"
       		}
       	],
       	"exclusion_allday": "",
@@ -1281,7 +1281,7 @@ class OrderControllerTest : IntegrationTestBase() {
         "service_end_date": "${mockEndDate.format(formatter)}",
         "curfew_description": "",
       	"curfew_start": "${mockStartDate.format(dateTimeFormatter)}",
-      	"curfew_end": "${mockEndDate.format(dateTimeFormatter)}",
+      	"curfew_end": "$mockEndDateInBritishTime",
       	"curfew_duration": [
       		{
       			"location": "primary",
@@ -1540,12 +1540,12 @@ class OrderControllerTest : IntegrationTestBase() {
       		{
       			"condition": "Curfew with EM",
             "start_date": "${mockStartDate.format(dateTimeFormatter)}",
-            "end_date": "${mockEndDate.format(dateTimeFormatter)}"
+            "end_date": "$mockEndDateInBritishTime"
       		},
       		{
       			"condition": "Location Monitoring (Fitted Device)",
             "start_date": "${mockStartDate.format(dateTimeFormatter)}",
-            "end_date": "${mockEndDate.format(dateTimeFormatter)}"
+            "end_date": "$mockEndDateInBritishTime"
       		},
       		{
       			"condition": "EM Exclusion / Inclusion Zone",
@@ -1555,7 +1555,7 @@ class OrderControllerTest : IntegrationTestBase() {
       		{
       			"condition": "AAMR",
             "start_date": "${mockStartDate.format(dateTimeFormatter)}",
-            "end_date": "${mockEndDate.format(dateTimeFormatter)}"
+            "end_date": "$mockEndDateInBritishTime"
       		}
       	],
       	"exclusion_allday": "",
@@ -1617,7 +1617,7 @@ class OrderControllerTest : IntegrationTestBase() {
         "service_end_date": "${mockEndDate.format(formatter)}",
         "curfew_description": "",
       	"curfew_start": "${mockStartDate.format(dateTimeFormatter)}",
-      	"curfew_end": "${mockEndDate.format(dateTimeFormatter)}",
+      	"curfew_end": "$mockEndDateInBritishTime",
       	"curfew_duration": [
       		{
       			"location": "primary",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/MonitoringConditionsAlcoholServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/MonitoringConditionsAlcoholServiceTest.kt
@@ -59,16 +59,7 @@ class MonitoringConditionsAlcoholServiceTest {
     prisonName = null,
     probationOfficeName = null,
   )
-  private val mockDefaultStartDate = ZonedDateTime.of(
-    mockStartDate.year,
-    mockStartDate.monthValue,
-    mockStartDate.dayOfMonth,
-    0,
-    0,
-    0,
-    0,
-    mockStartDate.zone,
-  )
+
   private val mockDefaultEndDate = ZonedDateTime.of(
     mockEndDate.year,
     mockEndDate.monthValue,
@@ -77,13 +68,13 @@ class MonitoringConditionsAlcoholServiceTest {
     59,
     0,
     0,
-    mockStartDate.zone,
+    ZoneId.of("Europe/London"),
   )
   private val mockAlcoholMonitoringConditions = AlcoholMonitoringConditions(
     id = mockAlcoholMonitoringConditionsId,
     versionId = mockVersionId,
     monitoringType = AlcoholMonitoringType.ALCOHOL_ABSTINENCE,
-    startDate = mockDefaultStartDate,
+    startDate = mockStartDate,
     endDate = mockDefaultEndDate,
     installationLocation = AlcoholMonitoringInstallationLocationType.PRIMARY,
     installationAddressId = mockAddressId,
@@ -173,16 +164,6 @@ class MonitoringConditionsAlcoholServiceTest {
 
     @Test
     fun `address ID is null when alcohol monitoring installation location does not match an address type`() {
-      val mockDefaultStartDate = ZonedDateTime.of(
-        mockStartDate.year,
-        mockStartDate.monthValue,
-        mockStartDate.dayOfMonth,
-        0,
-        0,
-        0,
-        0,
-        mockStartDate.zone,
-      )
       val mockDefaultEndDate = ZonedDateTime.of(
         mockEndDate.year,
         mockEndDate.monthValue,
@@ -191,7 +172,7 @@ class MonitoringConditionsAlcoholServiceTest {
         59,
         0,
         0,
-        mockStartDate.zone,
+        ZoneId.of("Europe/London"),
       )
       val mockAlcoholMonitoringConditionsUpdateRecord = UpdateAlcoholMonitoringConditionsDto(
         monitoringType = AlcoholMonitoringType.ALCOHOL_ABSTINENCE,
@@ -205,7 +186,7 @@ class MonitoringConditionsAlcoholServiceTest {
         id = mockAlcoholMonitoringConditionsId,
         versionId = mockVersionId,
         monitoringType = AlcoholMonitoringType.ALCOHOL_ABSTINENCE,
-        startDate = mockDefaultStartDate,
+        startDate = mockStartDate,
         endDate = mockDefaultEndDate,
         installationLocation = AlcoholMonitoringInstallationLocationType.PROBATION_OFFICE,
         installationAddressId = null,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/OrderSectionServiceBaseTests.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/OrderSectionServiceBaseTests.kt
@@ -1,0 +1,64 @@
+package uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.service
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.stereotype.Service
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.repository.OrderRepository
+import java.time.ZoneId
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
+
+@ActiveProfiles("test")
+@SpringBootTest
+class OrderSectionServiceBaseTests {
+  @MockitoBean
+  lateinit var orderRepo: OrderRepository
+
+  @Autowired
+  lateinit var testObject: OrderServiceBaseTestObject
+
+  private val dateTimeFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
+  private val londonTimeZone = ZoneId.of("Europe/London")
+
+  private fun getBritishDateAndTime(dateTime: ZonedDateTime?): String? =
+    dateTime?.toInstant()?.atZone(londonTimeZone)?.format(dateTimeFormatter)
+
+  @Test
+  fun `default BST date should have time converted to UTC`() {
+    val userSuppliedDate = ZonedDateTime.of(2025, 5, 22, 0, 0, 0, 0, ZoneId.of("UTC"))
+
+    // Expect stored time is 22:59 in UTC
+    val expectedDate = ZonedDateTime.of(2025, 5, 22, 22, 59, 0, 0, ZoneId.of("UTC"))
+
+    val actualDate = testObject.getDefaultZonedDateTimeWrapper(userSuppliedDate, 23, 59)
+    assertThat(actualDate).isEqualTo(expectedDate)
+
+    // Assert Serco would receive time value with 23:59:00
+    assertThat(getBritishDateAndTime(actualDate)).isEqualTo("2025-05-22 23:59:00")
+  }
+
+  @Test
+  fun `default GMT date should have time converted to UTC`() {
+    val userSuppliedDate = ZonedDateTime.of(2025, 12, 22, 0, 0, 0, 0, ZoneId.of("UTC"))
+
+    // Expect stored time is 23:59 in UTC
+    val expectedDate = ZonedDateTime.of(2025, 12, 22, 23, 59, 0, 0, ZoneId.of("UTC"))
+
+    val actualDate = testObject.getDefaultZonedDateTimeWrapper(userSuppliedDate, 23, 59)
+    assertThat(actualDate).isEqualTo(expectedDate)
+
+    // Assert Serco would receive time value with 23:59:00
+    assertThat(getBritishDateAndTime(actualDate)).isEqualTo("2025-12-22 23:59:00")
+  }
+}
+
+@Service
+class OrderServiceBaseTestObject : OrderSectionServiceBase() {
+
+  public fun getDefaultZonedDateTimeWrapper(date: ZonedDateTime?, hours: Int, minutes: Int): ZonedDateTime? =
+    getDefaultZonedDateTime(date, hours, minutes)
+}


### PR DESCRIPTION
This is Step 1 of [ELM-3733](https://dsdmoj.atlassian.net/jira/software/c/projects/ELM/boards/1659?selectedIssue=ELM-3733)

Changes included:

Remove defaulting for start date, UI does not capture start time for monitoring condition types, therefore it is defaulted to 00:00:00 already. 

Refactor end date defaulting to use Europe/London timezone, so it will be stored as 23:59:00 in Europe/London for the date captured in UI and will display the end date as per user input.

Update FMS mapping to use getBritishDateAndTime for monitoring condition type end date mapping so Serco will received 23:59:00 as time on the end date

Please note this is interim fix while we implementing the proposed long term fix detailed in [ELM-3733](https://dsdmoj.atlassian.net/jira/software/c/projects/ELM/boards/1659?selectedIssue=ELM-3733)

[ELM-3733]: https://dsdmoj.atlassian.net/browse/ELM-3733?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ELM-3733]: https://dsdmoj.atlassian.net/browse/ELM-3733?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ