### PR TITLE
update list order spec

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/criteria/OrderListCriteria.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/criteria/OrderListCriteria.kt
@@ -1,3 +1,3 @@
 package uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.criteria
 
-data class OrderListCriteria(val searchTerm: String = "", val username: String)
+data class OrderListCriteria(val username: String)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/resource/OrderController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/resource/OrderController.kt
@@ -75,12 +75,9 @@ class OrderController(@Autowired val orderService: OrderService) {
   }
 
   @GetMapping("/orders")
-  fun listOrders(
-    @RequestParam searchTerm: String = "",
-    authentication: Authentication,
-  ): ResponseEntity<List<OrderDto>> {
+  fun listOrders(authentication: Authentication): ResponseEntity<List<OrderDto>> {
     val username = authentication.name
-    val orders = orderService.listOrders(OrderListCriteria(searchTerm, username))
+    val orders = orderService.listOrders(OrderListCriteria(username))
 
     return ResponseEntity(orders.map { convertToDto(it) }, HttpStatus.OK)
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/resources/OrderControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/resources/OrderControllerTest.kt
@@ -159,7 +159,7 @@ class OrderControllerTest {
     `when`(orderService.listOrders(OrderListCriteria(username = "mockUser"))).thenReturn(orders)
     `when`(authentication.name).thenReturn("mockUser")
 
-    val result = controller.listOrders("", authentication)
+    val result = controller.listOrders(authentication)
     Assertions.assertThat(result.body).isEqualTo(
       listOf(
         OrderDto(


### PR DESCRIPTION
Update list orders to return all orders that are in progress or failed

No longer return submitted orders
No longer accept a search term as this is handled by the search orders endpoint