### PR TITLE
Not mark dev image as latest

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -53,13 +53,27 @@ jobs:
       - app_version
   build:
     name: Build docker image from hmpps-github-actions
+    if: github.ref == 'refs/heads/main'
     uses: ministryofjustice/hmpps-github-actions/.github/workflows/docker_build.yml@v2 # WORKFLOW_VERSION
     needs:
       - gradle_verify
     with:
       docker_registry: 'ghcr.io'
       registry_org: 'ministryofjustice'
-      additional_docker_tag: ${{ inputs.additional_docker_tag }}
+      additional_docker_tag: 'main'
+      push: ${{ inputs.push || inputs.push == null }}
+      docker_multiplatform: false
+      download_build_artifacts: true
+  build_dev:
+    name: Build docker image from hmpps-github-actions for dev
+    if: github.ref != 'refs/heads/main'
+    uses: ministryofjustice/hmpps-github-actions/.github/workflows/docker_build.yml@v2 # WORKFLOW_VERSION
+    needs:
+      - gradle_verify
+    with:
+      docker_registry: 'ghcr.io'
+      registry_org: 'ministryofjustice'
+      additional_docker_tag: 'dev'
       push: ${{ inputs.push || inputs.push == null }}
       docker_multiplatform: false
       download_build_artifacts: true
@@ -67,7 +81,7 @@ jobs:
     name: Deploy to the dev environment
     if: github.ref != 'refs/heads/main'
     needs:
-      - build
+      - build_dev
       - helm_lint
     uses: ministryofjustice/hmpps-github-actions/.github/workflows/deploy_env.yml@v2
     secrets: inherit

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -73,7 +73,7 @@ jobs:
     with:
       docker_registry: 'ghcr.io'
       registry_org: 'ministryofjustice'
-      additional_docker_tag: '${{ inputs.additional_docker_tag }}'
+      additional_docker_tag: 'dev'
       push: ${{ inputs.push || inputs.push == null }}
       docker_multiplatform: false
       download_build_artifacts: true

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -53,6 +53,7 @@ jobs:
       - app_version
   build:
     name: Build docker image from hmpps-github-actions
+    if: github.ref == 'refs/heads/main'
     uses: ministryofjustice/hmpps-github-actions/.github/workflows/docker_build.yml@v2 # WORKFLOW_VERSION
     needs:
       - gradle_verify
@@ -63,11 +64,24 @@ jobs:
       push: ${{ inputs.push || inputs.push == null }}
       docker_multiplatform: false
       download_build_artifacts: true
+  build_dev:
+    name: Build docker image from hmpps-github-actions for dev
+    if: github.ref != 'refs/heads/main'
+    uses: ministryofjustice/hmpps-github-actions/.github/workflows/docker_build.yml@v2 # WORKFLOW_VERSION
+    needs:
+      - gradle_verify
+    with:
+      docker_registry: 'quay.io'
+      registry_org: 'ministryofjustice'
+      additional_docker_tag: ${{ inputs.additional_docker_tag }}
+      push: ${{ inputs.push || inputs.push == null }}
+      docker_multiplatform: false
+      download_build_artifacts: true
   deploy_dev:
     name: Deploy to the dev environment
     if: github.ref != 'refs/heads/main'
     needs:
-      - build
+      - build_dev
       - helm_lint
     uses: ministryofjustice/hmpps-github-actions/.github/workflows/deploy_env.yml@v2
     secrets: inherit

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -60,7 +60,7 @@ jobs:
     with:
       docker_registry: 'ghcr.io'
       registry_org: 'ministryofjustice'
-      additional_docker_tag: 'main'
+      additional_docker_tag: ${{ inputs.additional_docker_tag }}
       push: ${{ inputs.push || inputs.push == null }}
       docker_multiplatform: false
       download_build_artifacts: true
@@ -73,10 +73,11 @@ jobs:
     with:
       docker_registry: 'ghcr.io'
       registry_org: 'ministryofjustice'
-      additional_docker_tag: 'dev'
+      additional_docker_tag: '${{ inputs.additional_docker_tag }}'
       push: ${{ inputs.push || inputs.push == null }}
       docker_multiplatform: false
       download_build_artifacts: true
+      tag_latest: false
   deploy_dev:
     name: Deploy to the dev environment
     if: github.ref != 'refs/heads/main'

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -73,7 +73,7 @@ jobs:
     with:
       docker_registry: 'ghcr.io'
       registry_org: 'ministryofjustice'
-      additional_docker_tag: 'dev'
+      additional_docker_tag: ${{ inputs.additional_docker_tag }}
       push: ${{ inputs.push || inputs.push == null }}
       docker_multiplatform: false
       download_build_artifacts: true

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -73,7 +73,7 @@ jobs:
     with:
       docker_registry: 'ghcr.io'
       registry_org: 'ministryofjustice'
