### PR TITLE
Elm 4792 get case status from downstream

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/client/FmsClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/client/FmsClient.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.client
 
+import FmsStateResponse
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.core.io.InputStreamResource
 import org.springframework.http.HttpHeaders
@@ -7,6 +8,7 @@ import org.springframework.http.MediaType
 import org.springframework.stereotype.Service
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.WebClientResponseException
+import org.springframework.web.reactive.function.client.bodyToMono
 import reactor.core.publisher.Mono
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.exception.CreateSercoEntityException
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.exception.SercoConnectionException
@@ -164,16 +166,16 @@ class FmsClient(@Value("\${services.serco.url}") url: String, private val fmsAut
     return result
   }
 
-  fun getState(caseId: String): FmsResponse {
+  fun getState(caseId: String): FmsStateResponse {
     val token = fmsAuthClient.getClientToken()
 
-    val result = webClient.get().uri("/now/table/x_serg2_ems_csm_case/$caseId")
+    val result = webClient.get().uri("/now/table/x_serg2_ems_csm_case/$caseId?sysparm_fields=state")
       .header(HttpHeaders.AUTHORIZATION, "Bearer $token")
       .retrieve()
       .onStatus(
         { t -> t.isError },
         {
-          it.bodyToMono(FmsErrorResponse::class.java).flatMap { error ->
+          it.bodyToMono<FmsErrorResponse>().flatMap { error ->
             Mono.error(
               SercoConnectionException(
                 "Error fetching state for case $caseId: ${error?.error?.detail}",
@@ -182,7 +184,7 @@ class FmsClient(@Value("\${services.serco.url}") url: String, private val fmsAut
           }
         },
       )
-      .bodyToMono(FmsResponse::class.java)
+      .bodyToMono<FmsStateResponse>()
       .onErrorResume(WebClientResponseException::class.java) { Mono.empty() }
       .block()!!
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/client/FmsClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/client/FmsClient.kt
@@ -12,6 +12,7 @@ import org.springframework.web.reactive.function.client.bodyToMono
 import reactor.core.publisher.Mono
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.exception.CreateSercoEntityException
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.exception.SercoConnectionException
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.CaseState
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.RequestType
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.fms.FmsAttachmentResponse
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.fms.FmsErrorResponse
@@ -166,7 +167,7 @@ class FmsClient(@Value("\${services.serco.url}") url: String, private val fmsAut
     return result
   }
 
-  fun getState(caseId: String): FmsStateResponse {
+  fun getState(caseId: String): CaseState {
     val token = fmsAuthClient.getClientToken()
 
     val result = webClient.get().uri("/now/table/x_serg2_ems_csm_case/$caseId?sysparm_fields=state")
@@ -188,6 +189,6 @@ class FmsClient(@Value("\${services.serco.url}") url: String, private val fmsAut
       .onErrorResume(WebClientResponseException::class.java) { Mono.empty() }
       .block()!!
 
-    return result
+    return CaseState.fromStateString(result.result?.state)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/client/FmsClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/client/FmsClient.kt
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.client
 
-import com.fasterxml.jackson.databind.ObjectMapper
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.core.io.InputStreamResource
 import org.springframework.http.HttpHeaders
@@ -10,6 +9,7 @@ import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.WebClientResponseException
 import reactor.core.publisher.Mono
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.exception.CreateSercoEntityException
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.exception.SercoConnectionException
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.RequestType
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.fms.FmsAttachmentResponse
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.fms.FmsErrorResponse
@@ -17,11 +17,7 @@ import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.mo
 import java.util.*
 
 @Service
-class FmsClient(
-  @Value("\${services.serco.url}") url: String,
-  private val fmsAuthClient: FmsAuthClient,
-  private val objectMapper: ObjectMapper,
-) {
+class FmsClient(@Value("\${services.serco.url}") url: String, private val fmsAuthClient: FmsAuthClient) {
   private val webClient: WebClient = WebClient.builder().baseUrl(url).build()
 
   fun createDeviceWearer(deviceWearerPayload: String, orderId: UUID): FmsResponse {
@@ -165,6 +161,31 @@ class FmsClient(
       .bodyToMono(FmsAttachmentResponse::class.java)
       .onErrorResume(WebClientResponseException::class.java) { Mono.empty() }
       .block()!!
+    return result
+  }
+
+  fun getState(caseId: String): FmsResponse {
+    val token = fmsAuthClient.getClientToken()
+
+    val result = webClient.get().uri("/now/table/x_serg2_ems_csm_case/$caseId")
+      .header(HttpHeaders.AUTHORIZATION, "Bearer $token")
+      .retrieve()
+      .onStatus(
+        { t -> t.isError },
+        {
+          it.bodyToMono(FmsErrorResponse::class.java).flatMap { error ->
+            Mono.error(
+              SercoConnectionException(
+                "Error fetching state for case $caseId: ${error?.error?.detail}",
+              ),
+            )
+          }
+        },
+      )
+      .bodyToMono(FmsResponse::class.java)
+      .onErrorResume(WebClientResponseException::class.java) { Mono.empty() }
+      .block()!!
+
     return result
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/enums/CaseState.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/enums/CaseState.kt
@@ -1,0 +1,24 @@
+package uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums
+
+enum class CaseState(val value: String) {
+  NEW("New"),
+  CLOSED("Closed"),
+  RESOLVED("Resolved"),
+  CANCELLED("Cancelled"),
+  OPEN("Open"),
+  AWAITING_INFO("AwaitingInfo"),
+  UNKNOWN("Unknown"),
+  ;
+
+  companion object {
+    fun fromStateString(value: String?): CaseState = when (value) {
+      "1" -> NEW
+      "3" -> CLOSED
+      "6" -> RESOLVED
+      "7" -> CANCELLED
+      "10" -> OPEN
+      "18" -> AWAITING_INFO
+      else -> UNKNOWN
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/enums/CaseState.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/enums/CaseState.kt
@@ -11,6 +11,6 @@ enum class CaseState(val value: String) {
   ;
 
   companion object {
-    fun fromStateString(value: String?): CaseState = CaseState.entries.firstOrNull { it.name == value } ?: UNKNOWN
+    fun fromStateString(value: String?): CaseState = CaseState.entries.firstOrNull { it.value == value } ?: UNKNOWN
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/enums/CaseState.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/enums/CaseState.kt
@@ -1,24 +1,16 @@
 package uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums
 
 enum class CaseState(val value: String) {
-  NEW("New"),
-  CLOSED("Closed"),
-  RESOLVED("Resolved"),
-  CANCELLED("Cancelled"),
-  OPEN("Open"),
-  AWAITING_INFO("AwaitingInfo"),
+  NEW("1"),
+  CLOSED("3"),
+  RESOLVED("6"),
+  CANCELLED("7"),
+  OPEN("10"),
+  AWAITING_INFO("18"),
   UNKNOWN("Unknown"),
   ;
 
   companion object {
-    fun fromStateString(value: String?): CaseState = when (value) {
-      "1" -> NEW
-      "3" -> CLOSED
-      "6" -> RESOLVED
-      "7" -> CANCELLED
-      "10" -> OPEN
-      "18" -> AWAITING_INFO
-      else -> UNKNOWN
-    }
+    fun fromStateString(value: String?): CaseState = CaseState.entries.firstOrNull { it.name == value } ?: UNKNOWN
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/fms/FmsStateResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/fms/FmsStateResponse.kt
@@ -1,0 +1,3 @@
+class FmsStateResponse(val result: FmsState?)
+
+class FmsState(val state: String)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/client/FmsClientTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/client/FmsClientTest.kt
@@ -17,6 +17,7 @@ import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.ex
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.integration.wiremock.SercoAuthMockServerExtension.Companion.sercoAuthApi
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.integration.wiremock.SercoMockApiExtension.Companion.sercoApi
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.CaseState
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.RequestType
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.fms.DeviceWearer
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.fms.ErrorResponse
@@ -367,8 +368,8 @@ class FmsClientTest : IntegrationTestBase() {
       val result = fmsClient.getState(caseId)
 
       assertThat(
-        result.result?.state,
-      ).isEqualTo("1")
+        result,
+      ).isEqualTo(CaseState.NEW)
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/client/FmsClientTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/client/FmsClientTest.kt
@@ -1,5 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.client
 
+import FmsState
+import FmsStateResponse
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
@@ -337,7 +339,7 @@ class FmsClientTest : IntegrationTestBase() {
       sercoApi.stubGetState(
         caseId,
         status = HttpStatus.UNAUTHORIZED,
-        result = FmsResponse(),
+        result = FmsStateResponse(result = null),
         errorResponse = FmsErrorResponse(
           error = ErrorResponse(message = "User not authorised", detail = "User is unauthorised"),
         ),
@@ -359,14 +361,14 @@ class FmsClientTest : IntegrationTestBase() {
       sercoApi.stubGetState(
         caseId,
         status = HttpStatus.OK,
-        result = FmsResponse(),
+        result = FmsStateResponse(FmsState("1")),
       )
 
       val result = fmsClient.getState(caseId)
 
       assertThat(
-        result,
-      ).isNotNull
+        result.result?.state,
+      ).isEqualTo("1")
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/client/FmsClientTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/client/FmsClientTest.kt
@@ -11,6 +11,7 @@ import org.springframework.core.io.InputStreamResource
 import org.springframework.http.HttpStatus
 import org.springframework.test.context.ActiveProfiles
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.exception.CreateSercoEntityException
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.exception.SercoConnectionException
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.integration.wiremock.SercoAuthMockServerExtension.Companion.sercoAuthApi
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.integration.wiremock.SercoMockApiExtension.Companion.sercoApi
@@ -323,6 +324,49 @@ class FmsClientTest : IntegrationTestBase() {
       assertThat(
         exception.message,
       ).isEqualTo("Error creating $documentType attachment for order: $caseId with error: Error detail")
+    }
+  }
+
+  @Nested
+  @DisplayName("Get api/now/table/x_serg2_ems_csm_case/{case_id}")
+  inner class GetState {
+    @Test
+    fun `it should handle 403 responses`() {
+      val caseId = "mockCaseId"
+      sercoAuthApi.stubGrantToken()
+      sercoApi.stubGetState(
+        caseId,
+        status = HttpStatus.UNAUTHORIZED,
+        result = FmsResponse(),
+        errorResponse = FmsErrorResponse(
+          error = ErrorResponse(message = "User not authorised", detail = "User is unauthorised"),
+        ),
+      )
+
+      val exception = assertThrows<SercoConnectionException> {
+        fmsClient.getState(caseId)
+      }
+
+      assertThat(
+        exception.message,
+      ).isEqualTo("Error fetching state for case $caseId: User is unauthorised")
+    }
+
+    @Test
+    fun `should return successful result`() {
+      val caseId = "mockCaseId"
+      sercoAuthApi.stubGrantToken()
+      sercoApi.stubGetState(
+        caseId,
+        status = HttpStatus.OK,
+        result = FmsResponse(),
+      )
+
+      val result = fmsClient.getState(caseId)
+
+      assertThat(
+        result,
+      ).isNotNull
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/wiremock/SercoMockApi.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/wiremock/SercoMockApi.kt
@@ -1,11 +1,12 @@
-
 package uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.integration.wiremock
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock.aResponse
 import com.github.tomakehurst.wiremock.client.WireMock.equalTo
+import com.github.tomakehurst.wiremock.client.WireMock.get
 import com.github.tomakehurst.wiremock.client.WireMock.post
+import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
 import com.github.tomakehurst.wiremock.client.WireMock.urlPathTemplate
 import org.junit.jupiter.api.extension.AfterAllCallback
 import org.junit.jupiter.api.extension.BeforeAllCallback
@@ -138,6 +139,25 @@ class SercoMockApiServer : WireMockServer(WIREMOCK_PORT) {
         .withQueryParam("table_name", equalTo(result.result.tableName))
         .withQueryParam("table_sys_id", equalTo(result.result.tableSysId))
         .withQueryParam("file_name", equalTo(result.result.fileName))
+        .willReturn(
+          aResponse()
+            .withHeader("Content-Type", "application/json")
+            .withBody(
+              body,
+            )
+            .withStatus(status.value()),
+        ),
+    )
+  }
+
+  fun stubGetState(caseId: String, status: HttpStatus, result: FmsResponse, errorResponse: FmsErrorResponse? = null) {
+    val body = if (errorResponse != null) {
+      objectMapper.writeValueAsString(errorResponse)
+    } else {
+      objectMapper.writeValueAsString(result)
+    }
+    stubFor(
+      get(urlEqualTo("/now/table/x_serg2_ems_csm_case/$caseId"))
         .willReturn(
           aResponse()
             .withHeader("Content-Type", "application/json")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/wiremock/SercoMockApi.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/wiremock/SercoMockApi.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.integration.wiremock
 
+import FmsStateResponse
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock.aResponse
@@ -150,14 +151,19 @@ class SercoMockApiServer : WireMockServer(WIREMOCK_PORT) {
     )
   }
 
-  fun stubGetState(caseId: String, status: HttpStatus, result: FmsResponse, errorResponse: FmsErrorResponse? = null) {
+  fun stubGetState(
+    caseId: String,
+    status: HttpStatus,
+    result: FmsStateResponse,
+    errorResponse: FmsErrorResponse? = null,
+  ) {
     val body = if (errorResponse != null) {
       objectMapper.writeValueAsString(errorResponse)
     } else {
       objectMapper.writeValueAsString(result)
     }
     stubFor(
-      get(urlEqualTo("/now/table/x_serg2_ems_csm_case/$caseId"))
+      get(urlEqualTo("/now/table/x_serg2_ems_csm_case/$caseId?sysparm_fields=state"))
         .willReturn(
           aResponse()
             .withHeader("Content-Type", "application/json")


### PR DESCRIPTION
### Context

Ticket: https://dsdmoj.atlassian.net/browse/ELM-4792

Integrate with api/now/table/x_serg2_ems_csm_case/{case_id} endpoint to retrieve case details from SNOW, most importantly the state of the case

### Changes proposed in this pull request

Have added the endpoint call code to the fms client. Haven't done too much more as design should be driven by domain logic


# Backend PR Checklist

These are items (excluding GitHub Checks) which should be confirmed before a branch is ready to merge.

- [x] Ensure backwards compatibility (did not remove existing code, only added new)
- [x] Did not remove/edit existing enum values
- [x] Added relevant automation tests (updated or new)
- [x] Verified Serco Mapping changes are safe for production (e.g Postman)
- [x] Relevant documentation is updated and linked
- [x] PR has been self-reviewed by the author
- [x] Reused existing components before creating new ones
- [x] Code refined to the best of your knowledge
- [x] Ticket number included in the description
- [ ] (If applicable) Ran frontend scenario tests against backend changes