### PR TITLE
License upload: Set permitted file formats and max size

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/config/HmppsElectronicMonitoringCreateAnOrderApiExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/config/HmppsElectronicMonitoringCreateAnOrderApiExceptionHandler.kt
@@ -167,15 +167,16 @@ class HmppsElectronicMonitoringCreateAnOrderApiExceptionHandler {
     ).also { log.error("Illegal state exception", e) }
 
   @ExceptionHandler(MaxUploadSizeExceededException::class)
-  fun handleMaxUploadSizeExceededException(e: Exception): ResponseEntity<ErrorResponse> = ResponseEntity
-    .status(BAD_REQUEST)
-    .body(
-      ErrorResponse(
-        status = BAD_REQUEST,
-        userMessage = "File uploaded exceed max file size limit of 10MB",
-        developerMessage = e.message,
-      ),
-    ).also { log.error("Unexpected exception", e) }
+  fun handleMaxUploadSizeExceededException(e: MaxUploadSizeExceededException): ResponseEntity<ErrorResponse> =
+    ResponseEntity
+      .status(BAD_REQUEST)
+      .body(
+        ErrorResponse(
+          status = BAD_REQUEST,
+          userMessage = "File uploaded is larger than the max file size limit of ${e.maxUploadSize}MB",
+          developerMessage = "Maximum upload size of ${e.maxUploadSize}MB exceeded",
+        ),
+      ).also { log.error("Unexpected exception", e) }
 
   // The default exception handler returns a fixed text response to avoid leaking internal implementation
   // details. If you want to return a more sensible error,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/enums/DocumentType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/enums/DocumentType.kt
@@ -1,7 +1,24 @@
 package uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums
 
