### PR TITLE
ELM-4736: Programatically infer the responsible officer for the Home Office

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/fms/MonitoringOrder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/fms/MonitoringOrder.kt
@@ -388,13 +388,9 @@ data class MonitoringOrder(
           }
           roEmail = if (variationInPast) "" else parties.responsibleOrganisationEmail
 
-          notifyingOfficerName = if (notifyingOrg == NotifyingOrganisationDDv5.HOME_OFFICE) {
-            "Home Office"
-          } else {
-            ""
-          }
-
           notifyingOrganization = getNotifyingOrganisation(parties, order.dataDictionaryVersion)
+          notifyingOfficerName =
+            if (notifyingOrganization == NotifyingOrganisationDDv5.HOME_OFFICE.value) "Home Office" else ""
           noName = getNotifyingOrganisationName(parties, order.dataDictionaryVersion)
           noEmail = parties.notifyingOrganisationEmail
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/fms/MonitoringOrder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/fms/MonitoringOrder.kt
@@ -377,15 +377,7 @@ data class MonitoringOrder(
         val notifyingOrg = NotifyingOrganisationDDv5.from(parties.notifyingOrganisation)
 
         monitoringOrder.apply {
-          responsibleOfficerName = if (variationInPast) {
-            ""
-          } else {
-            if (notifyingOrg == NotifyingOrganisationDDv5.HOME_OFFICE) {
-              "Home Office"
-            } else {
-              parties.getResponsibleOfficerFullName()
-            }
-          }
+          responsibleOfficerName = if (variationInPast) "" else parties.getResponsibleOfficerFullName()
           responsibleOfficerPhone = if (variationInPast) "" else getResponsibleOfficerPhoneNumber(parties)
           responsibleOfficerEmail = if (variationInPast) "" else parties.responsibleOfficerEmail ?: ""
           responsibleOrganization = if (variationInPast) "" else getResponsibleOrganisation(parties)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/fms/MonitoringOrder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/fms/MonitoringOrder.kt
@@ -374,11 +374,12 @@ data class MonitoringOrder(
         val orderIsVariation = RequestType.VARIATION_TYPES.contains(order.type)
         val variationInPast = startDateIsInPast && orderIsVariation
 
+        val notifyingOrg = NotifyingOrganisationDDv5.from(parties.notifyingOrganisation)
+
         monitoringOrder.apply {
           responsibleOfficerName = if (variationInPast) {
             ""
           } else {
-            val notifyingOrg = NotifyingOrganisationDDv5.from(parties.notifyingOrganisation)
             if (notifyingOrg == NotifyingOrganisationDDv5.HOME_OFFICE) {
               "Home Office"
             } else {
@@ -394,6 +395,12 @@ data class MonitoringOrder(
             pduResponsible = if (variationInPast) "" else getProbationDeliveryUnit(order)
           }
           roEmail = if (variationInPast) "" else parties.responsibleOrganisationEmail
+
+          notifyingOfficerName = if (notifyingOrg == NotifyingOrganisationDDv5.HOME_OFFICE) {
+            "Home Office"
+          } else {
+            ""
+          }
 
           notifyingOrganization = getNotifyingOrganisation(parties, order.dataDictionaryVersion)
           noName = getNotifyingOrganisationName(parties, order.dataDictionaryVersion)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/fms/MonitoringOrder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/fms/MonitoringOrder.kt
@@ -375,7 +375,16 @@ data class MonitoringOrder(
         val variationInPast = startDateIsInPast && orderIsVariation
 
         monitoringOrder.apply {
-          responsibleOfficerName = if (variationInPast) "" else parties.getResponsibleOfficerFullName()
+          responsibleOfficerName = if (variationInPast) {
+            ""
+          } else {
+            val notifyingOrg = NotifyingOrganisationDDv5.from(parties.notifyingOrganisation)
+            if (notifyingOrg == NotifyingOrganisationDDv5.HOME_OFFICE) {
+              "Home Office"
+            } else {
+              parties.getResponsibleOfficerFullName()
+            }
+          }
           responsibleOfficerPhone = if (variationInPast) "" else getResponsibleOfficerPhoneNumber(parties)
           responsibleOfficerEmail = if (variationInPast) "" else parties.responsibleOfficerEmail ?: ""
           responsibleOrganization = if (variationInPast) "" else getResponsibleOrganisation(parties)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/model/fms/MonitoringOrderTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/model/fms/MonitoringOrderTest.kt
@@ -1399,7 +1399,7 @@ class MonitoringOrderTest : OrderTestBase() {
   }
 
   @Test
-  fun `It should infer responsible and notifying officer names if notifying org home office`() {
+  fun `It should infer notifying officer name if notifying org home office`() {
     val order = createOrder(
       interestedParties = createInterestedParty(
         notifyingOrganisation = NotifyingOrganisationDDv5.HOME_OFFICE.name,
@@ -1409,7 +1409,6 @@ class MonitoringOrderTest : OrderTestBase() {
     val featureFlags = FeatureFlags(ddV6CourtMappings = true, dataDictionaryVersion = DataDictionaryVersion.DDV6)
     val fmsMonitoringOrder = MonitoringOrder.fromOrder(order, null, featureFlags)
 
-    assertThat(fmsMonitoringOrder.responsibleOfficerName).isEqualTo("Home Office")
     assertThat(fmsMonitoringOrder.notifyingOfficerName).isEqualTo("Home Office")
     assertThat(fmsMonitoringOrder.responsibleOfficerDetailsReceived).isEqualTo("Yes")
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/model/fms/MonitoringOrderTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/model/fms/MonitoringOrderTest.kt
@@ -1411,6 +1411,7 @@ class MonitoringOrderTest : OrderTestBase() {
 
     assertThat(fmsMonitoringOrder.responsibleOfficerName).isEqualTo("Home Office")
     assertThat(fmsMonitoringOrder.notifyingOfficerName).isEqualTo("Home Office")
+    assertThat(fmsMonitoringOrder.responsibleOfficerDetailsReceived).isEqualTo("Yes")
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/model/fms/MonitoringOrderTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/model/fms/MonitoringOrderTest.kt
@@ -1399,6 +1399,20 @@ class MonitoringOrderTest : OrderTestBase() {
   }
 
   @Test
+  fun `It should infer responsible officer name if notifying org home office`() {
+    val order = createOrder(
+      interestedParties = createInterestedParty(
+        notifyingOrganisation = NotifyingOrganisationDDv5.HOME_OFFICE.name,
+      ),
+    )
+
+    val featureFlags = FeatureFlags(ddV6CourtMappings = true, dataDictionaryVersion = DataDictionaryVersion.DDV6)
+    val fmsMonitoringOrder = MonitoringOrder.fromOrder(order, null, featureFlags)
+
+    assertThat(fmsMonitoringOrder.responsibleOfficerName).isEqualTo("Home Office")
+  }
+
+  @Test
   fun `It should map responsible officer email`() {
     val order = createOrder(
       interestedParties = createInterestedParty(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/model/fms/MonitoringOrderTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/model/fms/MonitoringOrderTest.kt
@@ -1399,7 +1399,7 @@ class MonitoringOrderTest : OrderTestBase() {
   }
 
   @Test
-  fun `It should infer responsible officer name if notifying org home office`() {
+  fun `It should infer responsible and notifying officer names if notifying org home office`() {
     val order = createOrder(
       interestedParties = createInterestedParty(
         notifyingOrganisation = NotifyingOrganisationDDv5.HOME_OFFICE.name,
@@ -1410,6 +1410,7 @@ class MonitoringOrderTest : OrderTestBase() {
     val fmsMonitoringOrder = MonitoringOrder.fromOrder(order, null, featureFlags)
 
     assertThat(fmsMonitoringOrder.responsibleOfficerName).isEqualTo("Home Office")
+    assertThat(fmsMonitoringOrder.notifyingOfficerName).isEqualTo("Home Office")
   }
 
   @Test


### PR DESCRIPTION
### Context

Ticket: [https://dsdmoj.atlassian.net/browse/ELM-4736](https://dsdmoj.atlassian.net/browse/ELM-4736)

If the user is from the Home Office, we need to send the responsible officer details automatically without the user having to enter them on the UI. This is because the responsible officer page will be skipped in UI to prevent users from entering their own details which would be a rejection.

### Changes proposed in this pull request

For a user from the home office cohort, send the details below:

```
"responsible_officer_details_received":"Yes"
"responsible_officer_name": "Home Office"
"notifying_officer_name": "Home Office"
```

# Backend PR Checklist

These are items (excluding GitHub Checks) which should be confirmed before a branch is ready to merge.

- [X] Ensure backwards compatibility (did not remove existing code, only added new)
- [X] Did not remove/edit existing enum values
- [X] Added relevant automation tests (updated or new)
- [ ] Verified Serco Mapping changes are safe for production (e.g Postman)
- [X] Relevant documentation is updated and linked
- [X] PR has been self-reviewed by the author
- [X] Reused existing components before creating new ones
- [X] Code refined to the best of your knowledge
- [X] Ticket number included in the description
- [X] (If applicable) Ran frontend scenario tests against backend changes