### PR TITLE
set new version type as variation if old one is variation

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/OrderService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/OrderService.kt
@@ -111,18 +111,24 @@ class OrderService(
     if (currentVersion.status != OrderStatus.SUBMITTED) {
       throw BadRequestException("Order latest version not submitted")
     }
+    val newVersionType =
+      if (versionType == RequestType.AMEND_ORIGINAL_REQUEST && currentVersion.type == RequestType.VARIATION) {
+        RequestType.VARIATION
+      } else {
+        versionType
+      }
+
     if (versionType == RequestType.AMEND_ORIGINAL_REQUEST) {
       currentVersion.type = RequestType.REJECTED
     }
-    val newVersionNumber = currentVersion.versionId + 1
-    val dataDictionaryVersion = featureFlags.dataDictionaryVersion
+
     val newOrderVersion = OrderVersion(
       orderId = orderId,
-      versionId = newVersionNumber,
+      versionId = currentVersion.versionId + 1,
       status = OrderStatus.IN_PROGRESS,
-      type = versionType,
+      type = newVersionType,
       username = token.name,
-      dataDictionaryVersion = dataDictionaryVersion,
+      dataDictionaryVersion = featureFlags.dataDictionaryVersion,
       fmsResultId = null,
       fmsResultDate = null,
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/OrderServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/OrderServiceTest.kt
@@ -939,11 +939,11 @@ class OrderServiceTest {
       @BeforeEach
       fun setup() {
         whenever(authentication.name).thenReturn(order.username)
-        service.createVersion(order.id, authentication, RequestType.AMEND_ORIGINAL_REQUEST)
       }
 
       @Test
       fun `It should create an new order version with type Request`() {
+        service.createVersion(order.id, authentication, RequestType.AMEND_ORIGINAL_REQUEST)
         argumentCaptor<Order>().apply {
           verify(repo, times(1)).save(capture())
           assertThat(firstValue.id).isEqualTo(order.id)
@@ -957,7 +957,53 @@ class OrderServiceTest {
       }
 
       @Test
+      fun `It should set the type as variation when previous was variation`() {
+        val variationOrder = TestUtilities.createReadyToSubmitOrder(
+          versionId = originalVersionId,
+          requestType = RequestType.VARIATION,
+          startDate = mockStartDate,
+          endDate = mockEndDate,
+          status = OrderStatus.SUBMITTED,
+          dataDictionaryVersion = DataDictionaryVersion.DDV4,
+          installationLocation = InstallationLocation(
+            versionId = originalVersionId,
+            location = InstallationLocationType.PRISON,
+          ),
+          installationAppointment = InstallationAppointment(
+            versionId = originalVersionId,
+            appointmentDate = mockStartDate,
+          ),
+          documents = mutableListOf(
+            AdditionalDocument(
+              versionId = originalVersionId,
+              fileName = "MockFile",
+              fileType = DocumentType.LICENCE,
+              documentId = mockLicenceDocumentId,
+            ),
+            AdditionalDocument(
+              versionId = originalVersionId,
+              fileName = "MockPhotoFile",
+              fileType = DocumentType.PHOTO_ID,
+              documentId = mockPhotoDocumentId,
+            ),
+          ),
+        )
+        whenever(repo.findById(variationOrder.id)).thenReturn(Optional.of(variationOrder))
+        whenever(repo.save(variationOrder)).thenReturn(variationOrder)
+
+        service.createVersion(variationOrder.id, authentication, RequestType.AMEND_ORIGINAL_REQUEST)
+
+        argumentCaptor<Order>().apply {
+          verify(repo, times(1)).save(capture())
+          assertThat(firstValue.id).isEqualTo(variationOrder.id)
+          assertThat(firstValue.versions.count()).isEqualTo(2)
+          assertThat(firstValue.versions.last().type).isEqualTo(RequestType.VARIATION)
+        }
+      }
+
+      @Test
       fun `It should set previous version type to REJECTED`() {
+        service.createVersion(order.id, authentication, RequestType.AMEND_ORIGINAL_REQUEST)
         argumentCaptor<Order>().apply {
           verify(repo, times(1)).save(capture())
           assertThat(firstValue.id).isEqualTo(order.id)


### PR DESCRIPTION
### Context

Ticket: https://dsdmoj.atlassian.net/browse/ELM-4918

If the user is trying to change an order (especially using the ‘Tell us about a change sent by email’ journey) results in a double rejection because by answering ‘Yes’ it is sent as a New order.

### Changes proposed in this pull request

Set new version type to Variation if original was variation


# Backend PR Checklist

These are items (excluding GitHub Checks) which should be confirmed before a branch is ready to merge.

- [x] Ensure backwards compatibility (did not remove existing code, only added new)
- [x] Did not remove/edit existing enum values
- [x] Added relevant automation tests (updated or new)
- [x] Verified Serco Mapping changes are safe for production (e.g Postman)
- [x] Relevant documentation is updated and linked
- [x] PR has been self-reviewed by the author
- [x] Reused existing components before creating new ones
- [x] Code refined to the best of your knowledge
- [x] Ticket number included in the description
- [x] (If applicable) Ran frontend scenario tests against backend changes