### PR TITLE
Support DDv5 Variation types

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/data/ValidationErrors.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/data/ValidationErrors.kt
@@ -121,6 +121,7 @@ object ValidationErrors {
     const val TYPE_REQUIRED: String = "Variation type is required"
     const val DATE_REQUIRED: String = "Variation date is required"
     const val TYPE_MUST_BE_VALID: String = "Variation type must be a valid variation type"
+    fun typeObsolete(type: String): String = "Variation type $type is obsolete"
     const val DATE_MUST_BE_VALID: String = "Variation date must be a valid date"
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/dto/UpdateVariationDetailsDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/dto/UpdateVariationDetailsDto.kt
@@ -13,6 +13,7 @@ data class UpdateVariationDetailsDto(
 
   @field:NotEmpty(message = ValidationErrors.VariationDetails.DATE_REQUIRED)
   val variationDate: String = "",
+
 ) {
   @AssertTrue(message = ValidationErrors.VariationDetails.TYPE_MUST_BE_VALID)
   fun isVariationType(): Boolean {
@@ -26,7 +27,6 @@ data class UpdateVariationDetailsDto(
         return true
       }
     }
-
     return false
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/enums/VariationType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/enums/VariationType.kt
@@ -6,4 +6,39 @@ enum class VariationType(val value: String) {
   ENFORCEMENT_ADD("Change to add an Inclusion or Exclusion Zone(s)"),
   ENFORCEMENT_UPDATE("Change to an existing Inclusion or Exclusion Zone(s)"),
   SUSPENSION("Order Suspension"),
+
+  CHANGE_TO_ADDRESS("Change to Address"),
+  CHANGE_TO_PERSONAL_DETAILS("Change to Personal Details"),
+  CHANGE_TO_ADD_AN_EXCLUSION_ZONES("Change to add an Inclusion or Exclusion Zone(s)"),
+  CHANGE_TO_AN_EXISTING_EXCLUSION("Change to an existing Inclusion or Exclusion"),
+  CHANGE_TO_CURFEW_HOURS("Change to Curfew Hours"),
+  ORDER_SUSPENSION("Order Suspension"),
+  CHANGE_TO_DEVICE_TYPE("Change to Device Type"),
+  CHANGE_TO_ENFORCEABLE_CONDITION("Change to Enforceable Condition"),
+  ADMIN_ERROR("Admin Error "),
+  OTHER("Other "),
+  ;
+
+  companion object {
+    val DDv4_TYPES = listOf(
+      CURFEW_HOURS,
+      ADDRESS,
+      ENFORCEMENT_ADD,
+      ENFORCEMENT_UPDATE,
+      SUSPENSION,
+    )
+
+    val DDv5_TYPES = listOf(
+      CHANGE_TO_ADDRESS,
+      CHANGE_TO_PERSONAL_DETAILS,
+      CHANGE_TO_ADD_AN_EXCLUSION_ZONES,
+      CHANGE_TO_AN_EXISTING_EXCLUSION,
+      CHANGE_TO_CURFEW_HOURS,
+      ORDER_SUSPENSION,
+      CHANGE_TO_DEVICE_TYPE,
+      CHANGE_TO_ENFORCEABLE_CONDITION,
+      ADMIN_ERROR,
+      OTHER,
+    )
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/VariationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/VariationService.kt
@@ -1,6 +1,10 @@
 package uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.service
 
+import jakarta.validation.ValidationException
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Configuration
 import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.data.ValidationErrors
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.VariationDetails
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.dto.UpdateVariationDetailsDto
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.VariationType
@@ -8,7 +12,9 @@ import java.time.ZonedDateTime
 import java.util.*
 
 @Service
-class VariationService : OrderSectionServiceBase() {
+@Configuration
+class VariationService(@Value("\${toggle.data-dictionary.v5-1.enabled:false}") val ddV5Enabled: Boolean) :
+  OrderSectionServiceBase() {
   fun updateVariationDetails(
     orderId: UUID,
     username: String,
@@ -16,6 +22,10 @@ class VariationService : OrderSectionServiceBase() {
   ): VariationDetails {
     val order = this.findEditableOrder(orderId, username)
 
+    val type = VariationType.entries.firstOrNull { it.name == updateRecord.variationType }
+    if (ddV5Enabled && VariationType.DDv4_TYPES.contains(type)) {
+      throw ValidationException(ValidationErrors.VariationDetails.typeObsolete(updateRecord.variationType))
+    }
     with(updateRecord) {
       order.variationDetails = VariationDetails(
         versionId = order.getCurrentVersion().id,


### PR DESCRIPTION
Ticket: https://dsdmoj.atlassian.net/jira/software/c/projects/ELM/boards/1659?selectedIssue=ELM-3679

Added support for DDv5 Variation types.

Mark DDv4 variation types obsolete based on feature flag