-      additional_docker_tag: ${{ inputs.additional_docker_tag }}
+      additional_docker_tag: 'dev'
       push: ${{ inputs.push || inputs.push == null }}
       docker_multiplatform: false
       download_build_artifacts: true
@@ -88,7 +88,7 @@ jobs:
     secrets: inherit
     with:
       environment: 'dev'
-      app_version: '${{ needs.build.outputs.app_version }}'
+      app_version: '${{ needs.build_dev.outputs.app_version }}'
       helm_timeout: '5m'
   deploy_preprod:
     name: Deploy to the preprod environment

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -77,19 +77,6 @@ jobs:
       push: ${{ inputs.push || inputs.push == null }}
       docker_multiplatform: false
       download_build_artifacts: true
-  build_dev:
-    name: Build docker image from hmpps-github-actions for dev
-    if: github.ref != 'refs/heads/main'
-    uses: ministryofjustice/hmpps-github-actions/.github/workflows/docker_build.yml@v2 # WORKFLOW_VERSION
-    needs:
-      - gradle_verify
-    with:
-      docker_registry: 'quay.io'
-      registry_org: 'ministryofjustice'
-      additional_docker_tag: ${{ inputs.additional_docker_tag }}
-      push: ${{ inputs.push || inputs.push == null }}
-      docker_multiplatform: false
-      download_build_artifacts: true
   deploy_dev:
     name: Deploy to the dev environment
     if: github.ref != 'refs/heads/main'

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -2,9 +2,9 @@ spring:
   jpa:
     show-sql: true
     hibernate:
-      ddl-auto: create
+      ddl-auto: validate
   datasource:
-    url: jdbc:postgresql://localhost:5432/postgres?sslmode=prefer
+    url: jdbc:postgresql://localhost:5432/postgres?sslmode:prefer
     username: postgres
     password: postgres
   cloud:
@@ -23,20 +23,29 @@ spring:
 #      queueName: court_case_events_queue
 #      queueArn: arn:aws:sns:eu-west-2:000000000000:court_case_events_queue
 #      dlqName: court_case_events_dead_letter_queue
+settings:
+  data-dictionary-version: DDV6
+  device-wearer-payload-version: Dev
 hmpps.s3:
   bucketName: testbucket
 services:
   hmppsauth:
-    url: http://localhost:9090/auth
-#    url: https://sign-in-dev.hmpps.service.justice.gov.uk/auth
+    url: http://localhost:9091/auth
+  #    url: https://sign-in-dev.hmpps.service.justice.gov.uk/auth
   document:
-    url: http://localhost:8081/
+    url: http://localhost:9091/hmpps
 #    url: https://document-api-dev.hmpps.service.justice.gov.uk/
-  manage-user:
-    url: http://localhost:9091/manage-user/
-#    url: https://manage-users-dev.hmpps.service.justice.gov.uk/
-CLIENT_ID: hmpps-electronic-monitoring-create-an-order-api
-CLIENT_SECRET: clientsecret
 
-settings:
-  device-wearer-payload-version: Dev
+CLIENT_ID: clientid
+CLIENT_SECRET: clientsecret
+SERCO_AUTH_URL: http://localhost:9091/auth/oauth/token
+SERCO_CLIENT_ID: clientid
+SERCO_CLIENT_SECRET: clientsecret
+SERCO_USERNAME: serco
+SERCO_PASSWORD: serco
+SERCO_URL: http://localhost:9091/fms
+CEMO_FMS_INTEGRATION_ENABLED: true
+MANAGE_USER_URL: http://localhost:9091/manage-user
+DDV6_COURT_MAPPINGS: true
+
+

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -2,49 +2,32 @@ spring:
   jpa:
     show-sql: true
     hibernate:
-      ddl-auto: validate
-  datasource:
-    url: jdbc:postgresql://localhost:5432/postgres?sslmode:prefer
-    username: postgres
-    password: postgres
-  cloud:
-    aws:
-      region:
-        static: eu-west-2
-      endpoint: http://127.0.0.1:4566
+      ddl-auto: create
+    datasource:
+      url: jdbc:postgresql://localhost:5432/postgres?sslmode=prefer
+      username: postgres
+      password: postgres
+    cloud:
+  #      queueName: court_case_events_queue
+  #      queueArn: arn:aws:sns:eu-west-2:000000000000:court_case_events_queue
+  #      dlqName: court_case_events_dead_letter_queue
+  hmpps.s3:
+    bucketName: testbucket
+  services:
+    hmppsauth:
+      url: http://localhost:9090/auth
+    #    url: https://sign-in-dev.hmpps.service.justice.gov.uk/auth
+    document:
+      url: http://localhost:8081/
+    #    url: https://document-api-dev.hmpps.service.justice.gov.uk/
+    manage-user:
+      url: http://localhost:9091/manage-user/
+  #    url: https://manage-users-dev.hmpps.service.justice.gov.uk/
+  CLIENT_ID: hmpps-electronic-monitoring-create-an-order-api
+  CLIENT_SECRET: clientsecret
 
