### PR TITLE
ELM-3742: split risk categories into two section in UI

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/enums/RiskCategory.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/enums/RiskCategory.kt
@@ -17,4 +17,5 @@ enum class RiskCategory(val value: String) {
   OTHER_RISKS("Other known Risks"),
   HOMOPHOBIC_VIEWS("Is there evidence known to the subject having homophobic views"),
   UNDER_18("Under 18 living at property"),
+  NO_RISK("No risk"),
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/fms/DeviceWearer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/fms/DeviceWearer.kt
@@ -231,7 +231,12 @@ data class DeviceWearer(
     private fun getRiskCategories(order: Order): List<FmsRiskCategory> {
       if (order.installationAndRisk?.riskCategory?.any() == true) {
         return order.installationAndRisk!!.riskCategory!!
-          .filter { RiskCategory.entries.any { riskCategory -> riskCategory.name == it } }
+          .filter {
+            RiskCategory.entries.any { riskCategory ->
+              riskCategory != RiskCategory.NO_RISK &&
+                riskCategory.name == it
+            }
+          }
           .map { FmsRiskCategory(RiskCategory.entries.first { riskCategory -> riskCategory.name == it }.value) }
           .toList()
       }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/model/fms/DeviceWearerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/model/fms/DeviceWearerTest.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.model.fms
 
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
@@ -42,6 +43,17 @@ class DeviceWearerTest : FmsTestBase() {
     val fmsDeviceWearer = FmsDeviceWearer.fromCemoOrder(order)
 
     assertThat(fmsDeviceWearer.riskCategory!!.first().category).isEqualTo(mappedValue)
+  }
+
+  @Test
+  fun `It should not map risk category to serco when risk category is NO_RISK`() {
+    val order = createOrder(
+      deviceWearer = createDeviceWearer(),
+      installationAndRisk = createInstallationAndRisk(riskCategory = "NO_RISK"),
+    )
+    val fmsDeviceWearer = FmsDeviceWearer.fromCemoOrder(order)
+
+    assertThat(fmsDeviceWearer.riskCategory!!.count()).isEqualTo(0)
   }
 
   companion object {


### PR DESCRIPTION
Add NO_RISK to risk category enum and not map this option to Serco