### PR TITLE
Elm-4052: pilots

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/MonitoringConditions.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/MonitoringConditions.kt
@@ -12,6 +12,7 @@ import jakarta.persistence.Table
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.MonitoringConditionType
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.OrderType
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.OrderTypeDescription
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.Pilot
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.SentenceType
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.YesNoUnknown
 import java.time.ZonedDateTime
@@ -79,8 +80,9 @@ data class MonitoringConditions(
   @Column(name = "PRARR", nullable = true)
   var prarr: YesNoUnknown? = null,
 
+  @Enumerated(EnumType.STRING)
   @Column(name = "PILOT", nullable = true)
-  var pilot: String? = null,
+  var pilot: Pilot? = null,
 
   @Schema(hidden = true)
   @OneToOne

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/dto/UpdateMonitoringConditionsDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/dto/UpdateMonitoringConditionsDto.kt
@@ -7,6 +7,7 @@ import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.da
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.MonitoringConditionType
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.OrderType
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.OrderTypeDescription
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.Pilot
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.SentenceType
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.YesNoUnknown
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.resource.validator.AtLeastOneSelected
@@ -50,7 +51,7 @@ data class UpdateMonitoringConditionsDto(
 
   val prarr: YesNoUnknown = YesNoUnknown.UNKNOWN,
 
-  val pilot: String? = null,
+  val pilot: Pilot? = null,
 ) {
   @AssertTrue(message = ValidationErrors.MonitoringConditions.END_DATE_MUST_BE_AFTER_START_DATE)
   fun isEndDate(): Boolean {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/enums/Pilot.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/enums/Pilot.kt
@@ -7,7 +7,7 @@ enum class Pilot(val value: String) {
   DOMESTIC_ABUSE_PROTECTION_ORDER("Domestic Abuse Protection Order (DAPO)"),
   DOMESTIC_ABUSE_PERPETRATOR_ON_LICENCE_DAPOL("Domestic Abuse Perpetrator on Licence (DAPOL)"),
   DOMESTIC_ABUSE_PERPETRATOR_ON_LICENCE_HOME_DETENTION_CURFEW_DAPOL_HDC(
-    "Domestic Abuse Perpetrator on Licence Home Detention Curfew (DAPOL HDC))",
+    "Domestic Abuse Perpetrator on Licence Home Detention Curfew (DAPOL HDC)",
   ),
   GPS_ACQUISITIVE_CRIME_HOME_DETENTION_CURFEW("GPS Acquisitive Crime Home Detention Curfew"),
   GPS_ACQUISITIVE_CRIME_PAROLE("GPS Acquisitive Crime Parole"),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/enums/Pilot.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/enums/Pilot.kt
@@ -1,0 +1,15 @@
+package uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums
+
+enum class Pilot(val value: String) {
+  ACQUISITIVE_CRIME_PROJECT("Acquisitive Crime Project"),
+  DOMESTIC_ABUSE_PERPETRATOR_ON_LICENCE_PROJECT("Domestic Abuse perpetrators on Licence Project"),
+  LICENCE_VARIATION_PROJECT("Licence Variation Project"),
+  DOMESTIC_ABUSE_PROTECTION_ORDER("Domestic Abuse Protection Order (DAPO)"),
+  DOMESTIC_ABUSE_PERPETRATOR_ON_LICENCE_DAPOL("Domestic Abuse Perpetrator on Licence (DAPOL)"),
+  DOMESTIC_ABUSE_PERPETRATOR_ON_LICENCE_HOME_DETENTION_CURFEW_DAPOL_HDC(
+    "Domestic Abuse Perpetrator on Licence Home Detention Curfew (DAPOL HDC))",
+  ),
+  GPS_ACQUISITIVE_CRIME_HOME_DETENTION_CURFEW("GPS Acquisitive Crime Home Detention Curfew"),
+  GPS_ACQUISITIVE_CRIME_PAROLE("GPS Acquisitive Crime Parole"),
+  UNKNOWN(""),
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/fms/MonitoringOrder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/fms/MonitoringOrder.kt
@@ -203,8 +203,8 @@ data class MonitoringOrder(
   var hdc: String = "",
   @JsonProperty("order_status")
   var orderStatus: String? = "",
-//  @JsonProperty("pilot")
-//  var pilot: String? = "",
+  @JsonProperty("pilot")
+  var pilot: String? = "",
 ) {
 
   companion object {
@@ -233,7 +233,7 @@ data class MonitoringOrder(
         orderId = order.id.toString(),
         orderStatus = "Not Started",
         offence = getOffence(order),
-        // pilot = conditions.pilot?.value?:"",
+        pilot = conditions.pilot?.value ?: "",
       )
 
       monitoringOrder.sentenceType = conditions.sentenceType?.value ?: ""

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/fms/MonitoringOrder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/fms/MonitoringOrder.kt
@@ -203,6 +203,8 @@ data class MonitoringOrder(
   var hdc: String = "",
   @JsonProperty("order_status")
   var orderStatus: String? = "",
+//  @JsonProperty("pilot")
+//  var pilot: String? = "",
 ) {
 
   companion object {
@@ -231,6 +233,7 @@ data class MonitoringOrder(
         orderId = order.id.toString(),
         orderStatus = "Not Started",
         offence = getOffence(order),
+        // pilot = conditions.pilot?.value?:"",
       )
 
       monitoringOrder.sentenceType = conditions.sentenceType?.value ?: ""

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/MonitoringConditionsControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/MonitoringConditionsControllerTest.kt
@@ -4,14 +4,13 @@ import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.http.MediaType
-import org.springframework.test.web.reactive.server.expectBody
-import org.springframework.test.web.reactive.server.returnResult
 import org.springframework.web.reactive.function.BodyInserters
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.MonitoringConditions
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.MonitoringConditionType
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.OrderType
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.OrderTypeDescription
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.Pilot
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.SentenceType
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.YesNoUnknown
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.resource.validator.ValidationError
@@ -526,7 +525,7 @@ class MonitoringConditionsControllerTest : IntegrationTestBase() {
               "alcohol": null,
               "startDate": "$mockStartDate",
               "endDate": "$mockEndDate",
-              "pilot": "some pilot"
+              "pilot": "ACQUISITIVE_CRIME_PROJECT"
             }
           """.trimIndent(),
         ),
@@ -538,6 +537,6 @@ class MonitoringConditionsControllerTest : IntegrationTestBase() {
       .expectBody(MonitoringConditions::class.java)
       .returnResult()
 
-    Assertions.assertThat(updateMonitoringConditions.responseBody?.pilot).isEqualTo("some pilot")
+    Assertions.assertThat(updateMonitoringConditions.responseBody?.pilot).isEqualTo(Pilot.ACQUISITIVE_CRIME_PROJECT)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/OrderControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/OrderControllerTest.kt
@@ -1,5 +1,8 @@
 package uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.integration.resource
 
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
@@ -53,6 +56,7 @@ import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.mo
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.fms.FmsErrorResponse
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.fms.FmsResponse
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.fms.FmsResult
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.fms.MonitoringOrder
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.repository.FmsSubmissionResultRepository
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 import java.time.DayOfWeek
@@ -60,13 +64,14 @@ import java.time.ZoneId
 import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
 import java.util.*
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.fms.DeviceWearer as FmsDeviceWearer
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.fms.ErrorResponse as FmsErrorResponseDetails
 
 class OrderControllerTest : IntegrationTestBase() {
 
   @Autowired
   lateinit var fmsResultRepository: FmsSubmissionResultRepository
-
+  private val objectMapper: ObjectMapper = jacksonObjectMapper()
   val mockStartDate: ZonedDateTime = ZonedDateTime.now().plusMonths(1)
   val mockEndDate: ZonedDateTime = ZonedDateTime.now().plusMonths(2)
 
@@ -1201,8 +1206,14 @@ class OrderControllerTest : IntegrationTestBase() {
       }
       """.trimIndent()
 
-      assertThat(submitResult!!.deviceWearerResult.payload).isEqualTo(expectedDWJson.removeWhitespaceAndNewlines())
-      assertThat(submitResult.monitoringOrderResult.payload).isEqualTo(expectedOrderJson.removeWhitespaceAndNewlines())
+      val expectedDeviceWearer = objectMapper.readValue<FmsDeviceWearer>(expectedDWJson)
+      val storedDeviceWearer = objectMapper.readValue<FmsDeviceWearer>(submitResult!!.deviceWearerResult.payload)
+      assertThat(expectedDeviceWearer).isEqualTo(storedDeviceWearer)
+
+      val expectedMonitoringOrder = objectMapper.readValue<MonitoringOrder>(expectedOrderJson)
+      val storedMonitoringOrder = objectMapper.readValue<MonitoringOrder>(submitResult.monitoringOrderResult.payload)
+      assertThat(expectedMonitoringOrder).isEqualTo(storedMonitoringOrder)
+
       assertThat(submitResult.attachmentResults[0].sysId).isEqualTo("MockSysId")
       assertThat(
         submitResult.attachmentResults[0].fileType,
@@ -1577,8 +1588,13 @@ class OrderControllerTest : IntegrationTestBase() {
       assertThat(submitResult!!.success).isEqualTo(true)
       assertThat(submitResult.error).isEqualTo("")
 
-      assertThat(submitResult.deviceWearerResult.payload).isEqualTo(expectedDWJson.removeWhitespaceAndNewlines())
-      assertThat(submitResult.monitoringOrderResult.payload).isEqualTo(expectedOrderJson.removeWhitespaceAndNewlines())
+      val expectedDeviceWearer = objectMapper.readValue<FmsDeviceWearer>(expectedDWJson)
+      val storedDeviceWearer = objectMapper.readValue<FmsDeviceWearer>(submitResult.deviceWearerResult.payload)
+      assertThat(expectedDeviceWearer).isEqualTo(storedDeviceWearer)
+
+      val expectedMonitoringOrder = objectMapper.readValue<MonitoringOrder>(expectedOrderJson)
+      val storedMonitoringOrder = objectMapper.readValue<MonitoringOrder>(submitResult.monitoringOrderResult.payload)
+      assertThat(expectedMonitoringOrder).isEqualTo(storedMonitoringOrder)
 
       assertThat(submitResult.attachmentResults[0])
         .usingRecursiveComparison()
@@ -1957,8 +1973,13 @@ class OrderControllerTest : IntegrationTestBase() {
       }
       """.trimIndent()
 
-      assertThat(submitResult!!.deviceWearerResult.payload).isEqualTo(expectedDWJson.removeWhitespaceAndNewlines())
-      assertThat(submitResult.monitoringOrderResult.payload).isEqualTo(expectedOrderJson.removeWhitespaceAndNewlines())
+      val expectedDeviceWearer = objectMapper.readValue<FmsDeviceWearer>(expectedDWJson)
+      val storedDeviceWearer = objectMapper.readValue<FmsDeviceWearer>(submitResult!!.deviceWearerResult.payload)
+      assertThat(expectedDeviceWearer).isEqualTo(storedDeviceWearer)
+
+      val expectedMonitoringOrder = objectMapper.readValue<MonitoringOrder>(expectedOrderJson)
+      val storedMonitoringOrder = objectMapper.readValue<MonitoringOrder>(submitResult.monitoringOrderResult.payload)
+      assertThat(expectedMonitoringOrder).isEqualTo(storedMonitoringOrder)
       val updatedOrder = getOrder(order.id)
       assertThat(updatedOrder.fmsResultId).isEqualTo(submitResult.id)
       assertThat(updatedOrder.status).isEqualTo(OrderStatus.SUBMITTED)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/scenarios/ScenarioTests.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/scenarios/ScenarioTests.kt
@@ -120,6 +120,7 @@ class ScenarioTests : IntegrationTestBase() {
     val expectedMonitoringOrder = objectMapper.readValue<MonitoringOrder>(expectedOrderJson)
 
     // Assert
+
     val storedDeviceWearer = objectMapper.readValue<DeviceWearer>(submitResult.deviceWearerResult.payload)
     assertThat(expectedDeviceWearer).isEqualTo(storedDeviceWearer)
 
@@ -159,13 +160,16 @@ class ScenarioTests : IntegrationTestBase() {
     val expectedVariationJson = Files.readString(Paths.get("$rootFilePath/expected_variation.json"))
       .replace("{expectedOderId}", submitResult.orderId.toString())
 
+    val expectedDeviceWearer = objectMapper.readValue<DeviceWearer>(expectedDeviceWearerJson)
+
+    val expectedMonitoringOrder = objectMapper.readValue<MonitoringOrder>(expectedVariationJson)
+
     // Assert
-    assertThat(
-      submitResult.deviceWearerResult.payload,
-    ).isEqualTo(expectedDeviceWearerJson.removeWhitespaceAndNewlines())
-    assertThat(
-      submitResult.monitoringOrderResult.payload,
-    ).isEqualTo(expectedVariationJson.removeWhitespaceAndNewlines())
+    val storedDeviceWearer = objectMapper.readValue<DeviceWearer>(submitResult.deviceWearerResult.payload)
+    assertThat(expectedDeviceWearer).isEqualTo(storedDeviceWearer)
+
+    val storedMonitoringOrder = objectMapper.readValue<MonitoringOrder>(submitResult.monitoringOrderResult.payload)
+    assertThat(expectedMonitoringOrder).isEqualTo(storedMonitoringOrder)
   }
 
   private fun getOrderFromFile(filePath: String): Order {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/scenarios/ScenarioTests.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/scenarios/ScenarioTests.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.integration.scenarios
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
@@ -14,10 +15,12 @@ import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.in
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.integration.wiremock.SercoAuthMockServerExtension.Companion.sercoAuthApi
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.integration.wiremock.SercoMockApiExtension.Companion.sercoApi
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.Order
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.fms.DeviceWearer
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.fms.FmsAttachmentResponse
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.fms.FmsAttachmentResult
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.fms.FmsResponse
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.fms.FmsResult
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.fms.MonitoringOrder
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.repository.FmsSubmissionResultRepository
 import java.nio.file.Files
 import java.nio.file.Paths
@@ -25,6 +28,8 @@ import java.nio.file.Paths
 class ScenarioTests : IntegrationTestBase() {
   @Autowired
   lateinit var fmsResultRepository: FmsSubmissionResultRepository
+
+  private val objectMapper: ObjectMapper = jacksonObjectMapper()
 
   @BeforeEach
   fun setup() {
@@ -110,13 +115,16 @@ class ScenarioTests : IntegrationTestBase() {
     val expectedOrderJson = Files.readString(Paths.get("$rootFilePath/expected_order.json"))
       .replace("{expectedOderId}", submitResult.orderId.toString())
 
+    val expectedDeviceWearer = objectMapper.readValue<DeviceWearer>(expectedDeviceWearerJson)
+
+    val expectedMonitoringOrder = objectMapper.readValue<MonitoringOrder>(expectedOrderJson)
+
     // Assert
-    assertThat(
-      submitResult.deviceWearerResult.payload,
-    ).isEqualTo(expectedDeviceWearerJson.removeWhitespaceAndNewlines())
-    assertThat(
-      submitResult.monitoringOrderResult.payload,
-    ).isEqualTo(expectedOrderJson.removeWhitespaceAndNewlines())
+    val storedDeviceWearer = objectMapper.readValue<DeviceWearer>(submitResult.deviceWearerResult.payload)
+    assertThat(expectedDeviceWearer).isEqualTo(storedDeviceWearer)
+
+    val storedMonitoringOrder = objectMapper.readValue<MonitoringOrder>(submitResult.monitoringOrderResult.payload)
+    assertThat(expectedMonitoringOrder).isEqualTo(storedMonitoringOrder)
   }
 
   fun runVariationTest(rootFilePath: String) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/model/OrderTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/model/OrderTestBase.kt
@@ -20,6 +20,7 @@ import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.mo
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.OrderStatus
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.OrderType
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.OrderTypeDescription
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.Pilot
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.RequestType
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.SentenceType
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.YesNoUnknown
@@ -200,6 +201,7 @@ abstract class OrderTestBase {
     alcohol: Boolean = false,
     mandatoryAttendance: Boolean = false,
     exclusionZone: Boolean = false,
+    pilot: Pilot = Pilot.UNKNOWN,
   ): MonitoringConditions = MonitoringConditions(
     versionId = UUID.randomUUID(),
     orderType = orderType,
@@ -216,6 +218,7 @@ abstract class OrderTestBase {
     alcohol = alcohol,
     mandatoryAttendance = mandatoryAttendance,
     exclusionZone = exclusionZone,
+    pilot = pilot,
   )
 
   protected fun createMandatoryAttendanceCondition(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/model/fms/MonitoringOrderTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/model/fms/MonitoringOrderTest.kt
@@ -7,6 +7,7 @@ import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import org.springframework.test.context.ActiveProfiles
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.model.OrderTestBase
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.Pilot
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.fms.EnforceableCondition
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.fms.MonitoringOrder
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.fms.Zone
@@ -81,6 +82,17 @@ class MonitoringOrderTest : OrderTestBase() {
     val fmsMonitoringOrder = MonitoringOrder.fromOrder(order, null)
 
     assertThat(fmsMonitoringOrder.noName).isEqualTo(mappedValue)
+  }
+
+  @ParameterizedTest(name = "it should map pilot to Serco - {0} -> {1}")
+  @MethodSource("getPilots")
+  fun `It should map correctly map saved pilots values to Serco`(savedValue: String, mappedValue: String) {
+    val order = createOrder(
+      monitoringConditions = createMonitoringConditions(pilot = Pilot.entries.first { it.name == savedValue }),
+    )
+    val fmsMonitoringOrder = MonitoringOrder.fromOrder(order, null)
+
+    assertThat(fmsMonitoringOrder.pilot).isEqualTo(mappedValue)
   }
 
   companion object {
@@ -346,6 +358,22 @@ class MonitoringOrderTest : OrderTestBase() {
       Arguments.of("WOODHILL_PRISON", "Woodhill Prison"),
       Arguments.of("WORMWOOD_SCRUBS_PRISON", "Wormwood Scrubs Prison"),
       Arguments.of("WYMOTT_PRISON", "Wymott Prison"),
+    )
+
+    @JvmStatic
+    fun getPilots() = listOf(
+      Arguments.of("ACQUISITIVE_CRIME_PROJECT", "Acquisitive Crime Project"),
+      Arguments.of("DOMESTIC_ABUSE_PERPETRATOR_ON_LICENCE_PROJECT", "Domestic Abuse perpetrators on Licence Project"),
+      Arguments.of("LICENCE_VARIATION_PROJECT", "Licence Variation Project"),
+      Arguments.of("DOMESTIC_ABUSE_PROTECTION_ORDER", "Domestic Abuse Protection Order (DAPO)"),
+      Arguments.of("DOMESTIC_ABUSE_PERPETRATOR_ON_LICENCE_DAPOL", "Domestic Abuse Perpetrator on Licence (DAPOL)"),
+      Arguments.of(
+        "DOMESTIC_ABUSE_PERPETRATOR_ON_LICENCE_HOME_DETENTION_CURFEW_DAPOL_HDC",
+        "Domestic Abuse Perpetrator on Licence Home Detention Curfew (DAPOL HDC)",
+      ),
+      Arguments.of("GPS_ACQUISITIVE_CRIME_HOME_DETENTION_CURFEW", "GPS Acquisitive Crime Home Detention Curfew"),
+      Arguments.of("GPS_ACQUISITIVE_CRIME_PAROLE", "GPS Acquisitive Crime Parole"),
+      Arguments.of("UNKNOWN", ""),
     )
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/repository/MonitoringConditionsRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/repository/MonitoringConditionsRepositoryTest.kt
@@ -11,6 +11,7 @@ import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.mo
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.OrderVersion
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.DataDictionaryVersion
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.OrderStatus
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.Pilot
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.RequestType
 import java.util.*
 
@@ -62,11 +63,16 @@ class MonitoringConditionsRepositoryTest {
       val order = orderRepo.findById(mockOrderId).get()
 
       order.monitoringConditions =
-        MonitoringConditions(versionId = mockVersionId, pilot = "some string")
+        MonitoringConditions(
+          versionId = mockVersionId,
+          pilot = Pilot.DOMESTIC_ABUSE_PERPETRATOR_ON_LICENCE_HOME_DETENTION_CURFEW_DAPOL_HDC,
+        )
 
       val finalMonitoringConditions = orderRepo.save(order).monitoringConditions
 
-      assert(finalMonitoringConditions?.pilot == "some string")
+      assert(
+        finalMonitoringConditions?.pilot == Pilot.DOMESTIC_ABUSE_PERPETRATOR_ON_LICENCE_HOME_DETENTION_CURFEW_DAPOL_HDC,
+      )
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/resources/MonitoringConditionsControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/resources/MonitoringConditionsControllerTest.kt
@@ -8,6 +8,7 @@ import org.mockito.Mockito.`when`
 import org.springframework.security.core.Authentication
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.MonitoringConditions
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.dto.UpdateMonitoringConditionsDto
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.Pilot
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.resource.MonitoringConditionsController
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.service.MonitoringConditionsService
 import java.util.*
@@ -36,14 +37,18 @@ class MonitoringConditionsControllerTest {
       monitoringConditionsService.updateMonitoringConditions(
         orderId = mockOrderId,
         username = mockUsername,
-        updateRecord = UpdateMonitoringConditionsDto(pilot = "some pilot"),
+        updateRecord = UpdateMonitoringConditionsDto(
+          pilot = Pilot.DOMESTIC_ABUSE_PERPETRATOR_ON_LICENCE_HOME_DETENTION_CURFEW_DAPOL_HDC,
+        ),
       ),
     ).thenReturn(mockMonitoringConditions)
     `when`(authentication.name).thenReturn("mockUser")
 
     val result = controller.updateMonitoringConditions(
       orderId = mockOrderId,
-      monitoringConditionsUpdateRecord = UpdateMonitoringConditionsDto(pilot = "some pilot"),
+      monitoringConditionsUpdateRecord = UpdateMonitoringConditionsDto(
+        pilot = Pilot.DOMESTIC_ABUSE_PERPETRATOR_ON_LICENCE_HOME_DETENTION_CURFEW_DAPOL_HDC,
+      ),
       authentication = authentication,
     )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/MonitoringConditionsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/MonitoringConditionsServiceTest.kt
@@ -18,6 +18,7 @@ import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.mo
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.DataDictionaryVersion
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.InstallationLocationType
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.OrderStatus
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.Pilot
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.RequestType
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.repository.OrderRepository
 import java.time.ZoneId
@@ -87,11 +88,19 @@ class MonitoringConditionsServiceTest {
     whenever(repo.save(mockOrder)).thenReturn(mockOrder)
 
     val result =
-      service.updateMonitoringConditions(mockOrderId, mockUsername, UpdateMonitoringConditionsDto(pilot = "some pilot"))
+      service.updateMonitoringConditions(
+        mockOrderId,
+        mockUsername,
+        UpdateMonitoringConditionsDto(
+          pilot = Pilot.DOMESTIC_ABUSE_PERPETRATOR_ON_LICENCE_HOME_DETENTION_CURFEW_DAPOL_HDC,
+        ),
+      )
 
     assertThat(mockOrder.monitoringConditions).isNotNull
-    assertThat(mockOrder.monitoringConditions!!.pilot).isEqualTo("some pilot")
-    assertThat(result.pilot).isEqualTo("some pilot")
+    assertThat(
+      mockOrder.monitoringConditions!!.pilot,
+    ).isEqualTo(Pilot.DOMESTIC_ABUSE_PERPETRATOR_ON_LICENCE_HOME_DETENTION_CURFEW_DAPOL_HDC)
+    assertThat(result.pilot).isEqualTo(Pilot.DOMESTIC_ABUSE_PERPETRATOR_ON_LICENCE_HOME_DETENTION_CURFEW_DAPOL_HDC)
   }
 
   @Test

--- a/src/test/resources/json/scenarios/cemo002/expected_order.json
+++ b/src/test/resources/json/scenarios/cemo002/expected_order.json
@@ -134,5 +134,6 @@
   "magistrate_court_case_reference_number": "",
   "issp": "No",
   "hdc": "No",
-  "order_status": "Not Started"
+  "order_status": "Not Started",
+  "pilot": "GPS Acquisitive Crime Parole"
 }

--- a/src/test/resources/json/scenarios/cemo012/expected_order.json
+++ b/src/test/resources/json/scenarios/cemo012/expected_order.json
@@ -92,5 +92,6 @@
   "magistrate_court_case_reference_number": "",
   "issp": "No",
   "hdc": "No",
-  "order_status": "Not Started"
+  "order_status": "Not Started",
+  "pilot": "GPS Acquisitive Crime Parole"
 }

--- a/src/test/resources/json/scenarios/cemo016/expected_order.json
+++ b/src/test/resources/json/scenarios/cemo016/expected_order.json
@@ -92,5 +92,6 @@
   "magistrate_court_case_reference_number": "",
   "issp": "No",
   "hdc": "No",
-  "order_status": "Not Started"
+  "order_status": "Not Started",
+  "pilot": "Acquisitive Crime Project"
 }

--- a/src/test/resources/json/scenarios/cemo016/order.json
+++ b/src/test/resources/json/scenarios/cemo016/order.json
@@ -91,7 +91,7 @@
     "issp": "UNKNOWN",
     "hdc": "UNKNOWN",
     "prarr": "UNKNOWN",
-    "pilot": "AQUISITIVE_CRIME_PROJECT"
+    "pilot": "ACQUISITIVE_CRIME_PROJECT"
   },
   "monitoringConditionsTrail": {
     "versionId": "0db52c0a-6561-42f4-b490-d37831cb773a",

--- a/src/test/resources/json/scenarios/cemo017/expected_order.json
+++ b/src/test/resources/json/scenarios/cemo017/expected_order.json
@@ -124,5 +124,6 @@
   "magistrate_court_case_reference_number": "",
   "issp": "No",
   "hdc": "No",
-  "order_status": "Not Started"
+  "order_status": "Not Started",
+  "pilot": "GPS Acquisitive Crime Parole"
 }

--- a/src/test/resources/json/scenarios/cemo036/expected_order.json
+++ b/src/test/resources/json/scenarios/cemo036/expected_order.json
@@ -129,5 +129,6 @@
   "magistrate_court_case_reference_number": "",
   "issp": "No",
   "hdc": "No",
-  "order_status": "Not Started"
+  "order_status": "Not Started",
+  "pilot": "GPS Acquisitive Crime Parole"
 }


### PR DESCRIPTION
Ticket: https://dsdmoj.atlassian.net/browse/ELM-4052

Changes:

Refactor pilot to use Enum

Map pilot to fms monitoring order

Refactor test to use data class comparison so we don't need to updated json filed with default value every time we add new field 