### PR TITLE
ELM-4807: Default responsible org for home office notifying org if value blank

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/fms/MonitoringOrder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/fms/MonitoringOrder.kt
@@ -727,8 +727,9 @@ data class MonitoringOrder(
 
     private fun getResponsibleOrganisation(interestedParties: InterestedParties): String =
       ResponsibleOrganisation.from(interestedParties.responsibleOrganisation)?.value
-        ?: interestedParties.responsibleOrganisation
-        ?: "N/A"
+        ?: interestedParties.responsibleOrganisation?.takeIf { it.isNotBlank() }
+        ?: "N/A".takeIf { interestedParties.notifyingOrganisation != NotifyingOrganisation.HOME_OFFICE.value }
+        ?: ResponsibleOrganisation.HOME_OFFICE.value
 
     private fun getResponsibleOrganisationRegion(interestedParties: InterestedParties): String {
       if (ResponsibleOrganisation.from(interestedParties.responsibleOrganisation) ==

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/fms/MonitoringOrder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/fms/MonitoringOrder.kt
@@ -728,7 +728,7 @@ data class MonitoringOrder(
     private fun getResponsibleOrganisation(interestedParties: InterestedParties): String =
       ResponsibleOrganisation.from(interestedParties.responsibleOrganisation)?.value
         ?: interestedParties.responsibleOrganisation?.takeIf { it.isNotBlank() }
-        ?: "N/A".takeIf { interestedParties.notifyingOrganisation != NotifyingOrganisation.HOME_OFFICE.value }
+        ?: "".takeIf { interestedParties.notifyingOrganisation != NotifyingOrganisation.HOME_OFFICE.value }
         ?: ResponsibleOrganisation.HOME_OFFICE.value
 
     private fun getResponsibleOrganisationRegion(interestedParties: InterestedParties): String {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/model/fms/MonitoringOrderTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/model/fms/MonitoringOrderTest.kt
@@ -41,6 +41,7 @@ import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.mo
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.FamilyCourtDDv5
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.FmsOrderSource
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.InstallationLocationType
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.NotifyingOrganisation
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.NotifyingOrganisationDDv5
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.OrderType
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.Pilot
@@ -1856,6 +1857,26 @@ class MonitoringOrderTest : OrderTestBase() {
     val result = MonitoringOrder.fromOrder(order, null, mockFeatureFlags, FmsOrderSource.CEMO)
 
     assertThat(result.deviceWearer).isEqualTo("First Last")
+  }
+
+  @Test
+  fun `should default to home office if responsible org`() {
+    val order =
+      createOrder(
+        deviceWearer = createDeviceWearer(
+          firstName = "First",
+          middleName = null,
+          lastName = "Last",
+        ),
+        interestedParties = createInterestedParty(
+          responsibleOrganisation = "",
+          notifyingOrganisation = NotifyingOrganisation.HOME_OFFICE.value,
+        ),
+      )
+
+    val result = MonitoringOrder.fromOrder(order, null, mockFeatureFlags, FmsOrderSource.CEMO)
+
+    assertThat(result.responsibleOrganization).isEqualTo("Home Office")
   }
 
   private fun assertNotifyingOrgNameMapping(


### PR DESCRIPTION


### Context

Ticket: https://dsdmoj.atlassian.net/browse/ELM-4807

[Why are we making this change?]
As part of 4807 we are required to default the responsible org order field if the order is from notifying org home office, in order to avoid that change in the frontend we have opted to conditionally populate this field before sending downstream

[What has been changed?]

getResponsibleOrganisation function checks if resonsible org is populated, if isnt populated and notifying org is home office, default responsible org to home office