### PR TITLE
Update README for running backend locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ There are a couple of options for doing so such as [curl](https://curl.se/) or
 The [Create an Electronic Monitoring Order UI](https://github.com/ministryofjustice/hmpps-electronic-monitoring-create-an-order) uses HMPPS Auth in development (rather than locally with Docker).
 
 To interact with the API using the front end, with both running locally:
-1. In the application-local.yml file in the API, change the HMPPS Auth URL value from http://localhost:8090/auth to https://sign-in-dev.hmpps.service.justice.gov.uk/auth
+1. In the application-local.yml file in the API, comment out the localhost URLs and uncomment the dev URLs for both HMPPS Auth and Document Management
 2. Run the UI locally, using [the UI documentation](https://github.com/ministryofjustice/hmpps-electronic-monitoring-create-an-order)
 3. Run the API locally using the same steps outlined in [get started](#get-started), but replacing the command in step 1 with `docker compose pull && docker compose up --scale hmpps-electronic-monitoring-create-an-order-api=0 --scale hmpps-auth=0` to start a docker instance of the database but not HMPPS Auth.
 

--- a/README.md
+++ b/README.md
@@ -157,4 +157,4 @@ There is no need to generate a HMPPS Auth token, as authentication is handled by
    `docker compose -f docker-compose-test.yml up`
 2.  Using command line to run integration test:
 
-    `./gradlew integration` 
+    `./gradlew integration`

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ There are a couple of options for doing so such as [curl](https://curl.se/) or
 
 #### Running both the UI And the API locally
 
-The [Create an Electronic Monitoring Order UI](https://github.com/ministryofjustice/hmpps-electronic-monitoring-create-an-order) uses HMPPS Auth in development (rather than locally with Docker).
+The [Create an Electronic Monitoring Order UI](https://github.com/ministryofjustice/hmpps-electronic-monitoring-create-an-order) uses HMPPS Auth and Document api in development (rather than locally with Docker).
 
 To interact with the API using the front end, with both running locally:
 1. In the application-local.yml file in the API, comment out the localhost URLs and uncomment the dev URLs for both HMPPS Auth and Document Management

--- a/README.md
+++ b/README.md
@@ -157,4 +157,4 @@ There is no need to generate a HMPPS Auth token, as authentication is handled by
    `docker compose -f docker-compose-test.yml up`
 2.  Using command line to run integration test:
 
-    `./gradlew integration`
+    `./gradlew integration` 

--- a/scripts/create-env.sh
+++ b/scripts/create-env.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 SECRETS=$(kubectl get secret serco-secret -o json -n hmpps-ems-cemo-ui-dev)
+DOCUMENT_SECRETS=$(kubectl get secret hmpps-electronic-monitoring-create-an-order-api -o json -n hmpps-ems-cemo-ui-dev)
 
 # Auth
 echo "HMPPS_AUTH_URL=https://sign-in-dev.hmpps.service.justice.gov.uk/auth" > .env
@@ -13,6 +14,8 @@ echo "DB_PASS=postgres" >> .env
 
 # Document Management API
 echo "DOCUMENT_MANAGEMENT_URL=http://localhost:8081/" >> .env
+echo "CLIENT_ID=$(jq -r '.data.API_CLIENT_ID' <<< "${DOCUMENT_SECRETS}" | base64 -d)" >> .env
+echo "CLIENT_SECRET=$(jq -r '.data.API_CLIENT_SECRET' <<< "${DOCUMENT_SECRETS}" | base64 -d)" >> .env
 
 # FMS Integration
 echo "SERCO_AUTH_URL=$(jq -r '.data.SERCO_AUTH_URL' <<< "${SECRETS}" | base64 -d)" >> .env

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -28,9 +28,10 @@ hmpps.s3:
 services:
   hmppsauth:
     url: http://localhost:9090/auth
-    # url: https://sign-in-dev.hmpps.service.justice.gov.uk/auth
+#    url: https://sign-in-dev.hmpps.service.justice.gov.uk/auth
+  document:
+    url: http://localhost:8081/
+#    url: https://document-api-dev.hmpps.service.justice.gov.uk/
 
-DOCUMENT_MANAGEMENT_URL:  http://localhost:8081/
-#DOCUMENT_MANAGEMENT_URL:  https://document-api-dev.hmpps.service.justice.gov.uk/
 CLIENT_ID: hmpps-electronic-monitoring-create-an-order-api
 CLIENT_SECRET: clientsecret


### PR DESCRIPTION
Use dev url for **document management api** when running locally

Update .env script for document management api secrets