### PR TITLE
ELM-3752:Add mapping from CEMO risk category to FMS risk category

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/fms/DeviceWearer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/fms/DeviceWearer.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.Order
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.AddressType
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.Gender
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.RiskCategory
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.Sex
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.fms.formatters.PhoneNumberFormatter
 import java.time.format.DateTimeFormatter
@@ -85,7 +86,7 @@ data class DeviceWearer(
   var mappaCaseType: String? = "",
 
   @JsonProperty("risk_categories")
-  var riskCategory: List<RiskCategory>? = emptyList(),
+  var riskCategory: List<FmsRiskCategory>? = emptyList(),
 
   @JsonProperty("responsible_adult_required")
   var responsibleAdultRequired: String? = "false",
@@ -161,6 +162,7 @@ data class DeviceWearer(
         disability = disabilities,
         phoneNumber = getPhoneNumber(order),
         riskDetails = order.installationAndRisk?.riskDetails,
+        riskCategory = getRiskCategories(order),
         mappa = order.installationAndRisk?.mappaLevel,
         mappaCaseType = order.installationAndRisk?.mappaCaseType,
         responsibleAdultRequired = (order.deviceWearerResponsibleAdult != null).toString(),
@@ -173,6 +175,7 @@ data class DeviceWearer(
         deliusId = order.deviceWearer?.deliusId,
         homeOfficeReferenceNumber = order.deviceWearer?.homeOfficeReferenceNumber,
         prisonNumber = order.deviceWearer?.prisonNumber,
+
       )
 
       if (order.deviceWearer?.noFixedAbode != null && !order.deviceWearer?.noFixedAbode!!) {
@@ -224,9 +227,19 @@ data class DeviceWearer(
 
     private fun getGender(order: Order): String =
       Gender.from(order.deviceWearer?.gender)?.value ?: order.deviceWearer?.gender ?: ""
+
+    private fun getRiskCategories(order: Order): List<FmsRiskCategory> {
+      if (order.installationAndRisk?.riskCategory?.any() == true) {
+        return order.installationAndRisk!!.riskCategory!!
+          .filter { RiskCategory.entries.any { riskCategory -> riskCategory.name == it } }
+          .map { FmsRiskCategory(RiskCategory.entries.first { riskCategory -> riskCategory.name == it }.value) }
+          .toList()
+      }
+      return emptyList()
+    }
   }
 }
 
 data class Disability(var disability: String? = "")
 
-data class RiskCategory(var category: String? = "")
+data class FmsRiskCategory(var category: String? = "")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/OrderControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/OrderControllerTest.kt
@@ -803,7 +803,14 @@ class OrderControllerTest : IntegrationTestBase() {
       	"risk_details": "Danger",
       	"mappa": "MAAPA 1",
       	"mappa_case_type": "CPPC (Critical Public Protection Case)",
-      	"risk_categories": [],
+      	"risk_categories": [
+          {
+            "category": "Sexual Offences"
+          },
+          {
+            "category": "Risk to Specific Gender"
+          }
+        ],
       	"responsible_adult_required": "true",
       	"parent": "Mark Smith",
       	"guardian": "",
@@ -1169,7 +1176,14 @@ class OrderControllerTest : IntegrationTestBase() {
       	"risk_details": "Danger",
       	"mappa": "MAAPA 1",
       	"mappa_case_type": "CPPC (Critical Public Protection Case)",
-      	"risk_categories": [],
+      	"risk_categories": [
+          {
+            "category": "Sexual Offences"
+          },
+          {
+            "category": "Risk to Specific Gender"
+          }
+        ],
       	"responsible_adult_required": "true",
       	"parent": "Mark Smith",
       	"guardian": "",
@@ -1506,7 +1520,14 @@ class OrderControllerTest : IntegrationTestBase() {
       	"risk_details": "Danger",
       	"mappa": "MAAPA 1",
       	"mappa_case_type": "CPPC (Critical Public Protection Case)",
-      	"risk_categories": [],
+      	"risk_categories": [
+          {
+            "category": "Sexual Offences"
+          },
+          {
+            "category": "Risk to Specific Gender"
+          }
+        ],
       	"responsible_adult_required": "true",
       	"parent": "Mark Smith",
       	"guardian": "",
@@ -1818,7 +1839,14 @@ class OrderControllerTest : IntegrationTestBase() {
       	"risk_details": "Danger",
       	"mappa": "MAAPA 1",
       	"mappa_case_type": "CPPC (Critical Public Protection Case)",
-      	"risk_categories": [],
+      	"risk_categories": [
+          {
+            "category": "Sexual Offences"
+          },
+          {
+            "category": "Risk to Specific Gender"
+          }
+        ],
       	"responsible_adult_required": "true",
       	"parent": "Mark Smith",
       	"guardian": "",
@@ -1955,6 +1983,7 @@ class OrderControllerTest : IntegrationTestBase() {
       versionId = versionId,
       offence = "FRAUD_OFFENCES",
       riskDetails = "Danger",
+      riskCategory = arrayOf("SEXUAL_OFFENCES", "RISK_TO_GENDER"),
       mappaLevel = "MAAPA 1",
       mappaCaseType = "CPPC (Critical Public Protection Case)",
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/model/fms/DeviceWearerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/model/fms/DeviceWearerTest.kt
@@ -32,6 +32,18 @@ class DeviceWearerTest : FmsTestBase() {
     assertThat(fmsDeviceWearer.genderIdentity).isEqualTo(mappedValue)
   }
 
+  @ParameterizedTest(name = "it should map saved risk category values to Serco - {0} -> {1}")
+  @MethodSource("getRiskCategories")
+  fun `It should map correctly map saved risk category values to Serco`(savedValue: String, mappedValue: String) {
+    val order = createOrder(
+      deviceWearer = createDeviceWearer(),
+      installationAndRisk = createInstallationAndRisk(riskCategory = savedValue),
+    )
+    val fmsDeviceWearer = FmsDeviceWearer.fromCemoOrder(order)
+
+    assertThat(fmsDeviceWearer.riskCategory!!.first().category).isEqualTo(mappedValue)
+  }
+
   companion object {
     @JvmStatic
     fun sexValues() = listOf(
@@ -48,6 +60,25 @@ class DeviceWearerTest : FmsTestBase() {
       Arguments.of("NON_BINARY", "Non-Binary"),
       Arguments.of("PREFER_TO_SELF_DESCRIBE", "Prefer to self-describe"),
       Arguments.of("NOT_ABLE_TO_PROVIDE_THIS_INFORMATION", ""),
+    )
+
+    @JvmStatic
+    fun getRiskCategories() = listOf(
+      Arguments.of("THREATS_OF_VIOLENCE", "Threats of Violence"),
+      Arguments.of("SEXUAL_OFFENCES", "Sexual Offences"),
+      Arguments.of("RISK_TO_GENDER", "Risk to Specific Gender"),
+      Arguments.of("RACIAL_ABUSE_OR_THREATS", "Racial Abuse or Threats"),
+      Arguments.of("DIVERSITY_CONCERNS", "Diversity Concerns (mental health issues, learning difficulties etc.)"),
+      Arguments.of("DANGEROUS_ANIMALS", "Dangerous Dogs/Pets at Premises"),
+      Arguments.of("IOM", "Is the Subject managed through IOM?"),
+      Arguments.of("SAFEGUARDING_ISSUE", "Safeguarding Issues"),
+      Arguments.of("SAFEGUARDING_ADULT", "Safeguarding Adult"),
+      Arguments.of("SAFEGUARDING_CHILD", "Safeguarding Child"),
+      Arguments.of("SAFEGUARDING_DOMESTIC_ABUSE", "Safeguarding Domestic Abuse"),
+      Arguments.of("OTHER_OCCUPANTS", "Other occupants who pose a risk to staff"),
+      Arguments.of("OTHER_RISKS", "Other known Risks"),
+      Arguments.of("HOMOPHOBIC_VIEWS", "Is there evidence known to the subject having homophobic views"),
+      Arguments.of("UNDER_18", "Under 18 living at property"),
     )
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/model/fms/FmsTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/model/fms/FmsTestBase.kt
@@ -80,6 +80,7 @@ abstract class FmsTestBase {
     prisonNumber: String = "prisonNumber",
     homeOfficeReferenceNumber: String = "homeOfficeReferenceNumber",
     noFixedAbode: Boolean = false,
+    riskCategory: String = "",
   ): DeviceWearer = DeviceWearer(
     versionId = UUID.randomUUID(),
     firstName = firstName,
@@ -129,12 +130,14 @@ abstract class FmsTestBase {
     riskDetails: String = "Danger",
     mappaLevel: String = "MAAPA 1",
     mappaCaseType: String = "CPPC (Critical Public Protection Case)",
+    riskCategory: String = "THREATS_OF_VIOLENCE",
   ) = InstallationAndRisk(
     versionId = UUID.randomUUID(),
     offence = offence,
     riskDetails = riskDetails,
     mappaLevel = mappaLevel,
     mappaCaseType = mappaCaseType,
+    riskCategory = arrayOf(riskCategory),
   )
 
   protected fun createMonitoringConditions(


### PR DESCRIPTION
Context
Ticket: https://dsdmoj.atlassian.net/jira/software/c/projects/ELM/boards/1659?selectedIssue=ELM-3752

[Why are we making this change?]
Additional risk categories are not being sent / mapped to Serco.

This means that even if the user checks the device wearers alerts and marks that they are for example violent, have a history of sexual violence or racist Serco are not receiving this information.

This is essential information so that Serco can ensure the safety of the crew they send to fit the device. This information influences who they send in that crew and if they need to send two crews.

### Changes proposed in this pull request

Added mapping from CEMO risk categories to FMS risk categories 

Update tests in OrderControllerTests to verify we are sending risk categories to Serco

Added test in DeviceWearerTest.kt to verify we map all CEMO risk category Enum to expected Data Dictionary values. 