### PR TITLE
ELM-4137: make youth custody service region mandatory

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/InterestedPartiesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/InterestedPartiesService.kt
@@ -9,6 +9,7 @@ import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.mo
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.FamilyCourtDDv5
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.NotifyingOrganisationDDv5
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.ProbationServiceRegion
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.YouthCustodyServiceRegionDDv5
 import java.util.*
 
 @Service
@@ -27,6 +28,8 @@ class InterestedPartiesService(private val addressService: AddressService) : Ord
             FamilyCourtDDv5.entries.none { it.name == updateRecord.notifyingOrganisationName }
           NotifyingOrganisationDDv5.PROBATION ->
             ProbationServiceRegion.entries.none { it.name == updateRecord.notifyingOrganisationName }
+          NotifyingOrganisationDDv5.YOUTH_CUSTODY_SERVICE ->
+            YouthCustodyServiceRegionDDv5.entries.none { it.name == updateRecord.notifyingOrganisationName }
           else -> false
         }
 


### PR DESCRIPTION
Ticket: https://dsdmoj.atlassian.net/browse/ELM-4137

Add validation check if notifying organisation is YOUTH_CUSTODY_SERVICE and notifying organisation name doesn't exist