### PR TITLE
Elm 4900 dont clear responsible officer for pre release

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/OrderService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/OrderService.kt
@@ -157,7 +157,14 @@ class OrderService(
               ?.takeIf { isUserFromOriginalNotifyingOrganistion },
             notifyingOrganisationEmail = currentIPs?.notifyingOrganisationEmail
               ?.takeIf { isUserFromOriginalNotifyingOrganistion },
+
             responsibleOrganisation = currentIPs?.responsibleOrganisation?.takeIf {
+              isStartDateInFuture
+            },
+            responsibleOrganisationRegion = currentIPs?.responsibleOrganisationRegion?.takeIf {
+              isStartDateInFuture
+            },
+            responsibleOrganisationEmail = currentIPs?.responsibleOrganisationEmail?.takeIf {
               isStartDateInFuture
             },
             responsibleOfficerName = currentIPs?.responsibleOfficerName?.takeIf {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/OrderService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/OrderService.kt
@@ -24,6 +24,7 @@ import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.mo
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.specification.OrderListSpecification
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.specification.OrderSearchSpecification
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.repository.OrderRepository
+import java.time.ZonedDateTime
 import java.util.*
 
 @Service
@@ -144,6 +145,8 @@ class OrderService(
         val currentIPs = currentVersion.interestedParties
         val isUserFromOriginalNotifyingOrganistion =
           isUserFromOriginalNotifyingOrganistion(token, currentIPs?.notifyingOrganisation)
+        val isStartDateInFuture = order.getMonitoringStartDate()?.isAfter(ZonedDateTime.now()) == true
+
         interestedParties =
           currentVersion.interestedParties?.copy(
             versionId = this.id,
@@ -154,8 +157,26 @@ class OrderService(
               ?.takeIf { isUserFromOriginalNotifyingOrganistion },
             notifyingOrganisationEmail = currentIPs?.notifyingOrganisationEmail
               ?.takeIf { isUserFromOriginalNotifyingOrganistion },
-
+            responsibleOrganisation = currentIPs?.responsibleOrganisation?.takeIf {
+              isStartDateInFuture
+            },
+            responsibleOfficerName = currentIPs?.responsibleOfficerName?.takeIf {
+              isStartDateInFuture
+            },
+            responsibleOfficerFirstName = currentIPs?.responsibleOfficerFirstName?.takeIf {
+              isStartDateInFuture
+            },
+            responsibleOfficerLastName = currentIPs?.responsibleOfficerLastName?.takeIf {
+              isStartDateInFuture
+            },
+            responsibleOfficerEmail = currentIPs?.responsibleOfficerEmail?.takeIf {
+              isStartDateInFuture
+            },
+            responsibleOfficerPhoneNumber = currentIPs?.responsibleOfficerPhoneNumber?.takeIf {
+              isStartDateInFuture
+            },
           )
+
         probationDeliveryUnit =
           currentVersion.probationDeliveryUnit?.copy(versionId = this.id, id = UUID.randomUUID())
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/OrderServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/OrderServiceTest.kt
@@ -573,6 +573,9 @@ class OrderServiceTest {
           assertThat(firstValue.versions.last().interestedParties).isNotNull()
           assertThat(newIP?.versionId).isEqualTo(firstValue.versions.last().id)
           assertThat(newIP?.versionId).isNotEqualTo(originalVersionId)
+          assertThat(newIP?.responsibleOrganisation).isEqualTo(originalIP?.responsibleOrganisation)
+          assertThat(newIP?.responsibleOrganisationRegion).isEqualTo(originalIP?.responsibleOrganisationRegion)
+          assertThat(newIP?.responsibleOrganisationEmail).isEqualTo(originalIP?.responsibleOrganisationEmail)
           assertThat(newIP?.responsibleOfficerName).isEqualTo(originalIP?.responsibleOfficerName)
           assertThat(newIP?.responsibleOfficerFirstName).isEqualTo(originalIP?.responsibleOfficerFirstName)
           assertThat(newIP?.responsibleOfficerLastName).isEqualTo(originalIP?.responsibleOfficerLastName)
@@ -880,6 +883,9 @@ class OrderServiceTest {
           verify(repo, times(1)).save(capture())
 
           val newIP = firstValue.versions.last().interestedParties
+          assertThat(newIP?.responsibleOrganisation).isNull()
+          assertThat(newIP?.responsibleOrganisationRegion).isNull()
+          assertThat(newIP?.responsibleOrganisationEmail).isNull()
           assertThat(newIP?.responsibleOfficerName).isNull()
           assertThat(newIP?.responsibleOfficerFirstName).isNull()
           assertThat(newIP?.responsibleOfficerLastName).isNull()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/OrderServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/OrderServiceTest.kt
@@ -568,12 +568,19 @@ class OrderServiceTest {
       fun `It should clone interestedParties referencing new version and clear notifying organisation data`() {
         argumentCaptor<Order>().apply {
           verify(repo, times(1)).save(capture())
+          val originalIP = firstValue.versions.last().interestedParties
+          val newIP = firstValue.versions.last().interestedParties
           assertThat(firstValue.versions.last().interestedParties).isNotNull()
-          assertThat(firstValue.versions.last().interestedParties?.versionId).isEqualTo(firstValue.versions.last().id)
-          assertThat(firstValue.versions.last().interestedParties?.versionId).isNotEqualTo(originalVersionId)
-          assertThat(firstValue.versions.last().interestedParties?.notifyingOrganisation).isNull()
-          assertThat(firstValue.versions.last().interestedParties?.notifyingOrganisationName).isNull()
-          assertThat(firstValue.versions.last().interestedParties?.notifyingOrganisationEmail).isNull()
+          assertThat(newIP?.versionId).isEqualTo(firstValue.versions.last().id)
+          assertThat(newIP?.versionId).isNotEqualTo(originalVersionId)
+          assertThat(newIP?.responsibleOfficerName).isEqualTo(originalIP?.responsibleOfficerName)
+          assertThat(newIP?.responsibleOfficerFirstName).isEqualTo(originalIP?.responsibleOfficerFirstName)
+          assertThat(newIP?.responsibleOfficerLastName).isEqualTo(originalIP?.responsibleOfficerLastName)
+          assertThat(newIP?.responsibleOfficerEmail).isEqualTo(originalIP?.responsibleOfficerEmail)
+          assertThat(newIP?.responsibleOfficerPhoneNumber).isEqualTo(originalIP?.responsibleOfficerPhoneNumber)
+          assertThat(newIP?.notifyingOrganisation).isNull()
+          assertThat(newIP?.notifyingOrganisationName).isNull()
+          assertThat(newIP?.notifyingOrganisationEmail).isNull()
           assertThat(firstValue.versions.last().interestedParties)
             .usingRecursiveComparison()
             .ignoringCollectionOrder()
@@ -841,6 +848,43 @@ class OrderServiceTest {
           assertThat(firstValue.versions.last().interestedParties?.notifyingOrganisation).isNotNull()
           assertThat(firstValue.versions.last().interestedParties?.notifyingOrganisationName).isNotNull()
           assertThat(firstValue.versions.last().interestedParties?.notifyingOrganisationEmail).isNotNull()
+        }
+      }
+    }
+
+    @Nested
+    @DisplayName("Create Version as Variation")
+    inner class CreateVersionAsVariationInPast {
+      val orderInPast = TestUtilities.createReadyToSubmitOrder(
+        versionId = originalVersionId,
+        startDate = mockStartDate,
+        endDate = mockEndDate,
+        status = OrderStatus.SUBMITTED,
+        dataDictionaryVersion = DataDictionaryVersion.DDV4,
+      ).apply {
+        monitoringConditions?.startDate = ZonedDateTime.now().minusMonths(1)
+      }
+
+      @BeforeEach
+      fun setup() {
+        val featureFlags = FeatureFlags(ddV6CourtMappings = true, dataDictionaryVersion = DataDictionaryVersion.DDV5)
+        service = OrderService(repo, fmsService, featureFlags, userCohortService)
+        whenever(repo.findById(orderInPast.id)).thenReturn(Optional.of(orderInPast))
+        whenever(repo.save(orderInPast)).thenReturn(orderInPast)
+      }
+
+      @Test
+      fun `Should clear notifying org when start date is in past`() {
+        service.createVersion(orderInPast.id, authentication, RequestType.VARIATION)
+        argumentCaptor<Order>().apply {
+          verify(repo, times(1)).save(capture())
+
+          val newIP = firstValue.versions.last().interestedParties
+          assertThat(newIP?.responsibleOfficerName).isNull()
+          assertThat(newIP?.responsibleOfficerFirstName).isNull()
+          assertThat(newIP?.responsibleOfficerLastName).isNull()
+          assertThat(newIP?.responsibleOfficerEmail).isNull()
+          assertThat(newIP?.responsibleOfficerPhoneNumber).isNull()
         }
       }
     }


### PR DESCRIPTION
### Context

Ticket: https://dsdmoj.atlassian.net/browse/ELM-4900

When the user changes an order and the start date of the order is in the future we delete the Responsible Organisation and Responsible Officer.

This means that prison users editing a form pre-release have to enter it all again.

We did this as there were some issue that we believe is corrected with the recent work to separate the Notifying organisation from this section.

Because of this the user has to re-enter all the information again. 

This is both painful and something they could easily get wrong.

### Changes proposed in this pull request

Copy responsible org and officer if the start date is in the future only


# Backend PR Checklist

These are items (excluding GitHub Checks) which should be confirmed before a branch is ready to merge.

- [x] Ensure backwards compatibility (did not remove existing code, only added new)
- [x] Did not remove/edit existing enum values
- [x] Added relevant automation tests (updated or new)
- [x] Verified Serco Mapping changes are safe for production (e.g Postman)
- [x] Relevant documentation is updated and linked
- [x] PR has been self-reviewed by the author
- [x] Reused existing components before creating new ones
- [x] Code refined to the best of your knowledge
- [x] Ticket number included in the description
- [ ] (If applicable) Ran frontend scenario tests against backend changes