### PR TITLE
ELM-4879: Data misalignment issue - DAPOL missed in error

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/fms/MonitoringOrder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/fms/MonitoringOrder.kt
@@ -835,7 +835,7 @@ data class MonitoringOrder(
         return ""
       }
 
-      return if (conditions.dapolMissedInError == YesNoUnknown.YES) "true" else "false"
+      return if (conditions.dapolMissedInError == YesNoUnknown.YES) "true" else ""
     }
 
     private fun getOrderType(orderType: OrderType): String = when (orderType) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/model/fms/MonitoringOrderTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/model/fms/MonitoringOrderTest.kt
@@ -1736,7 +1736,7 @@ class MonitoringOrderTest : OrderTestBase() {
     }
 
     @Test
-    fun `It should map dapolMissedInError as 'false' when DAPOL Pilot but value is no`() {
+    fun `It should map dapolMissedInError as empty string when DAPOL Pilot but value is no`() {
       val order = createOrder(
         dataDictionaryVersion = DataDictionaryVersion.DDV6,
         interestedParties = createInterestedParty(notifyingOrganisation = NotifyingOrganisationDDv5.PROBATION.name),
@@ -1747,7 +1747,7 @@ class MonitoringOrderTest : OrderTestBase() {
       )
       val fmsMonitoringOrder = MonitoringOrder.fromOrder(order, null, mockFeatureFlags, FmsOrderSource.CEMO)
 
-      assertThat(fmsMonitoringOrder.dapolMissedInError).isEqualTo("false")
+      assertThat(fmsMonitoringOrder.dapolMissedInError).isEqualTo("")
     }
 
     @Test


### PR DESCRIPTION
### Context

Ticket: [https://dsdmoj.atlassian.net/browse/ELM-4879](https://dsdmoj.atlassian.net/browse/ELM-4879)

We send False if the user selects 'No' to the DAPOL missed in error question.

When the user selects 'No', CEMO thinks it is a change because nothing was there before, so we will leave it blank.

### Changes proposed in this pull request

If the user selects 'No' for 'DAPOL missed in error', send dapol_missed_in_error as blank.

# Backend PR Checklist

These are items (excluding GitHub Checks) which should be confirmed before a branch is ready to merge.

- [X] Ensure backwards compatibility (did not remove existing code, only added new)
- [X] Did not remove/edit existing enum values
- [X] Added relevant automation tests (updated or new)
- [ ] Verified Serco Mapping changes are safe for production (e.g Postman)
- [X] Relevant documentation is updated and linked
- [X] PR has been self-reviewed by the author
- [X] Reused existing components before creating new ones
- [X] Code refined to the best of your knowledge
- [X] Ticket number included in the description
- [X] (If applicable) Ran frontend scenario tests against backend changes