### PR TITLE
Elm 4783 delete nofifying org on clone

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/OrderService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/OrderService.kt
@@ -101,7 +101,7 @@ class OrderService(
     notifyingOrganisation: String?,
   ): Boolean {
     val userCohort = userCohortService.getUserCohort(token)
-    return userCohortService.matchesNofifyingOrg(userCohort, notifyingOrganisation)
+    return userCohortService.matchesNofifyingOrg(userCohort.cohort, notifyingOrganisation)
   }
 
   fun createVersion(orderId: UUID, token: JwtAuthenticationToken, versionType: RequestType): Order {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/OrderService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/OrderService.kt
@@ -168,14 +168,15 @@ class OrderService(
         if (isFutureOrder) {
           probationDeliveryUnit =
             currentVersion.probationDeliveryUnit?.copy(versionId = this.id, id = UUID.randomUUID())
-          monitoringConditions =
-            currentVersion.monitoringConditions?.copy(
-              versionId = this.id,
-              id = UUID.randomUUID(),
-              startDate = null,
-              endDate = null,
-            )
         }
+
+        monitoringConditions =
+          currentVersion.monitoringConditions?.copy(
+            versionId = this.id,
+            id = UUID.randomUUID(),
+            startDate = null,
+            endDate = null,
+          )
 
         monitoringConditionsAlcohol =
           currentVersion.monitoringConditionsAlcohol?.copy(versionId = this.id, id = UUID.randomUUID())

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/OrderService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/OrderService.kt
@@ -12,7 +12,6 @@ import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.mo
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.MonitoringConditions
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.Order
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.OrderVersion
-import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.auth.Cohort
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.criteria.OrderListCriteria
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.criteria.OrderSearchCriteria
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.criteria.TagFilter
@@ -25,7 +24,6 @@ import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.mo
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.specification.OrderListSpecification
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.specification.OrderSearchSpecification
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.repository.OrderRepository
-import java.time.ZonedDateTime
 import java.util.*
 
 @Service
@@ -103,17 +101,7 @@ class OrderService(
     notifyingOrganisation: String?,
   ): Boolean {
     val userCohort = userCohortService.getUserCohort(token)
-    val notifyingOrganisation = NotifyingOrganisationDDv5.from(notifyingOrganisation)
-    return when (userCohort.cohort) {
-      Cohort.PRISON ->
-        notifyingOrganisation in
-          listOf(NotifyingOrganisationDDv5.PRISON, NotifyingOrganisationDDv5.YOUTH_CUSTODY_SERVICE)
-
-      Cohort.PROBATION -> notifyingOrganisation == NotifyingOrganisationDDv5.PROBATION
-      Cohort.COURT -> NotifyingOrganisationDDv5.COURTS.contains(notifyingOrganisation)
-      Cohort.HOME_OFFICE -> notifyingOrganisation == NotifyingOrganisationDDv5.HOME_OFFICE
-      else -> false
-    }
+    return userCohortService.matchesNofifyingOrg(userCohort, notifyingOrganisation)
   }
 
   fun createVersion(orderId: UUID, token: JwtAuthenticationToken, versionType: RequestType): Order {
@@ -153,26 +141,23 @@ class OrderService(
         curfewReleaseDateConditions =
           currentVersion.curfewReleaseDateConditions?.copy(versionId = this.id, id = UUID.randomUUID())
 
-        // only copy interested parties and PDU if order start date in the future
-        if (order.getMonitoringStartDate() != null && order.getMonitoringStartDate()!! > ZonedDateTime.now()) {
-          val currentIPs = currentVersion.interestedParties
-          val isUserFromOriginalNotifyingOrganistion =
-            isUserFromOriginalNotifyingOrganistion(token, currentVersion.interestedParties?.notifyingOrganisation)
-          interestedParties =
-            currentVersion.interestedParties?.copy(
-              versionId = this.id,
-              id = UUID.randomUUID(),
-              notifyingOrganisation = currentIPs?.notifyingOrganisation
-                ?.takeIf { isUserFromOriginalNotifyingOrganistion },
-              notifyingOrganisationName = currentIPs?.notifyingOrganisationName
-                ?.takeIf { isUserFromOriginalNotifyingOrganistion },
-              notifyingOrganisationEmail = currentIPs?.notifyingOrganisationEmail
-                ?.takeIf { isUserFromOriginalNotifyingOrganistion },
-            )
+        val currentIPs = currentVersion.interestedParties
+        val isUserFromOriginalNotifyingOrganistion =
+          isUserFromOriginalNotifyingOrganistion(token, currentIPs?.notifyingOrganisation)
+        interestedParties =
+          currentVersion.interestedParties?.copy(
+            versionId = this.id,
+            id = UUID.randomUUID(),
+            notifyingOrganisation = currentIPs?.notifyingOrganisation
+              ?.takeIf { isUserFromOriginalNotifyingOrganistion },
+            notifyingOrganisationName = currentIPs?.notifyingOrganisationName
+              ?.takeIf { isUserFromOriginalNotifyingOrganistion },
+            notifyingOrganisationEmail = currentIPs?.notifyingOrganisationEmail
+              ?.takeIf { isUserFromOriginalNotifyingOrganistion },
+          )
 
-          probationDeliveryUnit =
-            currentVersion.probationDeliveryUnit?.copy(versionId = this.id, id = UUID.randomUUID())
-        }
+        probationDeliveryUnit =
+          currentVersion.probationDeliveryUnit?.copy(versionId = this.id, id = UUID.randomUUID())
         monitoringConditions =
           currentVersion.monitoringConditions?.copy(
             versionId = this.id,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/OrderService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/OrderService.kt
@@ -24,6 +24,7 @@ import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.mo
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.specification.OrderListSpecification
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.specification.OrderSearchSpecification
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.repository.OrderRepository
+import java.time.ZonedDateTime
 import java.util.*
 
 @Service
@@ -142,6 +143,8 @@ class OrderService(
           currentVersion.curfewReleaseDateConditions?.copy(versionId = this.id, id = UUID.randomUUID())
 
         val currentIPs = currentVersion.interestedParties
+        val isFutureOrder =
+          order.getMonitoringStartDate() != null && order.getMonitoringStartDate()!! > ZonedDateTime.now()
         val isUserFromOriginalNotifyingOrganistion =
           isUserFromOriginalNotifyingOrganistion(token, currentIPs?.notifyingOrganisation)
         interestedParties =
@@ -154,17 +157,26 @@ class OrderService(
               ?.takeIf { isUserFromOriginalNotifyingOrganistion },
             notifyingOrganisationEmail = currentIPs?.notifyingOrganisationEmail
               ?.takeIf { isUserFromOriginalNotifyingOrganistion },
+            responsibleOrganisation = currentIPs?.responsibleOrganisation?.takeIf { isFutureOrder },
+            responsibleOfficerFirstName = currentIPs?.responsibleOfficerFirstName?.takeIf { isFutureOrder },
+            responsibleOfficerLastName = currentIPs?.responsibleOfficerLastName?.takeIf { isFutureOrder },
+            responsibleOfficerEmail = currentIPs?.responsibleOfficerEmail?.takeIf { isFutureOrder },
+            responsibleOrganisationRegion = currentIPs?.responsibleOrganisationRegion?.takeIf { isFutureOrder },
+            responsibleOrganisationEmail = currentIPs?.responsibleOrganisationEmail?.takeIf { isFutureOrder },
           )
 
-        probationDeliveryUnit =
-          currentVersion.probationDeliveryUnit?.copy(versionId = this.id, id = UUID.randomUUID())
-        monitoringConditions =
-          currentVersion.monitoringConditions?.copy(
-            versionId = this.id,
-            id = UUID.randomUUID(),
-            startDate = null,
-            endDate = null,
-          )
+        if (isFutureOrder) {
+          probationDeliveryUnit =
+            currentVersion.probationDeliveryUnit?.copy(versionId = this.id, id = UUID.randomUUID())
+          monitoringConditions =
+            currentVersion.monitoringConditions?.copy(
+              versionId = this.id,
+              id = UUID.randomUUID(),
+              startDate = null,
+              endDate = null,
+            )
+        }
+
         monitoringConditionsAlcohol =
           currentVersion.monitoringConditionsAlcohol?.copy(versionId = this.id, id = UUID.randomUUID())
         monitoringConditionsTrail =

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/UserCohortService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/UserCohortService.kt
@@ -6,6 +6,7 @@ import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.cl
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.auth.Cohort
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.auth.UserCohort
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.auth.UserRole
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.NotifyingOrganisationDDv5
 
 @Service
 class UserCohortService(private val webClient: ManageUserApi) {
@@ -20,8 +21,20 @@ class UserCohortService(private val webClient: ManageUserApi) {
         val caseload = webClient.getUserActiveCaseload(authentication.token)
         UserCohort(Cohort.PRISON, caseload?.name, caseload?.id)
       }
+
       UserRole.PROBATION.code in roles -> UserCohort(Cohort.PROBATION)
       else -> UserCohort(Cohort.OTHER)
+    }
+  }
+
+  fun matchesNofifyingOrg(userCohort: UserCohort, notifyingOrganisation: String): Boolean {
+    val parsedNotifyingOrganisation = NotifyingOrganisationDDv5.from(notifyingOrganisation)
+    return when (userCohort.cohort) {
+      Cohort.PRISON -> parsedNotifyingOrganisation == NotifyingOrganisationDDv5.PRISON
+      Cohort.PROBATION -> parsedNotifyingOrganisation == NotifyingOrganisationDDv5.PROBATION
+      Cohort.COURT -> NotifyingOrganisationDDv5.isCourt(notifyingOrganisation)
+      Cohort.HOME_OFFICE -> parsedNotifyingOrganisation == NotifyingOrganisationDDv5.HOME_OFFICE
+      Cohort.OTHER -> false
     }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/UserCohortService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/UserCohortService.kt
@@ -27,7 +27,9 @@ class UserCohortService(private val webClient: ManageUserApi) {
     }
   }
 
-  fun matchesNofifyingOrg(userCohort: UserCohort, notifyingOrganisation: String): Boolean {
+  fun matchesNofifyingOrg(userCohort: UserCohort, notifyingOrganisation: String?): Boolean {
+    if (notifyingOrganisation.isNullOrEmpty()) return false
+
     val parsedNotifyingOrganisation = NotifyingOrganisationDDv5.from(notifyingOrganisation)
     return when (userCohort.cohort) {
       Cohort.PRISON -> parsedNotifyingOrganisation == NotifyingOrganisationDDv5.PRISON

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/UserCohortService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/UserCohortService.kt
@@ -27,12 +27,14 @@ class UserCohortService(private val webClient: ManageUserApi) {
     }
   }
 
-  fun matchesNofifyingOrg(userCohort: UserCohort, notifyingOrganisation: String?): Boolean {
+  fun matchesNofifyingOrg(cohort: Cohort, notifyingOrganisation: String?): Boolean {
     if (notifyingOrganisation.isNullOrEmpty()) return false
 
     val parsedNotifyingOrganisation = NotifyingOrganisationDDv5.from(notifyingOrganisation)
-    return when (userCohort.cohort) {
-      Cohort.PRISON -> parsedNotifyingOrganisation == NotifyingOrganisationDDv5.PRISON
+    return when (cohort) {
+      Cohort.PRISON ->
+        parsedNotifyingOrganisation == NotifyingOrganisationDDv5.PRISON ||
+          parsedNotifyingOrganisation == NotifyingOrganisationDDv5.YOUTH_CUSTODY_SERVICE
       Cohort.PROBATION -> parsedNotifyingOrganisation == NotifyingOrganisationDDv5.PROBATION
       Cohort.COURT -> NotifyingOrganisationDDv5.isCourt(notifyingOrganisation)
       Cohort.HOME_OFFICE -> parsedNotifyingOrganisation == NotifyingOrganisationDDv5.HOME_OFFICE

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/OrderServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/OrderServiceTest.kt
@@ -590,6 +590,16 @@ class OrderServiceTest {
       }
 
       @Test
+      fun `Should only clear notifying org is user type does not match`() {
+        argumentCaptor<Order>().apply {
+          verify(repo, times(1)).save(capture())
+          assertThat(firstValue.versions.last().interestedParties?.notifyingOrganisation).isNull()
+          assertThat(firstValue.versions.last().interestedParties?.notifyingOrganisationName).isNull()
+          assertThat(firstValue.versions.last().interestedParties?.notifyingOrganisationEmail).isNull()
+        }
+      }
+
+      @Test
       fun `It should clone probationDeliveryUnit referencing new version`() {
         argumentCaptor<Order>().apply {
           verify(repo, times(1)).save(capture())
@@ -821,6 +831,28 @@ class OrderServiceTest {
         verify(repo, times(1)).save(capture())
         assertThat(firstValue.versions.last().interestedParties).isNull()
         assertThat(firstValue.versions.last().probationDeliveryUnit).isNull()
+      }
+    }
+
+    @Nested
+    @DisplayName("Create Version as Variation")
+    inner class CreateVersionAsVariationSameCohort {
+      @BeforeEach
+      fun setup() {
+        val mockUserCohort = UserCohort(Cohort.PRISON)
+        whenever(userCohortService.getUserCohort(authentication)).thenReturn(mockUserCohort)
+        whenever(userCohortService.matchesNofifyingOrg(mockUserCohort, "PRISON")).thenReturn(true)
+        service.createVersion(order.id, authentication, RequestType.VARIATION)
+      }
+
+      @Test
+      fun `Should not clear notifying org when user type matches`() {
+        argumentCaptor<Order>().apply {
+          verify(repo, times(1)).save(capture())
+          assertThat(firstValue.versions.last().interestedParties?.notifyingOrganisation).isNotNull()
+          assertThat(firstValue.versions.last().interestedParties?.notifyingOrganisationName).isNotNull()
+          assertThat(firstValue.versions.last().interestedParties?.notifyingOrganisationEmail).isNotNull()
+        }
       }
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/OrderServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/OrderServiceTest.kt
@@ -30,6 +30,7 @@ import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.mo
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.InstallationLocation
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.Order
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.OrderVersion
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.ProbationDeliveryUnit
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.auth.Cohort
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.auth.UserCohort
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.criteria.OrderListCriteria
@@ -43,6 +44,7 @@ import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.mo
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.OrderStatus
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.Prison
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.RequestType
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.ResponsibleOrganisation
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.SubmissionStatus
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.fms.FmsDeviceWearerSubmissionResult
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.fms.FmsMonitoringOrderSubmissionResult
@@ -831,16 +833,68 @@ class OrderServiceTest {
         val mockUserCohort = UserCohort(Cohort.PRISON)
         whenever(userCohortService.getUserCohort(authentication)).thenReturn(mockUserCohort)
         whenever(userCohortService.matchesNofifyingOrg(mockUserCohort.cohort, "PRISON")).thenReturn(true)
-        service.createVersion(order.id, authentication, RequestType.VARIATION)
       }
 
       @Test
       fun `Should not clear notifying org when user type matches`() {
+        service.createVersion(order.id, authentication, RequestType.VARIATION)
         argumentCaptor<Order>().apply {
           verify(repo, times(1)).save(capture())
           assertThat(firstValue.versions.last().interestedParties?.notifyingOrganisation).isNotNull()
           assertThat(firstValue.versions.last().interestedParties?.notifyingOrganisationName).isNotNull()
           assertThat(firstValue.versions.last().interestedParties?.notifyingOrganisationEmail).isNotNull()
+        }
+      }
+
+      @Test
+      fun `Should copy responsible organisation and officer and PDU if start Date is in the future`() {
+        order.monitoringConditions!!.startDate = ZonedDateTime.now().plusMonths(1)
+        order.interestedParties!!.responsibleOrganisation = ResponsibleOrganisation.PROBATION.name
+        order.interestedParties!!.responsibleOfficerFirstName = "John"
+        order.interestedParties!!.responsibleOfficerLastName = "Smith"
+        order.interestedParties!!.responsibleOfficerEmail = "a@b.com"
+        order.interestedParties!!.responsibleOrganisationRegion = "NORTH EAST"
+        order.interestedParties!!.responsibleOrganisationEmail = "a@b.com"
+        order.probationDeliveryUnit = ProbationDeliveryUnit(versionId = UUID.randomUUID(), unit = "Mock")
+        whenever(repo.findById(order.id)).thenReturn(Optional.of(order))
+        service.createVersion(order.id, authentication, RequestType.VARIATION)
+        argumentCaptor<Order>().apply {
+          verify(repo, times(1)).save(capture())
+          assertThat(firstValue.versions.last().interestedParties?.responsibleOrganisation).isEqualTo(
+            ResponsibleOrganisation.PROBATION.name,
+          )
+          assertThat(firstValue.versions.last().interestedParties?.responsibleOfficerFirstName).isEqualTo("John")
+          assertThat(firstValue.versions.last().interestedParties?.responsibleOfficerLastName).isEqualTo("Smith")
+          assertThat(firstValue.versions.last().interestedParties?.responsibleOfficerEmail).isEqualTo("a@b.com")
+          assertThat(
+            firstValue.versions.last().interestedParties?.responsibleOrganisationRegion,
+          ).isEqualTo("NORTH EAST")
+          assertThat(firstValue.versions.last().interestedParties?.responsibleOrganisationEmail).isEqualTo("a@b.com")
+          assertThat(firstValue.versions.last().probationDeliveryUnit?.unit).isEqualTo("Mock")
+        }
+      }
+
+      @Test
+      fun `Should not copy responsible organisation and officer and PDU if start Date is in the future`() {
+        order.monitoringConditions!!.startDate = ZonedDateTime.now().plusMonths(-1)
+        order.interestedParties!!.responsibleOrganisation = ResponsibleOrganisation.PROBATION.name
+        order.interestedParties!!.responsibleOfficerFirstName = "John"
+        order.interestedParties!!.responsibleOfficerLastName = "Smith"
+        order.interestedParties!!.responsibleOfficerEmail = "a@b.com"
+        order.interestedParties!!.responsibleOrganisationRegion = "NORTH EAST"
+        order.interestedParties!!.responsibleOrganisationEmail = "a@b.com"
+        order.probationDeliveryUnit = ProbationDeliveryUnit(versionId = UUID.randomUUID(), unit = "Mock")
+        whenever(repo.findById(order.id)).thenReturn(Optional.of(order))
+        service.createVersion(order.id, authentication, RequestType.VARIATION)
+        argumentCaptor<Order>().apply {
+          verify(repo, times(1)).save(capture())
+          assertThat(firstValue.versions.last().interestedParties?.responsibleOrganisation).isNull()
+          assertThat(firstValue.versions.last().interestedParties?.responsibleOfficerFirstName).isNull()
+          assertThat(firstValue.versions.last().interestedParties?.responsibleOfficerLastName).isNull()
+          assertThat(firstValue.versions.last().interestedParties?.responsibleOfficerEmail).isNull()
+          assertThat(firstValue.versions.last().interestedParties?.responsibleOrganisationRegion).isNull()
+          assertThat(firstValue.versions.last().interestedParties?.responsibleOrganisationEmail).isNull()
+          assertThat(firstValue.versions.last().probationDeliveryUnit).isNull()
         }
       }
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/OrderServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/OrderServiceTest.kt
@@ -823,17 +823,6 @@ class OrderServiceTest {
       }
     }
 
-    @Test
-    fun `It should not clone interested Parties and pdu if current version start date is in the past`() {
-      order.monitoringConditions!!.startDate = ZonedDateTime.now().plusDays(-10)
-      service.createVersion(order.id, authentication, RequestType.VARIATION)
-      argumentCaptor<Order>().apply {
-        verify(repo, times(1)).save(capture())
-        assertThat(firstValue.versions.last().interestedParties).isNull()
-        assertThat(firstValue.versions.last().probationDeliveryUnit).isNull()
-      }
-    }
-
     @Nested
     @DisplayName("Create Version as Variation")
     inner class CreateVersionAsVariationSameCohort {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/OrderServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/OrderServiceTest.kt
@@ -841,7 +841,7 @@ class OrderServiceTest {
       fun setup() {
         val mockUserCohort = UserCohort(Cohort.PRISON)
         whenever(userCohortService.getUserCohort(authentication)).thenReturn(mockUserCohort)
-        whenever(userCohortService.matchesNofifyingOrg(mockUserCohort, "PRISON")).thenReturn(true)
+        whenever(userCohortService.matchesNofifyingOrg(mockUserCohort.cohort, "PRISON")).thenReturn(true)
         service.createVersion(order.id, authentication, RequestType.VARIATION)
       }
 
@@ -887,64 +887,6 @@ class OrderServiceTest {
           assertThat(firstValue.versions.first().type).isEqualTo(RequestType.REJECTED)
         }
       }
-    }
-  }
-
-  @ParameterizedTest(
-    name = "It should clone NO if user cohort is same as original notifying org - {0} -> {1}",
-  )
-  @MethodSource("userCohortSameAsNotifyingOrgArguments")
-  fun `It should clone NO if user cohort is same as original notifying org`(
-    cohort: Cohort,
-    notifyingOrganisation: String,
-  ) {
-    val originalVersionId: UUID = UUID.randomUUID()
-    val order = TestUtilities.createReadyToSubmitOrder(
-      versionId = originalVersionId,
-      status = OrderStatus.SUBMITTED,
-      notifyingOrganisation = notifyingOrganisation,
-      notifyingOrganisationName = "Mock org",
-
-    )
-    whenever(userCohortService.getUserCohort(authentication)).thenReturn(UserCohort(cohort))
-    whenever(repo.findById(order.id)).thenReturn(Optional.of(order))
-    whenever(repo.save(order)).thenReturn(order)
-
-    service.createVersion(order.id, authentication, RequestType.VARIATION)
-
-    argumentCaptor<Order>().apply {
-      verify(repo, times(1)).save(capture())
-      assertThat(firstValue.versions.last().interestedParties?.notifyingOrganisation).isNotNull()
-      assertThat(firstValue.versions.last().interestedParties?.notifyingOrganisationName).isNotNull()
-    }
-  }
-
-  @ParameterizedTest(
-    name = "It should  not clone NO if user cohort is not same as original notifying org - {0} -> {1}",
-  )
-  @MethodSource("userCohortNotSameAsNotifyingOrgArguments")
-  fun `It should not clone NO if user cohort is not same as original notifying org`(
-    cohort: Cohort,
-    notifyingOrganisation: String,
-  ) {
-    val originalVersionId: UUID = UUID.randomUUID()
-    val order = TestUtilities.createReadyToSubmitOrder(
-      versionId = originalVersionId,
-      status = OrderStatus.SUBMITTED,
-      notifyingOrganisation = notifyingOrganisation,
-      notifyingOrganisationName = "Mock org",
-
-    )
-    whenever(userCohortService.getUserCohort(authentication)).thenReturn(UserCohort(cohort))
-    whenever(repo.findById(order.id)).thenReturn(Optional.of(order))
-    whenever(repo.save(order)).thenReturn(order)
-
-    service.createVersion(order.id, authentication, RequestType.VARIATION)
-
-    argumentCaptor<Order>().apply {
-      verify(repo, times(1)).save(capture())
-      assertThat(firstValue.versions.last().interestedParties?.notifyingOrganisation).isNull()
-      assertThat(firstValue.versions.last().interestedParties?.notifyingOrganisationName).isNull()
     }
   }
 
@@ -1105,28 +1047,6 @@ class OrderServiceTest {
       Arguments.of(NotifyingOrganisationDDv5.FAMILY_COURT.name, "Family Court"),
       Arguments.of(NotifyingOrganisationDDv5.HOME_OFFICE.name, "Home Office"),
       Arguments.of(NotifyingOrganisationDDv5.YOUTH_CUSTODY_SERVICE.name, ""),
-    )
-
-    @JvmStatic
-    fun userCohortSameAsNotifyingOrgArguments() = listOf(
-      Arguments.of(Cohort.PRISON, "PRISON"),
-      Arguments.of(Cohort.PRISON, "YOUTH_CUSTODY_SERVICE"),
-      Arguments.of(Cohort.PROBATION, "PROBATION"),
-      Arguments.of(Cohort.COURT, "CIVIL_COUNTY_COURT"),
-      Arguments.of(Cohort.COURT, "CROWN_COURT"),
-      Arguments.of(Cohort.COURT, "MAGISTRATES_COURT"),
-      Arguments.of(Cohort.COURT, "MILITARY_COURT"),
-      Arguments.of(Cohort.COURT, "SCOTTISH_COURT"),
-      Arguments.of(Cohort.COURT, "FAMILY_COURT"),
-      Arguments.of(Cohort.COURT, "YOUTH_COURT"),
-      Arguments.of(Cohort.HOME_OFFICE, "HOME_OFFICE"),
-    )
-
-    @JvmStatic
-    fun userCohortNotSameAsNotifyingOrgArguments() = listOf(
-      Arguments.of(Cohort.PRISON, "PROBATION"),
-      Arguments.of(Cohort.PROBATION, "PRISON"),
-      Arguments.of(Cohort.PROBATION, "YOUTH_CUSTODY_SERVICE"),
     )
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/UserCohortServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/UserCohortServiceTest.kt
@@ -12,6 +12,8 @@ import org.springframework.security.oauth2.server.resource.authentication.JwtAut
 import org.springframework.test.context.ActiveProfiles
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.client.ManageUserApi
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.auth.Cohort
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.auth.UserCohort
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.NotifyingOrganisationDDv5
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.external.hmpps.HmppsCaseload
 
 @ActiveProfiles("test")
@@ -71,5 +73,65 @@ class UserCohortServiceTest {
     val result = service.getUserCohort(authentication)
 
     Assertions.assertThat(result.cohort).isEqualTo(Cohort.HOME_OFFICE)
+  }
+
+  @Test
+  fun `matchesNotifyingOrg returns true both prison`() {
+    val testNotifyingOrganisation = NotifyingOrganisationDDv5.PRISON.name
+    val testCohort = UserCohort(cohort = Cohort.PRISON)
+
+    val result = service.matchesNofifyingOrg(testCohort, testNotifyingOrganisation)
+
+    Assertions.assertThat(result).isEqualTo(true)
+  }
+
+  @Test
+  fun `matchesNotifyingOrg returns true both probation`() {
+    val testNotifyingOrganisation = NotifyingOrganisationDDv5.PROBATION.name
+    val testCohort = UserCohort(cohort = Cohort.PROBATION)
+
+    val result = service.matchesNofifyingOrg(testCohort, testNotifyingOrganisation)
+
+    Assertions.assertThat(result).isEqualTo(true)
+  }
+
+  @Test
+  fun `matchesNotifyingOrg returns false prison probation`() {
+    val testNotifyingOrganisation = NotifyingOrganisationDDv5.PRISON.name
+    val testCohort = UserCohort(cohort = Cohort.PROBATION)
+
+    val result = service.matchesNofifyingOrg(testCohort, testNotifyingOrganisation)
+
+    Assertions.assertThat(result).isEqualTo(false)
+  }
+
+  @Test
+  fun `matchesNotifyingOrg returns true court court`() {
+    val testNotifyingOrganisation = NotifyingOrganisationDDv5.CIVIL_COUNTY_COURT.name
+    val testCohort = UserCohort(cohort = Cohort.COURT)
+
+    val result = service.matchesNofifyingOrg(testCohort, testNotifyingOrganisation)
+
+    Assertions.assertThat(result).isEqualTo(true)
+  }
+
+  @Test
+  fun `matchesNotifyingOrg returns true home office home office`() {
+    val testNotifyingOrganisation = NotifyingOrganisationDDv5.HOME_OFFICE.name
+    val testCohort = UserCohort(cohort = Cohort.HOME_OFFICE)
+
+    val result = service.matchesNofifyingOrg(testCohort, testNotifyingOrganisation)
+
+    Assertions.assertThat(result).isEqualTo(true)
+  }
+
+  @Test
+  fun `matchesNotifyingOrg returns false when cohort is other`() {
+    val testNotifyingOrganisation = NotifyingOrganisationDDv5.HOME_OFFICE.name
+    val testCohort = UserCohort(cohort = Cohort.OTHER)
+
+    val result = service.matchesNofifyingOrg(testCohort, testNotifyingOrganisation)
+
+    Assertions.assertThat(result).isEqualTo(false)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/UserCohortServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/UserCohortServiceTest.kt
@@ -3,8 +3,12 @@ package uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.s
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.`when`
+import org.mockito.kotlin.times
 import org.springframework.boot.test.autoconfigure.json.JsonTest
 import org.springframework.security.core.GrantedAuthority
 import org.springframework.security.oauth2.jwt.Jwt
@@ -12,8 +16,6 @@ import org.springframework.security.oauth2.server.resource.authentication.JwtAut
 import org.springframework.test.context.ActiveProfiles
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.client.ManageUserApi
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.auth.Cohort
-import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.auth.UserCohort
-import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.NotifyingOrganisationDDv5
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.external.hmpps.HmppsCaseload
 
 @ActiveProfiles("test")
@@ -75,63 +77,53 @@ class UserCohortServiceTest {
     Assertions.assertThat(result.cohort).isEqualTo(Cohort.HOME_OFFICE)
   }
 
-  @Test
-  fun `matchesNotifyingOrg returns true both prison`() {
-    val testNotifyingOrganisation = NotifyingOrganisationDDv5.PRISON.name
-    val testCohort = UserCohort(cohort = Cohort.PRISON)
-
-    val result = service.matchesNofifyingOrg(testCohort, testNotifyingOrganisation)
-
-    Assertions.assertThat(result).isEqualTo(true)
-  }
-
-  @Test
-  fun `matchesNotifyingOrg returns true both probation`() {
-    val testNotifyingOrganisation = NotifyingOrganisationDDv5.PROBATION.name
-    val testCohort = UserCohort(cohort = Cohort.PROBATION)
-
-    val result = service.matchesNofifyingOrg(testCohort, testNotifyingOrganisation)
+  @ParameterizedTest(
+    name = "It should return true if user cohort is same as original notifying org - {0} -> {1}",
+  )
+  @MethodSource("userCohortSameAsNotifyingOrgArguments")
+  fun `It should return true if user cohort is same as original notifying org`(
+    cohort: Cohort,
+    notifyingOrganisation: String,
+  ) {
+    val result = service.matchesNofifyingOrg(cohort, notifyingOrganisation)
 
     Assertions.assertThat(result).isEqualTo(true)
   }
 
-  @Test
-  fun `matchesNotifyingOrg returns false prison probation`() {
-    val testNotifyingOrganisation = NotifyingOrganisationDDv5.PRISON.name
-    val testCohort = UserCohort(cohort = Cohort.PROBATION)
-
-    val result = service.matchesNofifyingOrg(testCohort, testNotifyingOrganisation)
+  @ParameterizedTest(
+    name = "It should return false if user cohort is not same as original notifying org - {0} -> {1}",
+  )
+  @MethodSource("userCohortNotSameAsNotifyingOrgArguments")
+  fun `It should not clone NO if user cohort is not same as original notifying org`(
+    cohort: Cohort,
+    notifyingOrganisation: String,
+  ) {
+    val result = service.matchesNofifyingOrg(cohort, notifyingOrganisation)
 
     Assertions.assertThat(result).isEqualTo(false)
   }
 
-  @Test
-  fun `matchesNotifyingOrg returns true court court`() {
-    val testNotifyingOrganisation = NotifyingOrganisationDDv5.CIVIL_COUNTY_COURT.name
-    val testCohort = UserCohort(cohort = Cohort.COURT)
+  companion object {
+    @JvmStatic
+    fun userCohortSameAsNotifyingOrgArguments() = listOf(
+      Arguments.of(Cohort.PRISON, "PRISON"),
+      Arguments.of(Cohort.PRISON, "YOUTH_CUSTODY_SERVICE"),
+      Arguments.of(Cohort.PROBATION, "PROBATION"),
+      Arguments.of(Cohort.COURT, "CIVIL_COUNTY_COURT"),
+      Arguments.of(Cohort.COURT, "CROWN_COURT"),
+      Arguments.of(Cohort.COURT, "MAGISTRATES_COURT"),
+      Arguments.of(Cohort.COURT, "MILITARY_COURT"),
+      Arguments.of(Cohort.COURT, "SCOTTISH_COURT"),
+      Arguments.of(Cohort.COURT, "FAMILY_COURT"),
+      Arguments.of(Cohort.COURT, "YOUTH_COURT"),
+      Arguments.of(Cohort.HOME_OFFICE, "HOME_OFFICE"),
+    )
 
-    val result = service.matchesNofifyingOrg(testCohort, testNotifyingOrganisation)
-
-    Assertions.assertThat(result).isEqualTo(true)
-  }
-
-  @Test
-  fun `matchesNotifyingOrg returns true home office home office`() {
-    val testNotifyingOrganisation = NotifyingOrganisationDDv5.HOME_OFFICE.name
-    val testCohort = UserCohort(cohort = Cohort.HOME_OFFICE)
-
-    val result = service.matchesNofifyingOrg(testCohort, testNotifyingOrganisation)
-
-    Assertions.assertThat(result).isEqualTo(true)
-  }
-
-  @Test
-  fun `matchesNotifyingOrg returns false when cohort is other`() {
-    val testNotifyingOrganisation = NotifyingOrganisationDDv5.HOME_OFFICE.name
-    val testCohort = UserCohort(cohort = Cohort.OTHER)
-
-    val result = service.matchesNofifyingOrg(testCohort, testNotifyingOrganisation)
-
-    Assertions.assertThat(result).isEqualTo(false)
+    @JvmStatic
+    fun userCohortNotSameAsNotifyingOrgArguments() = listOf(
+      Arguments.of(Cohort.PRISON, "PROBATION"),
+      Arguments.of(Cohort.PROBATION, "PRISON"),
+      Arguments.of(Cohort.PROBATION, "YOUTH_CUSTODY_SERVICE"),
+    )
   }
 }


### PR DESCRIPTION
### Context

Ticket: https://dsdmoj.atlassian.net/browse/ELM-4783

We seem to always delete the notifying organisation on cloning an order.

This is a pain point for the user having to enter information again and leads to issues with bespoke areas of the form if they try and change something without setting the notifying organisation.

We should only delete the notifying organisation details when:
- The user is cloning an order
- The User type from Auth does NOT match the Notifying organisation

# Backend PR Checklist

These are items (excluding GitHub Checks) which should be confirmed before a branch is ready to merge.

- [x] Ensure backwards compatibility (did not remove existing code, only added new)
- [x] Did not remove/edit existing enum values
- [x] Added relevant automation tests (updated or new)
- [x] Verified Serco Mapping changes are safe for production (e.g Postman)
- [x] Relevant documentation is updated and linked
- [x] PR has been self-reviewed by the author
- [x] Reused existing components before creating new ones
- [x] Code refined to the best of your knowledge
- [x] Ticket number included in the description
- [ ] (If applicable) Ran frontend scenario tests against backend changes