### PR TITLE
Elm 4827 trail monitoring end date

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/data/ValidationErrors.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/data/ValidationErrors.kt
@@ -162,7 +162,6 @@ object ValidationErrors {
 
   object TrailMonitoringConditions {
     const val START_DATE_REQUIRED: String = "Enter date trail monitoring starts"
-    const val END_DATE_REQUIRED: String = "Enter date trail monitoring ends"
     const val END_DATE_MUST_BE_IN_FUTURE: String = "End date must be in the future"
     const val END_DATE_MUST_BE_AFTER_START_DATE: String =
       "Date trail monitoring ends must be after the date trail monitoring starts"

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/dto/UpdateTrailMonitoringConditionsDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/dto/UpdateTrailMonitoringConditionsDto.kt
@@ -11,7 +11,6 @@ data class UpdateTrailMonitoringConditionsDto(
   @field:NotNull(message = ValidationErrors.TrailMonitoringConditions.START_DATE_REQUIRED)
   val startDate: ZonedDateTime? = null,
 
-  @field:NotNull(message = ValidationErrors.TrailMonitoringConditions.END_DATE_REQUIRED)
   @field:Future(message = ValidationErrors.TrailMonitoringConditions.END_DATE_MUST_BE_IN_FUTURE)
   val endDate: ZonedDateTime? = null,
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/fms/MonitoringOrder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/fms/MonitoringOrder.kt
@@ -462,7 +462,7 @@ data class MonitoringOrder(
           EnforceableCondition(
             deviceType,
             startDate = getBritishDateAndTime(order.monitoringConditionsTrail!!.startDate),
-            endDate = getBritishDateAndTime(order.monitoringConditionsTrail!!.endDate),
+            endDate = getBritishDateAndTime(order.monitoringConditionsTrail!!.endDate ?: defaultEndDate),
           ),
 
         )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/fms/MonitoringOrder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/fms/MonitoringOrder.kt
@@ -462,7 +462,7 @@ data class MonitoringOrder(
           EnforceableCondition(
             deviceType,
             startDate = getBritishDateAndTime(order.monitoringConditionsTrail!!.startDate),
-            endDate = getBritishDateAndTime(order.monitoringConditionsTrail!!.endDate ?: defaultEndDate),
+            endDate = getBritishDateAndTime(order.monitoringConditionsTrail!!.endDate ?: defaultEndDate) ?: "",
           ),
 
         )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/MonitoringConditionsTrailControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/MonitoringConditionsTrailControllerTest.kt
@@ -1,12 +1,17 @@
 package uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.integration.resource
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.MediaType
 import org.springframework.web.reactive.function.BodyInserters
-import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.integration.UpdateOrderIntegrationTestBase
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.integration.UriTestCase
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.TrailMonitoringConditions
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.dto.UpdateTrailMonitoringConditionsDto
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.DeviceType
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.resource.validator.ValidationError
 import java.time.LocalDate
 import java.time.LocalTime
@@ -14,7 +19,8 @@ import java.time.ZoneId
 import java.time.ZonedDateTime
 import java.util.*
 
-class MonitoringConditionsTrailControllerTest : IntegrationTestBase() {
+class MonitoringConditionsTrailControllerTest(@Autowired private val objectMapper: ObjectMapper) :
+  UpdateOrderIntegrationTestBase() {
 
   private val mockStartDate: ZonedDateTime = ZonedDateTime.of(
     LocalDate.of(2025, 1, 1),
@@ -34,77 +40,17 @@ class MonitoringConditionsTrailControllerTest : IntegrationTestBase() {
       "Date trail monitoring ends must be after the date trail monitoring starts"
   }
 
+  override val testUris: List<UriTestCase> =
+    listOf(
+      UriTestCase(
+        uri = "/api/orders/:orderId/monitoring-conditions-trail",
+        createValidBody = { mockValidRequestBody() },
+      ),
+    )
+
   @BeforeEach
   fun setup() {
     repo.deleteAll()
-  }
-
-  @Test
-  fun `Trail monitoring conditions cannot be updated by a different user`() {
-    val order = createOrder()
-
-    webTestClient.put()
-      .uri("/api/orders/${order.id}/monitoring-conditions-trail")
-      .contentType(MediaType.APPLICATION_JSON)
-      .body(
-        BodyInserters.fromValue(
-          """
-            {
-              "startDate": "$mockStartDate",
-              "endDate": "$mockEndDate"
-            }
-          """.trimIndent(),
-        ),
-      )
-      .headers(setAuthorisation("AUTH_ADM_2"))
-      .exchange()
-      .expectStatus()
-      .isNotFound
-  }
-
-  @Test
-  fun `Trail monitoring conditions for a non-existent order are not update-able`() {
-    webTestClient.put()
-      .uri("/api/orders/${UUID.randomUUID()}/monitoring-conditions-trail")
-      .contentType(MediaType.APPLICATION_JSON)
-      .body(
-        BodyInserters.fromValue(
-          """
-            {
-              "startDate": "$mockStartDate",
-              "endDate": "$mockEndDate"
-            }
-          """.trimIndent(),
-        ),
-      )
-      .headers(setAuthorisation("AUTH_ADM"))
-      .exchange()
-      .expectStatus()
-      .isNotFound
-  }
-
-  @Test
-  fun `Trail monitoring conditions cannot be updated for a submitted order`() {
-    val order = createSubmittedOrder()
-
-    webTestClient.put()
-      .uri("/api/orders/${order.id}/monitoring-conditions-trail")
-      .contentType(MediaType.APPLICATION_JSON)
-      .body(
-        BodyInserters.fromValue(
-          """
-            {
-              "startDate": "$mockStartDate",
-              "endDate": "$mockEndDate",
-              "deviceType": "FITTED"
-            }
-          """.trimIndent(),
-        ),
-      )
-      .headers(setAuthorisation("AUTH_ADM"))
-      .exchange()
-      .expectStatus()
-      .isNotFound
   }
 
   @Test
@@ -233,5 +179,14 @@ class MonitoringConditionsTrailControllerTest : IntegrationTestBase() {
     Assertions.assertThat(result.responseBody!!).contains(
       ValidationError("endDate", ErrorMessages.END_DATE_MUST_BE_AFTER_START_DATE),
     )
+  }
+
+  private fun mockValidRequestBody(
+    startDate: ZonedDateTime = ZonedDateTime.now(),
+    endDate: ZonedDateTime = ZonedDateTime.now().plusMonths(1),
+  ): String {
+    val dto = UpdateTrailMonitoringConditionsDto(startDate, endDate, DeviceType.FITTED)
+
+    return objectMapper.writeValueAsString(dto)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/model/fms/MonitoringOrderTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/model/fms/MonitoringOrderTest.kt
@@ -151,6 +151,36 @@ class MonitoringOrderTest : OrderTestBase() {
       )
       assertThat(fmsMonitoringOrder.orderEnd).isEqualTo("2040-01-01 23:59:00")
     }
+
+    @Test
+    fun `It not should default end date to 2040 when no end date provided and data source is COMMON_PLATFORM`() {
+      val trailStartDate = ZonedDateTime.of(2026, 1, 23, 12, 0, 0, 0, ZoneId.of("UTC"))
+      val order = createOrder(
+        monitoringConditions = createMonitoringConditions(
+          trail = true,
+          endDate = null,
+        ),
+        trailMonitoringConditions = TrailMonitoringConditions(
+          versionId = UUID.randomUUID(),
+          startDate = trailStartDate,
+          deviceType = DeviceType.FITTED,
+        ),
+      )
+      val fmsMonitoringOrder = MonitoringOrder.fromOrder(
+        order,
+        caseId = "",
+        featureFlags = mockFeatureFlags,
+        FmsOrderSource.COMMON_PLATFORM,
+      )
+      assertThat(fmsMonitoringOrder.enforceableCondition).contains(
+        EnforceableCondition(
+          condition = "Location Monitoring (Fitted Device)",
+          startDate = "2026-01-23 12:00:00",
+          endDate = "",
+        ),
+      )
+      assertThat(fmsMonitoringOrder.orderEnd).isEqualTo("")
+    }
   }
 
   @Nested

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/model/fms/MonitoringOrderTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/model/fms/MonitoringOrderTest.kt
@@ -120,6 +120,40 @@ class MonitoringOrderTest : OrderTestBase() {
   }
 
   @Nested
+  inner class Trail {
+    @Test
+    fun `It should default end date to 2040 when no end date provided and data source is CEMO`() {
+      val trailStartDate = ZonedDateTime.of(2026, 1, 23, 12, 0, 0, 0, ZoneId.of("UTC"))
+      val order = createOrder(
+        monitoringConditions = createMonitoringConditions(
+          trail = true,
+          endDate = null,
+        ),
+        trailMonitoringConditions = TrailMonitoringConditions(
+          versionId = UUID.randomUUID(),
+          startDate = trailStartDate,
+          deviceType = DeviceType.FITTED,
+        ),
+      )
+      val fmsMonitoringOrder = MonitoringOrder.fromOrder(
+        order,
+        caseId = "",
+        featureFlags = mockFeatureFlags,
+        FmsOrderSource.CEMO,
+      )
+
+      assertThat(fmsMonitoringOrder.enforceableCondition).contains(
+        EnforceableCondition(
+          condition = "Location Monitoring (Fitted Device)",
+          startDate = "2026-01-23 12:00:00",
+          endDate = "2040-01-01 23:59:00",
+        ),
+      )
+      assertThat(fmsMonitoringOrder.orderEnd).isEqualTo("2040-01-01 23:59:00")
+    }
+  }
+
+  @Nested
   inner class EnforcementZone {
     @Test
     fun `It should map exclusion inclusion enforceable condition dates from enforcement zones`() {


### PR DESCRIPTION
### Context

Ticket: https://dsdmoj.atlassian.net/browse/ELM-4827

Default end date when mapping so that the 2040 date is not stored in the database

### Changes proposed in this pull request

Default the end date to 2040 if it is null


# Backend PR Checklist

These are items (excluding GitHub Checks) which should be confirmed before a branch is ready to merge.

- [x] Ensure backwards compatibility (did not remove existing code, only added new)
- [x] Did not remove/edit existing enum values
- [x] Added relevant automation tests (updated or new)
- [x] Verified Serco Mapping changes are safe for production (e.g Postman)
- [x] Relevant documentation is updated and linked
- [x] PR has been self-reviewed by the author
- [x] Reused existing components before creating new ones
- [x] Code refined to the best of your knowledge
- [x] Ticket number included in the description
- [ ] (If applicable) Ran frontend scenario tests against backend changes