### PR TITLE
ELM-3985: clear responsible adult when update device wearer

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/DeviceWearerService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/DeviceWearerService.kt
@@ -35,6 +35,11 @@ class DeviceWearerService : OrderSectionServiceBase() {
       homeOfficeReferenceNumber = order.deviceWearer?.homeOfficeReferenceNumber,
     )
 
+    // Clear responsible adult when device wearer is adult
+    if (updateRecord.adultAtTimeOfInstallation == true) {
+      order.deviceWearerResponsibleAdult = null
+    }
+
     return orderRepo.save(order).deviceWearer!!
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/DeviceWearerServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/DeviceWearerServiceTest.kt
@@ -1,0 +1,107 @@
+package uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.service
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.whenever
+import org.springframework.boot.test.autoconfigure.json.JsonTest
+import org.springframework.test.context.ActiveProfiles
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.Order
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.OrderVersion
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.ResponsibleAdult
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.dto.UpdateDeviceWearerDto
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.DataDictionaryVersion
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.OrderStatus
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.RequestType
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.repository.OrderRepository
+import java.time.ZoneId
+import java.time.ZonedDateTime
+import java.util.Optional
+import java.util.UUID
+
+@ActiveProfiles("test")
+@JsonTest
+class DeviceWearerServiceTest {
+
+  private lateinit var service: DeviceWearerService
+  private lateinit var orderRepo: OrderRepository
+  private val mockOrderId: UUID = UUID.randomUUID()
+  private val mockVersionId: UUID = UUID.randomUUID()
+  private val mockUsername: String = "username"
+  private val mockOrder = Order(
+    id = mockOrderId,
+    versions = mutableListOf(
+      OrderVersion(
+        id = mockVersionId,
+        versionId = 0,
+        status = OrderStatus.IN_PROGRESS,
+        orderId = mockOrderId,
+        type = RequestType.REQUEST,
+        username = mockUsername,
+        dataDictionaryVersion = DataDictionaryVersion.DDV4,
+        deviceWearerResponsibleAdult = ResponsibleAdult(
+          versionId = mockVersionId,
+
+        ),
+      ),
+    ),
+  )
+
+  @BeforeEach
+  fun setup() {
+    orderRepo = mock(OrderRepository::class.java)
+    service = DeviceWearerService()
+    service.orderRepo = orderRepo
+  }
+
+  @Test
+  fun `Should update device wearer`() {
+    whenever(orderRepo.findById(mockOrderId)).thenReturn(Optional.of(mockOrder))
+    whenever(orderRepo.save(mockOrder)).thenReturn(mockOrder)
+    val mockUpdateRecord = UpdateDeviceWearerDto(
+      firstName = "firstName",
+      lastName = "lastName",
+      alias = "alias",
+      adultAtTimeOfInstallation = true,
+      sex = "MALE",
+      gender = "MALE",
+      dateOfBirth = ZonedDateTime.of(1980, 1, 1, 1, 1, 1, 1, ZoneId.of("UTC")),
+      disabilities = null,
+      interpreterRequired = true,
+      language = "en",
+    )
+    service.updateDeviceWearer(mockOrderId, mockUsername, mockUpdateRecord)
+
+    assertThat(mockOrder.deviceWearer?.firstName).isEqualTo(mockUpdateRecord.firstName)
+    assertThat(mockOrder.deviceWearer?.lastName).isEqualTo(mockUpdateRecord.lastName)
+    assertThat(mockOrder.deviceWearer?.alias).isEqualTo(mockUpdateRecord.alias)
+    assertThat(mockOrder.deviceWearer?.gender).isEqualTo(mockUpdateRecord.gender)
+    assertThat(mockOrder.deviceWearer?.sex).isEqualTo(mockUpdateRecord.sex)
+    assertThat(mockOrder.deviceWearer?.adultAtTimeOfInstallation).isTrue
+    assertThat(mockOrder.deviceWearer?.dateOfBirth).isEqualTo(mockUpdateRecord.dateOfBirth)
+    assertThat(mockOrder.deviceWearer?.disabilities).isEqualTo(mockUpdateRecord.disabilities)
+    assertThat(mockOrder.deviceWearer?.interpreterRequired).isTrue
+    assertThat(mockOrder.deviceWearer?.language).isEqualTo(mockUpdateRecord.language)
+  }
+
+  @Test
+  fun `Should clear responsible adult when update record adultAtTimeOfInstallation is true`() {
+    whenever(orderRepo.findById(mockOrderId)).thenReturn(Optional.of(mockOrder))
+    whenever(orderRepo.save(mockOrder)).thenReturn(mockOrder)
+    val mockUpdateRecord = UpdateDeviceWearerDto(
+      firstName = "firstName",
+      lastName = "lastName",
+      alias = "alias",
+      adultAtTimeOfInstallation = true,
+      sex = "MALE",
+      gender = "MALE",
+      dateOfBirth = ZonedDateTime.of(1980, 1, 1, 1, 1, 1, 1, ZoneId.of("UTC")),
+      disabilities = null,
+      interpreterRequired = false,
+    )
+
+    service.updateDeviceWearer(mockOrderId, mockUsername, mockUpdateRecord)
+    assertThat(mockOrder.deviceWearerResponsibleAdult).isNull()
+  }
+}


### PR DESCRIPTION
Ticket: https://dsdmoj.atlassian.net/jira/software/c/projects/ELM/boards/4473?selectedIssue=ELM-3985

Clear device wearer responsible adult when update device wearer record adultAtTimeOfInstallation is set to true