### PR TITLE
ELM-4905Apply Adult YCS tag

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/OrderService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/OrderService.kt
@@ -275,7 +275,7 @@ class OrderService(
       }
 
       NotifyingOrganisationDDv5.YOUTH_CUSTODY_SERVICE.name -> {
-        if (order.deviceWearer?.adultAtTimeOfInstallation == false) "Youth YCS" else ""
+        if (order.deviceWearer?.adultAtTimeOfInstallation == false) "Youth YCS" else "Adult YCS"
       }
 
       NotifyingOrganisationDDv5.PROBATION.name -> "Probation"

--- a/src/main/resources/db/migration/V50__Apply_Adult_YCS_Tag.sql
+++ b/src/main/resources/db/migration/V50__Apply_Adult_YCS_Tag.sql
@@ -1,0 +1,8 @@
+UPDATE order_version
+SET tags = CASE when tags is null or tags = '' then concat(tags, 'Adult YCS') ELSE concat(tags, ',Adult YCS') END
+FROM interested_parties, device_wearer
+WHERE order_version.id = interested_parties.version_id
+AND order_version.id = device_wearer.version_id
+  AND order_version.status = 'SUBMITTED'
+  AND interested_parties.notifying_organisation = 'YOUTH_CUSTODY_SERVICE'
+  AND device_wearer.adult_at_time_of_installation = true;

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/OrderServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/OrderServiceTest.kt
@@ -1072,7 +1072,7 @@ class OrderServiceTest {
       Arguments.of(NotifyingOrganisationDDv5.PROBATION.name, "Probation"),
       Arguments.of(NotifyingOrganisationDDv5.CIVIL_COUNTY_COURT.name, "Civil Court"),
       Arguments.of(NotifyingOrganisationDDv5.FAMILY_COURT.name, "Family Court"),
-      Arguments.of(NotifyingOrganisationDDv5.HOME_OFFICE.name, "Home Office")
+      Arguments.of(NotifyingOrganisationDDv5.HOME_OFFICE.name, "Home Office"),
     )
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/OrderServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/OrderServiceTest.kt
@@ -282,6 +282,44 @@ class OrderServiceTest {
     }
   }
 
+  @Test
+  fun `Should add Adult YCS to tags when notifying org is YCS and responsible adult not required`() {
+    val mockOrder = TestUtilities.createReadyToSubmitOrder(
+      startDate = mockStartDate,
+      endDate = mockEndDate,
+      username = "mockUser",
+      notifyingOrganisation = NotifyingOrganisationDDv5.YOUTH_CUSTODY_SERVICE.name,
+    )
+
+    mockOrder.deviceWearer!!.adultAtTimeOfInstallation = true
+
+    reset(repo)
+
+    val mockFmsResult = FmsSubmissionResult(
+      orderId = mockOrder.getCurrentVersion().id,
+      deviceWearerResult = FmsDeviceWearerSubmissionResult(
+        status = SubmissionStatus.SUCCESS,
+        deviceWearerId = "mockDeviceWearerId",
+      ),
+      monitoringOrderResult = FmsMonitoringOrderSubmissionResult(
+        status = SubmissionStatus.SUCCESS,
+        monitoringOrderId = "mockMonitoringOrderId",
+      ),
+      orderSource = FmsOrderSource.CEMO,
+      strategy = FmsSubmissionStrategyKind.ORDER,
+    )
+    whenever(repo.findById(mockOrder.id)).thenReturn(Optional.of(mockOrder))
+    whenever(fmsService.submitOrder(any<Order>(), eq(FmsOrderSource.CEMO))).thenReturn(
+      mockFmsResult,
+    )
+    service.submitOrder(mockOrder.id, authentication, "mockName")
+
+    argumentCaptor<Order>().apply {
+      verify(repo, times(1)).save(capture())
+      assertThat(firstValue.tags!!.split(',')).contains("Adult YCS")
+    }
+  }
+
   @ParameterizedTest
   @MethodSource("tagScenarios")
   fun `Should add correct tag for notifying organisation`(notifyOrgName: String, expectedTag: String) {
@@ -1034,8 +1072,7 @@ class OrderServiceTest {
       Arguments.of(NotifyingOrganisationDDv5.PROBATION.name, "Probation"),
       Arguments.of(NotifyingOrganisationDDv5.CIVIL_COUNTY_COURT.name, "Civil Court"),
       Arguments.of(NotifyingOrganisationDDv5.FAMILY_COURT.name, "Family Court"),
-      Arguments.of(NotifyingOrganisationDDv5.HOME_OFFICE.name, "Home Office"),
-      Arguments.of(NotifyingOrganisationDDv5.YOUTH_CUSTODY_SERVICE.name, ""),
+      Arguments.of(NotifyingOrganisationDDv5.HOME_OFFICE.name, "Home Office")
     )
   }
 }


### PR DESCRIPTION
### Context

Ticket: https://dsdmoj.atlassian.net/browse/ELM-4905

Apply 'Adult YCS' tag to order that has notifying organisation of 'YOUTH_CUSTODY_SERVICE' and deviceWearer. adultAtTimeOfInstallation is true


# Backend PR Checklist

These are items (excluding GitHub Checks) which should be confirmed before a branch is ready to merge.

- [x] Ensure backwards compatibility (did not remove existing code, only added new)
- [x] Did not remove/edit existing enum values
- [x] Added relevant automation tests (updated or new)
- [ ] Verified Serco Mapping changes are safe for production (e.g Postman)
- [ ] Relevant documentation is updated and linked
- [x] PR has been self-reviewed by the author
- [x] Reused existing components before creating new ones
- [x] Code refined to the best of your knowledge
- [x] Ticket number included in the description
- [ ] (If applicable) Ran frontend scenario tests against backend changes