-enum class DocumentType {
-  LICENCE,
-  PHOTO_ID,
-  ENFORCEMENT_ZONE_MAP,
+data class FileUploadConfig(val maxSizeInMB: Long, val allowedExtensions: List<String>)
+
+enum class DocumentType(val config: FileUploadConfig) {
+  LICENCE(
+    FileUploadConfig(
+      maxSizeInMB = 25,
+      allowedExtensions = listOf("pdf", "doc", "docx"),
+    ),
+  ),
+  PHOTO_ID(
+    FileUploadConfig(
+      maxSizeInMB = 10,
+      allowedExtensions = listOf("pdf", "png", "jpeg", "jpg"),
+    ),
+  ),
+  ENFORCEMENT_ZONE_MAP(
+    FileUploadConfig(
+      maxSizeInMB = 10,
+      allowedExtensions = listOf("pdf", "jpeg", "jpg"),
+    ),
+  ),
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/validators/FileUploadValidator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/validators/FileUploadValidator.kt
@@ -1,0 +1,31 @@
+package uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.validators
+
+import jakarta.validation.ValidationException
+import org.apache.commons.io.FilenameUtils
+import org.springframework.util.StringUtils
+import org.springframework.web.multipart.MaxUploadSizeExceededException
+import org.springframework.web.multipart.MultipartFile
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.DocumentType
+
+object FileUploadValidator {
+  fun validateFileExtensionAndSize(multipartFile: MultipartFile, documentType: DocumentType) {
+    val config = documentType.config
+    val maxSizeInBytes = config.maxSizeInMB * 1024 * 1024
+    val extension = FilenameUtils.getExtension(multipartFile.originalFilename)?.lowercase()
+
+    if (!StringUtils.hasLength(extension) || !config.allowedExtensions.contains(extension)
+    ) {
+      throw ValidationException(
+        String.format(
+          "Unsupported or missing file type %s. Supported file types: %s",
+          extension,
+          config.allowedExtensions.joinToString(),
+        ),
+      )
+    }
+
+    if (multipartFile.size > maxSizeInBytes) {
+      throw MaxUploadSizeExceededException(config.maxSizeInMB)
+    }
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,10 +3,14 @@ info.app:
   version: 1.0
 
 spring:
+  servlet:
+    multipart:
+      max-file-size: 36MB
+      max-request-size: 36MB
   application:
     name: hmpps-electronic-monitoring-create-an-order-api
   codec:
-    max-in-memory-size: 10MB
+    max-in-memory-size: 36MB
   jackson:
     date-format: "yyyy-MM-dd HH:mm:ss"
     serialization:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/IntegrationTestBase.kt
@@ -68,12 +68,20 @@ abstract class IntegrationTestBase {
     hmppsAuth.stubHealthPing(status)
   }
 
-  fun mockFile(fileName: String? = "file-name.jpeg"): MockMultipartFile = MockMultipartFile(
-    "file",
-    fileName,
-    MediaType.IMAGE_JPEG_VALUE,
-    "Test file content".toByteArray(),
-  )
+  fun mockFile(fileName: String? = "file-name.jpeg", sizeInMB: Int? = 1): MockMultipartFile {
+    val testFileContent: ByteArray = if (sizeInMB != null) {
+      ByteArray(sizeInMB * 1024 * 1024) { 0 }
+    } else {
+      "Test file content".toByteArray()
+    }
+
+    return MockMultipartFile(
+      "file",
+      fileName,
+      MediaType.IMAGE_JPEG_VALUE,
+      testFileContent,
+    )
+  }
 
   fun createMultiPartBodyBuilder(multiPartFile: MockMultipartFile): MultipartBodyBuilder {
     val builder = MultipartBodyBuilder()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/AdditionalDocumentsControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/AdditionalDocumentsControllerTest.kt
@@ -35,31 +35,113 @@ class AdditionalDocumentsControllerTest : IntegrationTestBase() {
   @Nested
   @DisplayName("POST /api/orders/{orderId}/document-type/{documentType}")
   inner class UploadDocument {
-    @Suppress("ktlint:standard:max-line-length")
-    private val validationMessage = "Validation failure: Unsupported or missing file type txt. Supported file types: pdf, png, jpeg, jpg"
 
-    @Test
-    fun `it should return a validation error for an invalid file extension`() {
-      val order = createOrder()
-      val bodyBuilder = createMultiPartBodyBuilder(mockFile("filename2.txt"))
+    @Nested
+    @DisplayName("Photo ID upload")
+    inner class PhotoIDUpload {
 
-      val result = webTestClient.post()
-        .uri("/api/orders/${order.id}/document-type/${DocumentType.PHOTO_ID}")
-        .bodyValue(bodyBuilder.build())
-        .headers(setAuthorisation("AUTH_ADM"))
-        .exchange()
-        .expectStatus()
-        .isBadRequest
-        .expectBodyList(ErrorResponse::class.java)
-        .returnResult()
+      @Test
+      fun `it should return a validation error for an invalid file extension`() {
+        val order = createOrder()
+        val bodyBuilder = createMultiPartBodyBuilder(mockFile("filename1.txt"))
 
-      Assertions.assertThat(result.responseBody!!).contains(
-        ErrorResponse(
-          status = BAD_REQUEST,
-          developerMessage = "Unsupported or missing file type txt. Supported file types: pdf, png, jpeg, jpg",
-          userMessage = validationMessage,
-        ),
-      )
+        val result = webTestClient.post()
+          .uri("/api/orders/${order.id}/document-type/${DocumentType.PHOTO_ID}")
+          .bodyValue(bodyBuilder.build())
+          .headers(setAuthorisation("AUTH_ADM"))
+          .exchange()
+          .expectStatus()
+          .isBadRequest
+          .expectBodyList(ErrorResponse::class.java)
+          .returnResult()
+
+        Assertions.assertThat(result.responseBody!!).contains(
+          ErrorResponse(
+            status = BAD_REQUEST,
+            developerMessage = "Unsupported or missing file type txt. Supported file types: pdf, png, jpeg, jpg",
+            userMessage =
+            "Validation failure: Unsupported or missing file type txt. Supported file types: pdf, png, jpeg, jpg",
+          ),
+        )
+      }
+
+      @Test
+      fun `it should return a validation error for a file that is too large`() {
+        val order = createOrder()
+        val bodyBuilder = createMultiPartBodyBuilder(mockFile("filename2.pdf", 11))
+
+        val result = webTestClient.post()
+          .uri("/api/orders/${order.id}/document-type/${DocumentType.PHOTO_ID}")
+          .bodyValue(bodyBuilder.build())
+          .headers(setAuthorisation("AUTH_ADM"))
+          .exchange()
+          .expectStatus()
+          .isBadRequest
+          .expectBodyList(ErrorResponse::class.java)
+          .returnResult()
+
+        Assertions.assertThat(result.responseBody!!).contains(
+          ErrorResponse(
+            status = BAD_REQUEST,
+            developerMessage = "Maximum upload size of 10MB exceeded",
+            userMessage = "File uploaded is larger than the max file size limit of 10MB",
+          ),
+        )
+      }
+    }
+
+    @Nested
+    @DisplayName("Licence upload")
+    inner class LicenceUpload {
+
+      @Test
+      fun `it should return a validation error for an invalid file extension`() {
+        val order = createOrder()
+        val bodyBuilder = createMultiPartBodyBuilder(mockFile("filename3.txt"))
+
+        val result = webTestClient.post()
+          .uri("/api/orders/${order.id}/document-type/${DocumentType.LICENCE}")
+          .bodyValue(bodyBuilder.build())
+          .headers(setAuthorisation("AUTH_ADM"))
+          .exchange()
+          .expectStatus()
+          .isBadRequest
+          .expectBodyList(ErrorResponse::class.java)
+          .returnResult()
+
+        Assertions.assertThat(result.responseBody!!).contains(
+          ErrorResponse(
+            status = BAD_REQUEST,
+            developerMessage = "Unsupported or missing file type txt. Supported file types: pdf, doc, docx",
+            userMessage =
+            "Validation failure: Unsupported or missing file type txt. Supported file types: pdf, doc, docx",
+          ),
+        )
+      }
+
+      @Test
+      fun `it should return a validation error for a file that is too large`() {
+        val order = createOrder()
+        val bodyBuilder = createMultiPartBodyBuilder(mockFile("filename4.pdf", 26))
+
+        val result = webTestClient.post()
+          .uri("/api/orders/${order.id}/document-type/${DocumentType.LICENCE}")
+          .bodyValue(bodyBuilder.build())
+          .headers(setAuthorisation("AUTH_ADM"))
+          .exchange()
+          .expectStatus()
+          .isBadRequest
+          .expectBodyList(ErrorResponse::class.java)
+          .returnResult()
+
+        Assertions.assertThat(result.responseBody!!).contains(
+          ErrorResponse(
+            status = BAD_REQUEST,
+            developerMessage = "Maximum upload size of 25MB exceeded",
+            userMessage = "File uploaded is larger than the max file size limit of 25MB",
+          ),
+        )
+      }
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/AdditionalDocumentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/AdditionalDocumentServiceTest.kt
@@ -234,7 +234,7 @@ class AdditionalDocumentServiceTest {
       }
       Assertions.assertThat(
         e.message,
-      ).isEqualTo("Unsupported or missing file type txt. Supported file types: pdf, png, jpeg, jpg")
+      ).isEqualTo("Unsupported or missing file type txt. Supported file types: pdf, doc, docx")
     }
 
     @Test


### PR DESCRIPTION
### Context

Ticket: https://dsdmoj.atlassian.net/browse/ELM-3952

When uploading a License:
- Max file size should be 25MB
- Permitted file formats arePDF, DOC & DOCX

The allowed file types and max size for other attachment types (photo ID, exclusion zone maps) are unchanged.

### Changes proposed in this pull request

- To allow different file types to have different max upload sizes:  
  - Update the DocumentType enum to contain the max file size for each document type
  - Also move the permitted file types into this enum
  
- Create a shared upload validation utility that checks file type and size
- Increase the global `max-file-size` and `max-request-size` to 36MB. This is the maximum size of all uploads permitted by the order submission endpoint, so setting it to this value will prevent it from interfering with manually defined max file sizes for the time being. It could be set to a lower value (25MB at least) if preferred. 