### PR TITLE
Add unknown to order type description

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/enums/OrderTypeDescription.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/enums/OrderTypeDescription.kt
@@ -6,4 +6,5 @@ enum class OrderTypeDescription(val value: String) {
   DAPOL_HDC("DAPOL HDC"),
   GPS_ACQUISITIVE_CRIME_HDC("GPS Acquisitive Crime HDC"),
   GPS_ACQUISITIVE_CRIME_PAROLE("GPS Acquisitive Crime Parole"),
+  UNKNOWN("")
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/enums/OrderTypeDescription.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/enums/OrderTypeDescription.kt
@@ -6,5 +6,5 @@ enum class OrderTypeDescription(val value: String) {
   DAPOL_HDC("DAPOL HDC"),
   GPS_ACQUISITIVE_CRIME_HDC("GPS Acquisitive Crime HDC"),
   GPS_ACQUISITIVE_CRIME_PAROLE("GPS Acquisitive Crime Parole"),
-  UNKNOWN("")
+  UNKNOWN(""),
 }


### PR DESCRIPTION
https://dsdmoj.atlassian.net/browse/ELM-3891

Adding a new unknown type to the enum that will let us know when a user has selected the "They are not part of any of these pilots" option