### PR TITLE
Add order search endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/criteria/OrderListCriteria.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/criteria/OrderListCriteria.kt
@@ -1,3 +1,3 @@
 package uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.criteria
 
-data class OrderSearchCriteria(val searchTerm: String = "")
+data class OrderListCriteria(val searchTerm: String = "", val username: String)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/specification/OrderListSpecification.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/specification/OrderListSpecification.kt
@@ -12,7 +12,7 @@ import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.mo
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.OrderVersion
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.criteria.OrderSearchCriteria
 
-class OrderSpecification(private val criteria: OrderSearchCriteria) : Specification<Order> {
+class OrderListSpecification(private val criteria: OrderSearchCriteria) : Specification<Order> {
   private fun wildcard(str: String): String = "%$str%"
 
   private fun isOwnedByUser(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/specification/OrderListSpecification.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/specification/OrderListSpecification.kt
@@ -10,9 +10,9 @@ import org.springframework.lang.Nullable
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.DeviceWearer
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.Order
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.OrderVersion
-import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.criteria.OrderSearchCriteria
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.criteria.OrderListCriteria
 
-class OrderListSpecification(private val criteria: OrderSearchCriteria) : Specification<Order> {
+class OrderListSpecification(private val criteria: OrderListCriteria) : Specification<Order> {
   private fun wildcard(str: String): String = "%$str%"
 
   private fun isOwnedByUser(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/specification/OrderSearchSpecification.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/specification/OrderSearchSpecification.kt
@@ -10,7 +10,9 @@ import org.springframework.lang.Nullable
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.DeviceWearer
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.Order
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.OrderVersion
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.criteria.OrderListCriteria
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.criteria.OrderSearchCriteria
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.OrderStatus
 
 class OrderSearchSpecification(private val criteria: OrderSearchCriteria) : Specification<Order> {
   private fun wildcard(str: String): String = "%$str%"
@@ -52,6 +54,7 @@ class OrderSearchSpecification(private val criteria: OrderSearchCriteria) : Spec
     if (predicates.isNotEmpty()) {
       return criteriaBuilder.and(
         criteriaBuilder.equal(version.get<Int>("versionId"), subquery),
+        criteriaBuilder.equal(version.get<String>("status"), OrderStatus.SUBMITTED),
         criteriaBuilder.or(*predicates.toTypedArray()),
       )
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/specification/OrderSearchSpecification.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/specification/OrderSearchSpecification.kt
@@ -14,8 +14,6 @@ import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.mo
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.OrderStatus
 
 class OrderSearchSpecification(private val criteria: OrderSearchCriteria) : Specification<Order> {
-  private fun wildcard(str: String): String = "%$str%"
-
   private fun isLikeFullName(
     deviceWearer: Join<OrderVersion, DeviceWearer>,
     criteriaBuilder: CriteriaBuilder,
@@ -27,7 +25,7 @@ class OrderSearchSpecification(private val criteria: OrderSearchCriteria) : Spec
     val normalizedKeyword = keyword.trim().replace(Regex("\\s+"), " ").lowercase()
     return criteriaBuilder.like(
       criteriaBuilder.lower(fullName),
-      wildcard(normalizedKeyword),
+      normalizedKeyword,
     )
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/specification/OrderSearchSpecification.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/specification/OrderSearchSpecification.kt
@@ -10,7 +10,6 @@ import org.springframework.lang.Nullable
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.DeviceWearer
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.Order
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.OrderVersion
-import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.criteria.OrderListCriteria
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.criteria.OrderSearchCriteria
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.OrderStatus
 
@@ -60,6 +59,5 @@ class OrderSearchSpecification(private val criteria: OrderSearchCriteria) : Spec
     }
 
     return criteriaBuilder.equal(version.get<Int>("versionId"), subquery)
-
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/specification/OrderSearchSpecification.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/specification/OrderSearchSpecification.kt
@@ -1,0 +1,62 @@
+package uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.specification
+
+import jakarta.persistence.criteria.CriteriaBuilder
+import jakarta.persistence.criteria.CriteriaQuery
+import jakarta.persistence.criteria.Join
+import jakarta.persistence.criteria.Predicate
+import jakarta.persistence.criteria.Root
+import org.springframework.data.jpa.domain.Specification
+import org.springframework.lang.Nullable
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.DeviceWearer
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.Order
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.OrderVersion
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.criteria.OrderSearchCriteria
+
+class OrderSearchSpecification(private val criteria: OrderSearchCriteria) : Specification<Order> {
+  private fun wildcard(str: String): String = "%$str%"
+
+  private fun isLikeFullName(
+    deviceWearer: Join<OrderVersion, DeviceWearer>,
+    criteriaBuilder: CriteriaBuilder,
+    keyword: String,
+  ): Predicate {
+    var fullName = criteriaBuilder.concat(deviceWearer.get(DeviceWearer::firstName.name), " ")
+    fullName = criteriaBuilder.concat(fullName, deviceWearer.get(DeviceWearer::lastName.name))
+
+    val normalizedKeyword = keyword.trim().replace(Regex("\\s+"), " ").lowercase()
+    return criteriaBuilder.like(
+      criteriaBuilder.lower(fullName),
+      wildcard(normalizedKeyword),
+    )
+  }
+
+  override fun toPredicate(
+    root: Root<Order>,
+    @Nullable query: CriteriaQuery<*>?,
+    criteriaBuilder: CriteriaBuilder,
+  ): Predicate? {
+    val predicates = mutableListOf<Predicate>()
+    val version: Join<Order, OrderVersion> = root.join("versions")
+    val deviceWearer: Join<OrderVersion, DeviceWearer> = version.join("deviceWearer")
+
+    // Subquery to get the max version number
+    val subquery = query?.subquery(Int::class.java)
+    val subqueryRoot = subquery?.from(OrderVersion::class.java)
+    subquery?.select(criteriaBuilder.max(subqueryRoot?.get<Int>("versionId")))
+    subquery?.where(criteriaBuilder.equal(subqueryRoot?.get<Order>("order"), root))
+
+    if (this.criteria.searchTerm.isNotEmpty()) {
+      predicates.add(isLikeFullName(deviceWearer, criteriaBuilder, this.criteria.searchTerm))
+    }
+
+    if (predicates.isNotEmpty()) {
+      return criteriaBuilder.and(
+        criteriaBuilder.equal(version.get<Int>("versionId"), subquery),
+        criteriaBuilder.or(*predicates.toTypedArray()),
+      )
+    }
+
+    return criteriaBuilder.equal(version.get<Int>("versionId"), subquery)
+
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/resource/OrderController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/resource/OrderController.kt
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.Order
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.criteria.OrderListCriteria
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.criteria.OrderSearchCriteria
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.dto.CreateOrderDto
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.dto.OrderDto
@@ -67,7 +68,17 @@ class OrderController(@Autowired val orderService: OrderService) {
     authentication: Authentication,
   ): ResponseEntity<List<OrderDto>> {
     val username = authentication.name
-    val orders = orderService.listOrders(OrderSearchCriteria(searchTerm, username))
+    val orders = orderService.listOrders(OrderListCriteria(searchTerm, username))
+
+    return ResponseEntity(orders.map { convertToDto(it) }, HttpStatus.OK)
+  }
+
+  @GetMapping("/orders/search")
+  fun searchOrders(
+    @RequestParam searchTerm: String = "",
+    authentication: Authentication,
+  ): ResponseEntity<List<OrderDto>> {
+    val orders = orderService.searchOrders(OrderSearchCriteria(searchTerm))
 
     return ResponseEntity(orders.map { convertToDto(it) }, HttpStatus.OK)
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/OrderService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/OrderService.kt
@@ -11,7 +11,7 @@ import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.mo
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.dto.CreateOrderDto
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.FmsOrderSource
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.OrderStatus
-import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.specification.OrderSpecification
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.specification.OrderListSpecification
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.repository.OrderRepository
 import java.util.*
 
@@ -112,6 +112,6 @@ class OrderService(val repo: OrderRepository, val fmsService: FmsService) {
   }
 
   fun listOrders(searchCriteria: OrderSearchCriteria): List<Order> = repo.findAll(
-    OrderSpecification(searchCriteria),
+    OrderListSpecification(searchCriteria),
   )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/OrderService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/OrderService.kt
@@ -7,6 +7,7 @@ import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.mo
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.MonitoringConditions
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.Order
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.OrderVersion
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.criteria.OrderListCriteria
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.criteria.OrderSearchCriteria
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.dto.CreateOrderDto
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.FmsOrderSource
@@ -112,7 +113,7 @@ class OrderService(val repo: OrderRepository, val fmsService: FmsService) {
     return order
   }
 
-  fun listOrders(searchCriteria: OrderSearchCriteria): List<Order> = repo.findAll(
+  fun listOrders(searchCriteria: OrderListCriteria): List<Order> = repo.findAll(
     OrderListSpecification(searchCriteria),
   )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/OrderService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/OrderService.kt
@@ -12,6 +12,7 @@ import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.mo
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.FmsOrderSource
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.OrderStatus
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.specification.OrderListSpecification
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.specification.OrderSearchSpecification
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.repository.OrderRepository
 import java.util.*
 
@@ -113,5 +114,9 @@ class OrderService(val repo: OrderRepository, val fmsService: FmsService) {
 
   fun listOrders(searchCriteria: OrderSearchCriteria): List<Order> = repo.findAll(
     OrderListSpecification(searchCriteria),
+  )
+
+  fun searchOrders(searchCriteria: OrderSearchCriteria): List<Order> = repo.findAll(
+    OrderSearchSpecification(searchCriteria),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/OrderControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/OrderControllerTest.kt
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.integration.resource
 
-
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/OrderControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/OrderControllerTest.kt
@@ -476,14 +476,16 @@ class OrderControllerTest : IntegrationTestBase() {
 
       repo.save(order)
 
-      webTestClient.get()
+      val result = webTestClient.get()
         .uri("/api/orders?searchTerm=john smith")
         .headers(setAuthorisation("AUTH_ADM"))
         .exchange()
         .expectStatus()
         .isOk
         .expectBodyList(OrderDto::class.java)
-        .hasSize(1)
+        .hasSize(1).returnResult().responseBody
+
+      assertThat(result.first().deviceWearer?.versionId).isEqualTo(versionId2)
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/OrderControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/OrderControllerTest.kt
@@ -387,6 +387,66 @@ class OrderControllerTest : IntegrationTestBase() {
   }
 
   @Nested
+  @DisplayName("GET /api/orders/search")
+  inner class SearchOrders {
+    @Test
+    fun `It should return orders where the first and last names match`() {
+      createAndPersistReadyToSubmitOrder(status = OrderStatus.SUBMITTED)
+
+      webTestClient.get()
+        .uri("/api/orders/search?searchTerm=john smith")
+        .headers(setAuthorisation("AUTH_ADM"))
+        .exchange()
+        .expectStatus()
+        .isOk
+        .expectBodyList(OrderDto::class.java)
+        .hasSize(1)
+    }
+
+    @Test
+    fun `It should return orders created by a different user`() {
+      createAndPersistReadyToSubmitOrder(status = OrderStatus.SUBMITTED)
+
+      webTestClient.get()
+        .uri("/api/orders/search?searchTerm=john smith")
+        .headers(setAuthorisation("SOME_OTHER_USER"))
+        .exchange()
+        .expectStatus()
+        .isOk
+        .expectBodyList(OrderDto::class.java)
+        .hasSize(1)
+    }
+
+    @Test
+    fun `It should only return submitted orders`() {
+      createAndPersistReadyToSubmitOrder(status = OrderStatus.IN_PROGRESS)
+
+      webTestClient.get()
+        .uri("/api/orders/search?searchTerm=john smith")
+        .headers(setAuthorisation("AUTH_ADM"))
+        .exchange()
+        .expectStatus()
+        .isOk
+        .expectBodyList(OrderDto::class.java)
+        .hasSize(0)
+    }
+
+    @Test
+    fun `It should only return orders that match full name`() {
+      createAndPersistReadyToSubmitOrder(status = OrderStatus.IN_PROGRESS)
+
+      webTestClient.get()
+        .uri("/api/orders/search?searchTerm=john")
+        .headers(setAuthorisation("AUTH_ADM"))
+        .exchange()
+        .expectStatus()
+        .isOk
+        .expectBodyList(OrderDto::class.java)
+        .hasSize(0)
+    }
+  }
+
+  @Nested
   @DisplayName("GET /api/orders/{orderId}")
   inner class GetOrderVersion {
     @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/resources/OrderControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/resources/OrderControllerTest.kt
@@ -10,6 +10,7 @@ import org.springframework.security.core.Authentication
 import org.springframework.test.context.ActiveProfiles
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.Order
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.OrderVersion
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.criteria.OrderListCriteria
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.criteria.OrderSearchCriteria
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.dto.CreateOrderDto
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.dto.OrderDto
@@ -136,7 +137,7 @@ class OrderControllerTest {
       ),
     )
 
-    `when`(orderService.listOrders(OrderSearchCriteria(username = "mockUser"))).thenReturn(orders)
+    `when`(orderService.listOrders(OrderListCriteria(username = "mockUser"))).thenReturn(orders)
     `when`(authentication.name).thenReturn("mockUser")
 
     val result = controller.listOrders("", authentication)
@@ -191,6 +192,101 @@ class OrderControllerTest {
           monitoringConditionsAlcohol = null,
           monitoringConditionsTrail = null,
           status = OrderStatus.IN_PROGRESS,
+          type = RequestType.REQUEST,
+          username = "mockUser",
+          variationDetails = null,
+          probationDeliveryUnit = null,
+          installationLocation = null,
+          installationAppointment = null,
+        ),
+      ),
+    )
+  }
+
+  @Test
+  fun `Search for orders given a full name`() {
+    val orderId = UUID.randomUUID()
+    val orderId2 = UUID.randomUUID()
+    val orders: List<Order> = listOf(
+      Order(
+        id = orderId,
+        versions = mutableListOf(
+          OrderVersion(
+            orderId = orderId,
+            username = "mockUser",
+            status = OrderStatus.SUBMITTED,
+            type = RequestType.REQUEST,
+          ),
+        ),
+      ),
+      Order(
+        id = orderId2,
+        versions = mutableListOf(
+          OrderVersion(
+            orderId = orderId2,
+            username = "mockUser",
+            status = OrderStatus.SUBMITTED,
+            type = RequestType.REQUEST,
+          ),
+        ),
+      ),
+    )
+
+    `when`(orderService.searchOrders(OrderSearchCriteria(searchTerm = "Bob Smith"))).thenReturn(orders)
+    `when`(authentication.name).thenReturn("mockUser")
+
+    val result = controller.searchOrders("Bob Smith", authentication)
+    Assertions.assertThat(result.body).isEqualTo(
+      listOf(
+        OrderDto(
+          id = orderId,
+          additionalDocuments = mutableListOf(),
+          addresses = mutableListOf(),
+          contactDetails = null,
+          curfewConditions = null,
+          curfewReleaseDateConditions = null,
+          curfewTimeTable = mutableListOf(),
+          deviceWearer = null,
+          deviceWearerResponsibleAdult = null,
+          enforcementZoneConditions = mutableListOf(),
+          fmsResultId = null,
+          fmsResultDate = null,
+          installationAndRisk = null,
+          interestedParties = null,
+          isValid = false,
+          mandatoryAttendanceConditions = mutableListOf(),
+          monitoringConditions = null,
+          monitoringConditionsAlcohol = null,
+          monitoringConditionsTrail = null,
+          status = OrderStatus.SUBMITTED,
+          type = RequestType.REQUEST,
+          username = "mockUser",
+          variationDetails = null,
+          probationDeliveryUnit = null,
+          installationLocation = null,
+          installationAppointment = null,
+        ),
+        OrderDto(
+          id = orderId2,
+          additionalDocuments = mutableListOf(),
+          addresses = mutableListOf(),
+          contactDetails = null,
+          curfewConditions = null,
+          curfewReleaseDateConditions = null,
+          curfewTimeTable = mutableListOf(),
+          deviceWearer = null,
+          deviceWearerResponsibleAdult = null,
+          enforcementZoneConditions = mutableListOf(),
+          fmsResultId = null,
+          fmsResultDate = null,
+          installationAndRisk = null,
+          interestedParties = null,
+          isValid = false,
+          mandatoryAttendanceConditions = mutableListOf(),
+          monitoringConditions = null,
+          monitoringConditionsAlcohol = null,
+          monitoringConditionsTrail = null,
+          status = OrderStatus.SUBMITTED,
           type = RequestType.REQUEST,
           username = "mockUser",
           variationDetails = null,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/OrderServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/OrderServiceTest.kt
@@ -3,8 +3,8 @@ package uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.s
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.mockito.Mockito.mock
-import org.mockito.Mockito.reset
+import org.mockito.ArgumentMatchers
+import org.mockito.Mockito.*
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
@@ -12,6 +12,7 @@ import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.boot.test.autoconfigure.json.JsonTest
+import org.springframework.data.jpa.domain.Specification
 import org.springframework.test.context.ActiveProfiles
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.Address
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.AlcoholMonitoringConditions
@@ -28,6 +29,7 @@ import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.mo
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.OrderVersion
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.ResponsibleAdult
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.TrailMonitoringConditions
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.criteria.OrderSearchCriteria
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.dto.CreateOrderDto
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.AddressType
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.AlcoholMonitoringType
@@ -44,6 +46,7 @@ import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.mo
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.fms.FmsMonitoringOrderSubmissionResult
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.fms.FmsSubmissionResult
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.fms.FmsSubmissionStrategyKind
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.specification.OrderListSpecification
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.repository.OrderRepository
 import java.time.DayOfWeek
 import java.time.ZoneId
@@ -106,6 +109,18 @@ class OrderServiceTest {
       verify(repo, times(1)).save(capture())
       Assertions.assertThat(firstValue.fmsResultId).isEqualTo(mockFmsResult.id)
     }
+  }
+
+  @Test
+  fun `Should be able to list all orders`() {
+    val mockOrder = createReadyToSubmitOrder()
+    val mockCriteria = OrderSearchCriteria(username = "test")
+
+    whenever(repo.findAll(ArgumentMatchers.any(OrderListSpecification::class.java))).thenReturn(listOf(mockOrder))
+
+    val result = service.listOrders(mockCriteria)
+
+    Assertions.assertThat(result).isEqualTo(listOf(mockOrder))
   }
 
   val mockStartDate: ZonedDateTime = ZonedDateTime.now().plusMonths(1)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/OrderServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/OrderServiceTest.kt
@@ -4,7 +4,8 @@ import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.ArgumentMatchers
-import org.mockito.Mockito.*
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.reset
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/OrderServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/OrderServiceTest.kt
@@ -47,6 +47,7 @@ import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.mo
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.fms.FmsSubmissionResult
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.fms.FmsSubmissionStrategyKind
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.specification.OrderListSpecification
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.specification.OrderSearchSpecification
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.repository.OrderRepository
 import java.time.DayOfWeek
 import java.time.ZoneId
@@ -119,6 +120,18 @@ class OrderServiceTest {
     whenever(repo.findAll(ArgumentMatchers.any(OrderListSpecification::class.java))).thenReturn(listOf(mockOrder))
 
     val result = service.listOrders(mockCriteria)
+
+    Assertions.assertThat(result).isEqualTo(listOf(mockOrder))
+  }
+
+  @Test
+  fun `Should be able to search for orders`() {
+    val mockOrder = createReadyToSubmitOrder()
+    val mockCriteria = OrderSearchCriteria(searchTerm = "bob", username = "test")
+
+    whenever(repo.findAll(ArgumentMatchers.any(OrderSearchSpecification::class.java))).thenReturn(listOf(mockOrder))
+
+    val result = service.searchOrders(mockCriteria)
 
     Assertions.assertThat(result).isEqualTo(listOf(mockOrder))
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/OrderServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/OrderServiceTest.kt
@@ -12,7 +12,6 @@ import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.boot.test.autoconfigure.json.JsonTest
-import org.springframework.data.jpa.domain.Specification
 import org.springframework.test.context.ActiveProfiles
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.Address
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.AlcoholMonitoringConditions
@@ -29,6 +28,7 @@ import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.mo
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.OrderVersion
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.ResponsibleAdult
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.TrailMonitoringConditions
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.criteria.OrderListCriteria
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.criteria.OrderSearchCriteria
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.dto.CreateOrderDto
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.AddressType
@@ -115,7 +115,7 @@ class OrderServiceTest {
   @Test
   fun `Should be able to list all orders`() {
     val mockOrder = createReadyToSubmitOrder()
-    val mockCriteria = OrderSearchCriteria(username = "test")
+    val mockCriteria = OrderListCriteria(username = "test")
 
     whenever(repo.findAll(ArgumentMatchers.any(OrderListSpecification::class.java))).thenReturn(listOf(mockOrder))
 
@@ -127,7 +127,7 @@ class OrderServiceTest {
   @Test
   fun `Should be able to search for orders`() {
     val mockOrder = createReadyToSubmitOrder()
-    val mockCriteria = OrderSearchCriteria(searchTerm = "bob", username = "test")
+    val mockCriteria = OrderSearchCriteria(searchTerm = "Bob Smith")
 
     whenever(repo.findAll(ArgumentMatchers.any(OrderSearchSpecification::class.java))).thenReturn(listOf(mockOrder))
 


### PR DESCRIPTION
Add an search order endpoint to use on the frontend
List order endpoint needs some cleaning up but can do that later

Search endpoint only returns submitted orders