-#Uncomment the below to setup localstack for sqs listener, require localstack running in docker compose
-#hmpps.sqs:
-#  provider: localstack
-#  localstackUrl: http://localhost:4566
-#  useWebToken: false
-#  queues:
-#    courthearingeventqueue:
-#      queueName: court_case_events_queue
-#      queueArn: arn:aws:sns:eu-west-2:000000000000:court_case_events_queue
-#      dlqName: court_case_events_dead_letter_queue
-settings:
-  data-dictionary-version: DDV6
-  device-wearer-payload-version: Dev
-hmpps.s3:
-  bucketName: testbucket
-services:
-  hmppsauth:
-    url: http://localhost:9091/auth
-  #    url: https://sign-in-dev.hmpps.service.justice.gov.uk/auth
-  document:
-    url: http://localhost:9091/hmpps
-#    url: https://document-api-dev.hmpps.service.justice.gov.uk/
-
-CLIENT_ID: clientid
-CLIENT_SECRET: clientsecret
-SERCO_AUTH_URL: http://localhost:9091/auth/oauth/token
-SERCO_CLIENT_ID: clientid
-SERCO_CLIENT_SECRET: clientsecret
-SERCO_USERNAME: serco
-SERCO_PASSWORD: serco
-SERCO_URL: http://localhost:9091/fms
-CEMO_FMS_INTEGRATION_ENABLED: true
+  settings:
+    device-wearer-payload-version: Dev
 MANAGE_USER_URL: http://localhost:9091/manage-user
 DDV6_COURT_MAPPINGS: true
 

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -3,32 +3,40 @@ spring:
     show-sql: true
     hibernate:
       ddl-auto: create
-    datasource:
-      url: jdbc:postgresql://localhost:5432/postgres?sslmode=prefer
-      username: postgres
-      password: postgres
-    cloud:
-  #      queueName: court_case_events_queue
-  #      queueArn: arn:aws:sns:eu-west-2:000000000000:court_case_events_queue
-  #      dlqName: court_case_events_dead_letter_queue
-  hmpps.s3:
-    bucketName: testbucket
-  services:
-    hmppsauth:
-      url: http://localhost:9090/auth
-    #    url: https://sign-in-dev.hmpps.service.justice.gov.uk/auth
-    document:
-      url: http://localhost:8081/
-    #    url: https://document-api-dev.hmpps.service.justice.gov.uk/
-    manage-user:
-      url: http://localhost:9091/manage-user/
-  #    url: https://manage-users-dev.hmpps.service.justice.gov.uk/
-  CLIENT_ID: hmpps-electronic-monitoring-create-an-order-api
-  CLIENT_SECRET: clientsecret
+  datasource:
+    url: jdbc:postgresql://localhost:5432/postgres?sslmode=prefer
+    username: postgres
+    password: postgres
+  cloud:
+    aws:
+      region:
+        static: eu-west-2
+      endpoint: http://127.0.0.1:4566
 
-  settings:
-    device-wearer-payload-version: Dev
-MANAGE_USER_URL: http://localhost:9091/manage-user
-DDV6_COURT_MAPPINGS: true
+#Uncomment the below to setup localstack for sqs listener, require localstack running in docker compose
+#hmpps.sqs:
+#  provider: localstack
+#  localstackUrl: http://localhost:4566
+#  useWebToken: false
+#  queues:
+#    courthearingeventqueue:
+#      queueName: court_case_events_queue
+#      queueArn: arn:aws:sns:eu-west-2:000000000000:court_case_events_queue
+#      dlqName: court_case_events_dead_letter_queue
+hmpps.s3:
+  bucketName: testbucket
+services:
+  hmppsauth:
+    url: http://localhost:9090/auth
+  #    url: https://sign-in-dev.hmpps.service.justice.gov.uk/auth
+  document:
+    url: http://localhost:8081/
+  #    url: https://document-api-dev.hmpps.service.justice.gov.uk/
+  manage-user:
+    url: http://localhost:9091/manage-user/
+#    url: https://manage-users-dev.hmpps.service.justice.gov.uk/
+CLIENT_ID: hmpps-electronic-monitoring-create-an-order-api
+CLIENT_SECRET: clientsecret
 
-
+settings:
+  device-wearer-payload-version: Dev


### PR DESCRIPTION

[Why are we making this change?]

UI scenario tests is pulling latest API docker image, we currently have gated deployment to dev, meaning every PR can have multiple image create, which cause issue with running UI scenario tests.

### Changes proposed in this pull request


Do not mark dev image as latest, only mark latest image build from main as latest, so UI scenario tests only run against latest API main.


<img width="1162" height="552" alt="Screenshot 2026-05-13 at 12 49 48" src="https://github.com/user-attachments/assets/8e80d2b8-8992-4d32-9443-7d11dbdc2102" />



