### PR TITLE
Validate the mandatory End Date field of the Monitoring Conditions section

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/data/ValidationErrors.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/data/ValidationErrors.kt
@@ -98,6 +98,7 @@ object ValidationErrors {
     const val MONITORING_TYPE_MINIMUM_ONE: String = "Select monitoring required"
     const val ORDER_TYPE_REQUIRED: String = "Select order type"
     const val START_DATE_REQUIRED: String = "Enter start date for monitoring"
+    const val END_DATE_REQUIRED: String = "Enter end date for monitoring"
     const val TYPE_REQUIRED: String = "Select order type"
     const val END_DATE_MUST_BE_AFTER_START_DATE: String = "End date must be after start date"
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/dto/UpdateMonitoringConditionsDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/dto/UpdateMonitoringConditionsDto.kt
@@ -24,6 +24,7 @@ data class UpdateMonitoringConditionsDto(
   @field:NotNull(message = ValidationErrors.MonitoringConditions.START_DATE_REQUIRED)
   val startDate: ZonedDateTime? = null,
 
+  @field:NotNull(message = ValidationErrors.MonitoringConditions.END_DATE_REQUIRED)
   val endDate: ZonedDateTime? = null,
 
   val exclusionZone: Boolean? = null,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/MonitoringConditionsControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/MonitoringConditionsControllerTest.kt
@@ -28,6 +28,7 @@ class MonitoringConditionsControllerTest : IntegrationTestBase() {
   private object ErrorMessages {
     const val ORDER_TYPE_REQUIRED: String = "Select order type"
     const val START_DATE_REQUIRED: String = "Enter start date for monitoring"
+    const val END_DATE_REQUIRED: String = "Enter end date for monitoring"
     const val TYPE_REQUIRED: String = "Select order type"
     const val END_DATE_MUST_BE_AFTER_START_DATE: String = "End date must be after start date"
   }
@@ -115,7 +116,8 @@ class MonitoringConditionsControllerTest : IntegrationTestBase() {
               "curfew": true,
               "orderTypeDescription": "$mockOrderTypeDescription",
               "conditionType": "$mockConditionType",
-              "startDate": "$mockStartDate"
+              "startDate": "$mockStartDate",
+              "endDate": "$mockEndDate"
             }
           """.trimIndent(),
         ),
@@ -198,7 +200,6 @@ class MonitoringConditionsControllerTest : IntegrationTestBase() {
       .returnResult()
 
     Assertions.assertThat(result.responseBody).isNotNull
-    Assertions.assertThat(result.responseBody).hasSize(3)
     Assertions.assertThat(result.responseBody!!).contains(
       ValidationError("orderType", ErrorMessages.ORDER_TYPE_REQUIRED),
     )
@@ -207,6 +208,9 @@ class MonitoringConditionsControllerTest : IntegrationTestBase() {
     )
     Assertions.assertThat(result.responseBody!!).contains(
       ValidationError("startDate", ErrorMessages.START_DATE_REQUIRED),
+    )
+    Assertions.assertThat(result.responseBody!!).contains(
+      ValidationError("endDate", ErrorMessages.END_DATE_REQUIRED),
     )
   }
 
@@ -233,7 +237,7 @@ class MonitoringConditionsControllerTest : IntegrationTestBase() {
               "mandatoryAttendance": "true",
               "alcohol": "true",
               "startDate": "$mockPastStartDate",
-              "endDate": null
+              "endDate": "${mockPastStartDate.plusDays(1)}"
             }
           """.trimIndent(),
         ),


### PR DESCRIPTION
This PR adds validation of the now-mandatory End Date field of the Monitoring Conditions section.
This complements validation added to the frontend [in this PR](https://github.com/ministryofjustice/hmpps-electronic-monitoring-create-an-order/pull/371).