### PR TITLE
Enforcement zone map upload validation: Allow PNGs.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/data/ValidationErrors.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/data/ValidationErrors.kt
@@ -75,7 +75,7 @@ object ValidationErrors {
     const val END_DATE_MUST_BE_IN_FUTURE: String = "Exclusion zone end date must be in the future"
     const val START_DATE_REQUIRED: String = "Exclusion zone start date is required"
     const val TYPE_REQUIRED: String = "Exclusion Zone type is required"
-    const val INVALID_MAP_FILE_EXTENSION: String = "Select a PDF, JPEG or JPG"
+    const val INVALID_MAP_FILE_EXTENSION: String = "Select a PDF, PNG, JPEG or JPG"
   }
 
   object IdentityNumbers {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/enums/DocumentType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/enums/DocumentType.kt
@@ -26,7 +26,7 @@ enum class DocumentType(val config: FileUploadConfig) {
   ENFORCEMENT_ZONE_MAP(
     FileUploadConfig(
       maxSizeInMB = 10,
-      allowedExtensions = listOf("pdf", "jpeg", "jpg"),
+      allowedExtensions = listOf("pdf", "png", "jpeg", "jpg"),
       invalidExtensionMessage = ValidationErrors.EnforcementZone.INVALID_MAP_FILE_EXTENSION,
     ),
   ),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/EnforcementZoneService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/EnforcementZoneService.kt
@@ -16,8 +16,6 @@ import java.util.*
 @Service
 class EnforcementZoneService(val webClient: DocumentApiClient) : OrderSectionServiceBase() {
 
-  val allowedFileExtensions: List<String> = listOf("pdf", "jpeg", "jpg")
-
   fun updateEnforcementZone(orderId: UUID, username: String, updateRecord: UpdateEnforcementZoneDto) {
     val order = findEditableOrder(orderId, username)
     val zone = order.enforcementZoneConditions.firstOrNull { it.zoneId == updateRecord.zoneId }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/EnforcementZoneControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/EnforcementZoneControllerTest.kt
@@ -359,8 +359,8 @@ class EnforcementZoneControllerTest : IntegrationTestBase() {
       Assertions.assertThat(result.responseBody!!).contains(
         ErrorResponse(
           status = BAD_REQUEST,
-          developerMessage = "Validation failure: Select a PDF, JPEG or JPG",
-          userMessage = "Select a PDF, JPEG or JPG",
+          developerMessage = "Validation failure: Select a PDF, PNG, JPEG or JPG",
+          userMessage = "Select a PDF, PNG, JPEG or JPG",
         ),
       )
     }


### PR DESCRIPTION
### Context

Ticket: https://dsdmoj.atlassian.net/browse/ELM-4023

Users should be able to upload PNG format enforcement zone maps.

### Changes proposed in this pull request

- Permit upload of PNG enforcement zone maps
- Update validation error messages.
- Remove an obsolete `allowedFileExtensions` variable.
