### PR TITLE
Add order parameter table and update have photo

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/data/ValidationErrors.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/data/ValidationErrors.kt
@@ -187,5 +187,6 @@ object ValidationErrors {
   object AdditionalDocuments {
     const val INVALID_LICENSE_FILE_EXTENSION: String = "Select a PDF or Word document"
     const val INVALID_PHOTO_ID_FILE_EXTENSION: String = "Select a PDF, PNG, JPEG or JPG"
+    const val HAVE_PHOTO_REQUIRED: String = "Select if you have a photo to upload"
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/Order.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/Order.kt
@@ -24,7 +24,7 @@ data class Order(
   @OneToMany(fetch = FetchType.LAZY, cascade = [ALL], mappedBy = "order", orphanRemoval = true)
   var versions: MutableList<OrderVersion> = mutableListOf(),
 
-  ) {
+) {
   fun getCurrentVersion(): OrderVersion = versions.maxBy { it.versionId }
 
   fun deleteCurrentVersion() {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/Order.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/Order.kt
@@ -24,7 +24,7 @@ data class Order(
   @OneToMany(fetch = FetchType.LAZY, cascade = [ALL], mappedBy = "order", orphanRemoval = true)
   var versions: MutableList<OrderVersion> = mutableListOf(),
 
-) {
+  ) {
   fun getCurrentVersion(): OrderVersion = versions.maxBy { it.versionId }
 
   fun deleteCurrentVersion() {
@@ -216,5 +216,13 @@ data class Order(
   val dataDictionaryVersion: DataDictionaryVersion
     get() {
       return getCurrentVersion().dataDictionaryVersion
+    }
+
+  var orderParameters: OrderParameters?
+    get() {
+      return getCurrentVersion().orderParameters
+    }
+    set(orderParameters) {
+      getCurrentVersion().orderParameters = orderParameters
     }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/OrderParameters.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/OrderParameters.kt
@@ -20,7 +20,7 @@ data class OrderParameters(
   val versionId: UUID,
 
   @Column(name = "HAVE_PHOTO", nullable = true)
-  var havePhoto: Boolean,
+  var havePhoto: Boolean?,
 
   @Schema(hidden = true)
   @OneToOne

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/OrderParameters.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/OrderParameters.kt
@@ -1,8 +1,13 @@
 package uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models
 
 import io.swagger.v3.oas.annotations.media.Schema
-import jakarta.persistence.*
-import java.util.*
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.OneToOne
+import jakarta.persistence.Table
+import java.util.UUID
 
 @Entity
 @Table(name = "ORDER_PARAMETERS")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/OrderParameters.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/OrderParameters.kt
@@ -17,5 +17,5 @@ data class OrderParameters(
   val versionId: UUID,
 
   @Column(name = "HAVE_PHOTO", nullable = true)
-  val havePhoto: Boolean,
+  var havePhoto: Boolean,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/OrderParameters.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/OrderParameters.kt
@@ -1,0 +1,21 @@
+package uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.util.*
+
+@Entity
+@Table(name = "ORDER_PARAMETERS")
+data class OrderParameters(
+  @Id
+  @Column(name = "ID", nullable = false, unique = true)
+  val id: UUID = UUID.randomUUID(),
+
+  @Column(name = "VERSION_ID", nullable = false)
+  val versionId: UUID,
+
+  @Column(name = "HAVE_PHOTO", nullable = false)
+  val havePhoto: Boolean,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/OrderParameters.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/OrderParameters.kt
@@ -1,9 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models
 
-import jakarta.persistence.Column
-import jakarta.persistence.Entity
-import jakarta.persistence.Id
-import jakarta.persistence.Table
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.persistence.*
 import java.util.*
 
 @Entity
@@ -13,9 +11,14 @@ data class OrderParameters(
   @Column(name = "ID", nullable = false, unique = true)
   val id: UUID = UUID.randomUUID(),
 
-  @Column(name = "VERSION_ID", nullable = false)
+  @Column(name = "VERSION_ID", nullable = false, unique = true)
   val versionId: UUID,
 
   @Column(name = "HAVE_PHOTO", nullable = true)
   var havePhoto: Boolean,
+
+  @Schema(hidden = true)
+  @OneToOne
+  @JoinColumn(name = "VERSION_ID", updatable = false, insertable = false)
+  private val version: OrderVersion? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/OrderParameters.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/OrderParameters.kt
@@ -16,6 +16,6 @@ data class OrderParameters(
   @Column(name = "VERSION_ID", nullable = false)
   val versionId: UUID,
 
-  @Column(name = "HAVE_PHOTO", nullable = false)
+  @Column(name = "HAVE_PHOTO", nullable = true)
   val havePhoto: Boolean,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/OrderVersion.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/OrderVersion.kt
@@ -119,12 +119,15 @@ data class OrderVersion(
   @OneToOne(fetch = FetchType.LAZY, cascade = [ALL], mappedBy = "version", orphanRemoval = true)
   var installationAppointment: InstallationAppointment? = null,
 
+  @OneToOne(fetch = FetchType.LAZY, cascade = [ALL], mappedBy = "version", orphanRemoval = true)
+  var orderParameters: OrderParameters? = null,
+
   @Schema(hidden = true)
   @ManyToOne
   @JoinColumn(name = "ORDER_ID", updatable = false, insertable = false)
   private val order: Order? = null,
 
-) {
+  ) {
   private val adultOrHasResponsibleAdult: Boolean
     get() = (
       deviceWearer?.adultAtTimeOfInstallation == true ||

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/OrderVersion.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/OrderVersion.kt
@@ -127,7 +127,7 @@ data class OrderVersion(
   @JoinColumn(name = "ORDER_ID", updatable = false, insertable = false)
   private val order: Order? = null,
 
-  ) {
+) {
   private val adultOrHasResponsibleAdult: Boolean
     get() = (
       deviceWearer?.adultAtTimeOfInstallation == true ||

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/dto/OrderDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/dto/OrderDto.kt
@@ -15,6 +15,7 @@ import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.mo
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.InterestedParties
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.MandatoryAttendanceConditions
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.MonitoringConditions
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.OrderParameters
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.ProbationDeliveryUnit
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.ResponsibleAdult
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.TrailMonitoringConditions
@@ -79,4 +80,6 @@ data class OrderDto(
   val installationAppointment: InstallationAppointment?,
 
   val dataDictionaryVersion: DataDictionaryVersion?,
+
+  val orderParameters: OrderParameters?,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/dto/UpdateHavePhotoDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/dto/UpdateHavePhotoDto.kt
@@ -5,5 +5,5 @@ import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.da
 
 class UpdateHavePhotoDto(
   @field:NotNull(message = ValidationErrors.AdditionalDocuments.HAVE_PHOTO_REQUIRED)
-  val havePhoto: Boolean
+  val havePhoto: Boolean,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/dto/UpdateHavePhotoDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/dto/UpdateHavePhotoDto.kt
@@ -1,0 +1,9 @@
+package uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.dto
+
+import jakarta.validation.constraints.NotNull
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.data.ValidationErrors
+
+class UpdateHavePhotoDto(
+  @field:NotNull(message = ValidationErrors.AdditionalDocuments.HAVE_PHOTO_REQUIRED)
+  val havePhoto: Boolean
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/dto/UpdateHavePhotoDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/dto/UpdateHavePhotoDto.kt
@@ -5,5 +5,5 @@ import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.da
 
 class UpdateHavePhotoDto(
   @field:NotNull(message = ValidationErrors.AdditionalDocuments.HAVE_PHOTO_REQUIRED)
-  val havePhoto: Boolean,
+  val havePhoto: Boolean? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/resource/AdditionalDocumentsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/resource/AdditionalDocumentsController.kt
@@ -86,12 +86,12 @@ class AdditionalDocumentsController(@Autowired val documentService: AdditionalDo
     authentication: Authentication,
   ): ResponseEntity<OrderParameters> {
     val username = authentication.name
-    val risk = documentService.updateHavePhoto(
+    val parameters = documentService.updateHavePhoto(
       orderId,
       username,
       updateRecord,
     )
 
-    return ResponseEntity(risk, HttpStatus.OK)
+    return ResponseEntity(parameters, HttpStatus.OK)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/resource/AdditionalDocumentsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/resource/AdditionalDocumentsController.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.resource
 
+import jakarta.validation.Valid
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.core.io.InputStreamResource
 import org.springframework.http.HttpHeaders
@@ -12,11 +13,15 @@ import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestPart
 import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.multipart.MultipartFile
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.AdditionalDocument
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.OrderParameters
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.dto.UpdateHavePhotoDto
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.DocumentType
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.service.AdditionalDocumentService
 import java.util.UUID
@@ -72,5 +77,22 @@ class AdditionalDocumentsController(@Autowired val documentService: AdditionalDo
     documentService.deleteDocument(orderId, username, fileType)
 
     return ResponseEntity(HttpStatus.NO_CONTENT)
+  }
+
+  @PutMapping("/orders/{orderId}/attachments/have-photo")
+  fun havePhoto(
+    @PathVariable orderId: UUID,
+    @RequestBody @Valid updateRecord: UpdateHavePhotoDto,
+    authentication: Authentication
+  ): ResponseEntity<OrderParameters> {
+
+    val username = authentication.name
+    val risk = documentService.updateHavePhoto(
+      orderId,
+      username,
+      updateRecord,
+    )
+
+    return ResponseEntity(risk, HttpStatus.OK)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/resource/AdditionalDocumentsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/resource/AdditionalDocumentsController.kt
@@ -83,9 +83,8 @@ class AdditionalDocumentsController(@Autowired val documentService: AdditionalDo
   fun havePhoto(
     @PathVariable orderId: UUID,
     @RequestBody @Valid updateRecord: UpdateHavePhotoDto,
-    authentication: Authentication
+    authentication: Authentication,
   ): ResponseEntity<OrderParameters> {
-
     val username = authentication.name
     val risk = documentService.updateHavePhoto(
       orderId,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/resource/OrderController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/resource/OrderController.kt
@@ -111,5 +111,6 @@ class OrderController(@Autowired val orderService: OrderService) {
     installationLocation = order.installationLocation,
     installationAppointment = order.installationAppointment,
     dataDictionaryVersion = order.dataDictionaryVersion,
+    orderParameters = order.orderParameters,
   )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/AdditionalDocumentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/AdditionalDocumentService.kt
@@ -77,6 +77,9 @@ class AdditionalDocumentService(val webClient: DocumentApiClient) : OrderSection
       order.orderParameters =
         OrderParameters(versionId = order.getCurrentVersion().id, havePhoto = updateRecord.havePhoto)
     } else {
+      if (order.orderParameters?.havePhoto == true && updateRecord.havePhoto == false) {
+        order.additionalDocuments.removeAll { it.fileType == DocumentType.PHOTO_ID }
+      }
       order.orderParameters?.havePhoto = updateRecord.havePhoto
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/AdditionalDocumentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/AdditionalDocumentService.kt
@@ -6,7 +6,6 @@ import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.http.client.MultipartBodyBuilder
 import org.springframework.stereotype.Service
-import org.springframework.util.MultiValueMap
 import org.springframework.web.multipart.MultipartFile
 import reactor.core.publisher.Flux
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.client.DocumentApiClient
@@ -70,11 +69,7 @@ class AdditionalDocumentService(val webClient: DocumentApiClient) : OrderSection
     orderRepo.save(order)
   }
 
-  fun updateHavePhoto(
-    orderId: UUID,
-    username: String,
-    updateRecord: UpdateHavePhotoDto
-  ): OrderParameters {
+  fun updateHavePhoto(orderId: UUID, username: String, updateRecord: UpdateHavePhotoDto): OrderParameters {
     val order = this.findEditableOrder(orderId, username)
 
     // Either update current params or create a new record if one does not exist for this order version

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/AdditionalDocumentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/AdditionalDocumentService.kt
@@ -6,11 +6,14 @@ import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.http.client.MultipartBodyBuilder
 import org.springframework.stereotype.Service
+import org.springframework.util.MultiValueMap
 import org.springframework.web.multipart.MultipartFile
 import reactor.core.publisher.Flux
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.client.DocumentApiClient
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.AdditionalDocument
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.OrderParameters
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.documentmanagement.DocumentMetadata
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.dto.UpdateHavePhotoDto
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.DocumentType
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.validators.FileUploadValidator.validateFileExtensionAndSize
 import java.util.*
@@ -65,5 +68,23 @@ class AdditionalDocumentService(val webClient: DocumentApiClient) : OrderSection
     order.additionalDocuments.add(document)
 
     orderRepo.save(order)
+  }
+
+  fun updateHavePhoto(
+    orderId: UUID,
+    username: String,
+    updateRecord: UpdateHavePhotoDto
+  ): OrderParameters {
+    val order = this.findEditableOrder(orderId, username)
+
+    // Either update current params or create a new record if one does not exist for this order version
+    if (order.orderParameters == null) {
+      order.orderParameters =
+        OrderParameters(versionId = order.getCurrentVersion().id, havePhoto = updateRecord.havePhoto)
+    } else {
+      order.orderParameters?.havePhoto = updateRecord.havePhoto
+    }
+
+    return orderRepo.save(order).orderParameters!!
   }
 }

--- a/src/main/resources/db/migration/V14__Add_Order_Parameter_Table.sql
+++ b/src/main/resources/db/migration/V14__Add_Order_Parameter_Table.sql
@@ -1,7 +1,0 @@
-CREATE TABLE order_parameters
-(
-    id         UUID NOT NULL,
-    version_id UUID NOT NULL,
-    have_photo BOOLEAN,
-    CONSTRAINT pk_order_parameters PRIMARY KEY (id)
-);

--- a/src/main/resources/db/migration/V14__Add_Order_Parameter_Table.sql
+++ b/src/main/resources/db/migration/V14__Add_Order_Parameter_Table.sql
@@ -1,0 +1,7 @@
+CREATE TABLE order_parameters
+(
+    id         UUID NOT NULL,
+    version_id UUID NOT NULL,
+    have_photo BOOLEAN,
+    CONSTRAINT pk_order_parameters PRIMARY KEY (id)
+);

--- a/src/main/resources/db/migration/V14__Add_Order_Parameters_Table.sql
+++ b/src/main/resources/db/migration/V14__Add_Order_Parameters_Table.sql
@@ -1,0 +1,13 @@
+CREATE TABLE order_parameters
+(
+    id         UUID NOT NULL,
+    version_id UUID NOT NULL,
+    have_photo BOOLEAN,
+    CONSTRAINT pk_order_parameters PRIMARY KEY (id)
+);
+
+ALTER TABLE order_parameters
+    ADD CONSTRAINT uc_order_parameters_version UNIQUE (version_id);
+
+ALTER TABLE order_parameters
+    ADD CONSTRAINT FK_ORDER_PARAMETERS_ON_VERSION FOREIGN KEY (version_id) REFERENCES order_version (id);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/resources/AdditionalDocumentsControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/resources/AdditionalDocumentsControllerTest.kt
@@ -1,0 +1,49 @@
+package uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.resources
+
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import org.springframework.security.core.Authentication
+import org.springframework.test.context.ActiveProfiles
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.OrderParameters
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.dto.UpdateHavePhotoDto
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.resource.AdditionalDocumentsController
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.service.AdditionalDocumentService
+import java.util.*
+
+@ActiveProfiles("test")
+class AdditionalDocumentsControllerTest {
+  private val service: AdditionalDocumentService = mock()
+  private val controller = AdditionalDocumentsController(service)
+  private val mockUser: String = "mockUser"
+  private lateinit var authentication: Authentication
+  private lateinit var mockOrderId: UUID
+
+  @BeforeEach
+  fun setup() {
+    authentication = mock(Authentication::class.java)
+    mockOrderId = UUID.randomUUID()
+  }
+
+  @Test
+  fun `update have photo boolean`() {
+    `when`(authentication.name).thenReturn(mockUser)
+
+    val input = UpdateHavePhotoDto(havePhoto = true)
+    val mockOrderParameters = OrderParameters(versionId = UUID.randomUUID(), havePhoto = true)
+    `when`(
+      service.updateHavePhoto(
+        orderId = mockOrderId,
+        username = mockUser,
+        updateRecord = input,
+      ),
+    ).thenReturn(mockOrderParameters)
+
+    val result = controller.havePhoto(mockOrderId, input, authentication)
+
+    Assertions.assertThat(result.statusCode.is2xxSuccessful)
+    Assertions.assertThat(result.body).isEqualTo(mockOrderParameters)
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/resources/OrderControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/resources/OrderControllerTest.kt
@@ -110,6 +110,7 @@ class OrderControllerTest {
         installationLocation = null,
         installationAppointment = null,
         dataDictionaryVersion = mockDictionaryVersion,
+        orderParameters = null,
       ),
     )
   }
@@ -179,6 +180,7 @@ class OrderControllerTest {
           installationLocation = null,
           installationAppointment = null,
           dataDictionaryVersion = mockDictionaryVersion,
+          orderParameters = null,
         ),
         OrderDto(
           id = orderId2,
@@ -208,6 +210,7 @@ class OrderControllerTest {
           installationLocation = null,
           installationAppointment = null,
           dataDictionaryVersion = mockDictionaryVersion,
+          orderParameters = null,
         ),
       ),
     )
@@ -278,6 +281,7 @@ class OrderControllerTest {
           installationLocation = null,
           installationAppointment = null,
           dataDictionaryVersion = mockDictionaryVersion,
+          orderParameters = null,
         ),
         OrderDto(
           id = orderId2,
@@ -307,6 +311,7 @@ class OrderControllerTest {
           installationLocation = null,
           installationAppointment = null,
           dataDictionaryVersion = mockDictionaryVersion,
+          orderParameters = null,
         ),
       ),
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/AdditionalDocumentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/AdditionalDocumentServiceTest.kt
@@ -26,7 +26,9 @@ import reactor.core.publisher.Flux
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.client.DocumentApiClient
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.AdditionalDocument
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.Order
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.OrderParameters
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.OrderVersion
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.dto.UpdateHavePhotoDto
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.DataDictionaryVersion
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.DocumentType
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.OrderStatus
@@ -402,6 +404,118 @@ class AdditionalDocumentServiceTest {
           ).isEqualTo("DocumentMetadata(orderId=$mockOrderId, documentType=LICENCE)")
         }
       }
+    }
+  }
+
+  @Nested
+  @DisplayName("havePhoto")
+  inner class HavePhoto {
+    @Test
+    fun `should create a new order parameters if one does not exist`() {
+      val mockOrder = Order(
+        id = mockOrderId,
+        versions = mutableListOf(
+          OrderVersion(
+            id = mockVersionId,
+            status = OrderStatus.IN_PROGRESS,
+            type = RequestType.REQUEST,
+            username = username,
+            orderId = mockOrderId,
+            dataDictionaryVersion = mockDictionaryVersion,
+          ),
+        ),
+      )
+      whenever(
+        orderRepo.findById(mockOrderId),
+      ).thenReturn(
+        Optional.of(
+          mockOrder,
+        ),
+      )
+      whenever(orderRepo.save(mockOrder)).thenReturn(mockOrder)
+
+      val result = service.updateHavePhoto(
+        mockOrderId,
+        username,
+        updateRecord = UpdateHavePhotoDto(havePhoto = true),
+      )
+      Assertions.assertThat(result.havePhoto).isEqualTo(true)
+      Assertions.assertThat(result.versionId).isEqualTo(mockVersionId)
+    }
+
+    @Test
+    fun `should update order parameters if they already exist`() {
+      val mockOrder = Order(
+        id = mockOrderId,
+        versions = mutableListOf(
+          OrderVersion(
+            id = mockVersionId,
+            status = OrderStatus.IN_PROGRESS,
+            type = RequestType.REQUEST,
+            username = username,
+            orderId = mockOrderId,
+            dataDictionaryVersion = mockDictionaryVersion,
+            orderParameters = OrderParameters(havePhoto = false, versionId = mockVersionId),
+          ),
+        ),
+      )
+      whenever(
+        orderRepo.findById(mockOrderId),
+      ).thenReturn(
+        Optional.of(
+          mockOrder,
+        ),
+      )
+      whenever(orderRepo.save(mockOrder)).thenReturn(mockOrder)
+
+      val result = service.updateHavePhoto(
+        mockOrderId,
+        username,
+        updateRecord = UpdateHavePhotoDto(havePhoto = true),
+      )
+      Assertions.assertThat(result.havePhoto).isEqualTo(true)
+      Assertions.assertThat(result.versionId).isEqualTo(mockVersionId)
+    }
+
+    @Test
+    fun `should delete photo if have photo is set to false`() {
+      val mockOrder = Order(
+        id = mockOrderId,
+        versions = mutableListOf(
+          OrderVersion(
+            id = mockVersionId,
+            status = OrderStatus.IN_PROGRESS,
+            type = RequestType.REQUEST,
+            username = username,
+            orderId = mockOrderId,
+            dataDictionaryVersion = mockDictionaryVersion,
+            orderParameters = OrderParameters(havePhoto = true, versionId = mockVersionId),
+            additionalDocuments = mutableListOf(
+              AdditionalDocument(versionId = mockVersionId, fileType = DocumentType.PHOTO_ID),
+              AdditionalDocument(versionId = mockVersionId, fileType = DocumentType.LICENCE),
+            ),
+          ),
+        ),
+      )
+      whenever(
+        orderRepo.findById(mockOrderId),
+      ).thenReturn(
+        Optional.of(
+          mockOrder,
+        ),
+      )
+      whenever(orderRepo.save(mockOrder)).thenReturn(mockOrder)
+
+      val result = service.updateHavePhoto(
+        mockOrderId,
+        username,
+        updateRecord = UpdateHavePhotoDto(havePhoto = false),
+      )
+      Assertions.assertThat(result.havePhoto).isEqualTo(false)
+      Assertions.assertThat(result.versionId).isEqualTo(mockVersionId)
+      Assertions.assertThat(mockOrder.additionalDocuments.size).isEqualTo(1)
+      Assertions.assertThat(mockOrder.additionalDocuments.filter { x -> x.fileType == DocumentType.PHOTO_ID }.size)
+        .isEqualTo(0)
     }
   }
 }


### PR DESCRIPTION
Create a new Order Parameters table

Backend changes required for: https://dsdmoj.atlassian.net/browse/ELM-3425

This will be used any time we need a "yes" "no" page in the frontend that will lead to future pages being / not being rendered

I have also added an endpoint to update the "havePhoto" boolean which will be used in the new additional documents flow
When the user changes from "yes" to "no", the photo attachment is deleted