### PR TITLE
ELM-4966:Should allow get documents for submitted order

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/AdditionalDocumentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/AdditionalDocumentService.kt
@@ -26,7 +26,7 @@ class AdditionalDocumentService(val webClient: DocumentApiClient) : OrderSection
     username: String,
     documentType: DocumentType,
   ): ResponseEntity<Flux<InputStreamResource>>? {
-    val order = this.findOrder(orderId, username)
+    val order = this.findCohortOrder(orderId, username)
     val doc = order.additionalDocuments.firstOrNull { it.fileType == documentType }
 
     if (doc === null) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/AdditionalDocumentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/AdditionalDocumentService.kt
@@ -26,7 +26,7 @@ class AdditionalDocumentService(val webClient: DocumentApiClient) : OrderSection
     username: String,
     documentType: DocumentType,
   ): ResponseEntity<Flux<InputStreamResource>>? {
-    val order = this.findEditableOrder(orderId, username)
+    val order = this.findOrder(orderId, username)
     val doc = order.additionalDocuments.firstOrNull { it.fileType == documentType }
 
     if (doc === null) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/OrderSectionServiceBase.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/OrderSectionServiceBase.kt
@@ -8,8 +8,10 @@ import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.co
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.data.ValidationErrors
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.InterestedParties
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.Order
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.auth.Cohort
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.NotifyingOrganisationDDv5
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.OrderStatus
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.Prison
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.repository.OrderRepository
 import java.time.OffsetDateTime
 import java.util.*
@@ -19,6 +21,9 @@ abstract class OrderSectionServiceBase {
   @Autowired
   lateinit var orderRepo: OrderRepository
 
+  @Autowired
+  lateinit var userCohortService: UserCohortService
+
   internal fun findOrder(id: UUID, username: String): Order {
     val order = orderRepo.findById(id).orElseThrow {
       EntityNotFoundException(ValidationErrors.OrderSectionServiceBase.noEditableOrderExists(id))
@@ -26,6 +31,35 @@ abstract class OrderSectionServiceBase {
 
     if (order.username != username) {
       throw EntityNotFoundException(ValidationErrors.OrderSectionServiceBase.noEditableOrderExists(id))
+    }
+    return order
+  }
+
+  internal fun findCohortOrder(id: UUID, username: String): Order {
+    val order = orderRepo.findById(id).orElseThrow {
+      EntityNotFoundException(ValidationErrors.OrderSectionServiceBase.noEditableOrderExists(id))
+    }
+    if (order.username == username) {
+      return order
+    }
+
+    val authentication = SecurityContextHolder.getContext().authentication as AuthAwareAuthenticationToken
+    val userCohort = userCohortService.getUserCohort(authentication)
+    if (userCohort.cohort == Cohort.PRISON) {
+      val userPrisons = Prison.fromId(userCohort.activeCaseLoadId)
+
+      if (order.ownerCohort == null ||
+        userPrisons.all { it.name != order.ownerCohort }
+      ) {
+        // allow admin user to all draft orders
+        if (userCohort.activeCaseLoadId != "CADM_I") {
+          throw EntityNotFoundException(ValidationErrors.OrderSectionServiceBase.noEditableOrderExists(id))
+        }
+      }
+    } else {
+      if (order.ownerCohort != userCohort.cohort.name) {
+        throw EntityNotFoundException(ValidationErrors.OrderSectionServiceBase.noEditableOrderExists(id))
+      }
     }
     return order
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/OrderSectionServiceBase.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/OrderSectionServiceBase.kt
@@ -14,16 +14,20 @@ abstract class OrderSectionServiceBase {
   @Autowired
   lateinit var orderRepo: OrderRepository
 
-  internal fun findEditableOrder(id: UUID, username: String): Order {
+  internal fun findOrder(id: UUID, username: String): Order {
     val order = orderRepo.findById(id).orElseThrow {
       EntityNotFoundException(ValidationErrors.OrderSectionServiceBase.noEditableOrderExists(id))
     }
 
-    if (order.status !== OrderStatus.IN_PROGRESS) {
+    if (order.username != username) {
       throw EntityNotFoundException(ValidationErrors.OrderSectionServiceBase.noEditableOrderExists(id))
     }
+    return order
+  }
 
-    if (order.username != username) {
+  internal fun findEditableOrder(id: UUID, username: String): Order {
+    val order = findOrder(id, username)
+    if (order.status !== OrderStatus.IN_PROGRESS) {
       throw EntityNotFoundException(ValidationErrors.OrderSectionServiceBase.noEditableOrderExists(id))
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/OrderService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/OrderService.kt
@@ -35,11 +35,7 @@ import java.util.*
 @EnableConfigurationProperties(
   FeatureFlags::class,
 )
-class OrderService(
-  val fmsService: FmsService,
-  private val featureFlags: FeatureFlags,
-  private val userCohortService: UserCohortService,
-) : OrderSectionServiceBase() {
+class OrderService(val fmsService: FmsService, private val featureFlags: FeatureFlags) : OrderSectionServiceBase() {
 
   fun createOrder(username: String, createRecord: CreateOrderDto): Order {
     val order = Order()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/AdditionalDocumentsControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/AdditionalDocumentsControllerTest.kt
@@ -370,6 +370,28 @@ class AdditionalDocumentsControllerTest : UpdateOrderIntegrationTestBase() {
     }
 
     @Test
+    fun `it should return an error if the order was created by the same cohort`() {
+      val order = createOrder()
+
+      val result = webTestClient.get()
+        .uri("/api/orders/${order.id}/document-type/${DocumentType.PHOTO_ID}/raw")
+        .headers(setAuthorisation("AUTH_ADM"))
+        .exchange()
+        .expectStatus()
+        .isNotFound
+        .expectBodyList(ErrorResponse::class.java)
+        .returnResult()
+
+      Assertions.assertThat(result.responseBody!!).contains(
+        ErrorResponse(
+          status = NOT_FOUND,
+          developerMessage = "An editable order with ${order.id} does not exist",
+          userMessage = "Not Found",
+        ),
+      )
+    }
+
+    @Test
     fun `it should return the raw document from the document management api`() {
       val order = createOrder()
       val bodyBuilder = createMultiPartBodyBuilder(mockFile())

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/AdditionalDocumentsControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/AdditionalDocumentsControllerTest.kt
@@ -370,28 +370,6 @@ class AdditionalDocumentsControllerTest : UpdateOrderIntegrationTestBase() {
     }
 
     @Test
-    fun `it should return an error if the order was created by the same cohort`() {
-      val order = createOrder()
-
-      val result = webTestClient.get()
-        .uri("/api/orders/${order.id}/document-type/${DocumentType.PHOTO_ID}/raw")
-        .headers(setAuthorisation("AUTH_ADM"))
-        .exchange()
-        .expectStatus()
-        .isNotFound
-        .expectBodyList(ErrorResponse::class.java)
-        .returnResult()
-
-      Assertions.assertThat(result.responseBody!!).contains(
-        ErrorResponse(
-          status = NOT_FOUND,
-          developerMessage = "An editable order with ${order.id} does not exist",
-          userMessage = "Not Found",
-        ),
-      )
-    }
-
-    @Test
     fun `it should return the raw document from the document management api`() {
       val order = createOrder()
       val bodyBuilder = createMultiPartBodyBuilder(mockFile())

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/AdditionalDocumentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/AdditionalDocumentServiceTest.kt
@@ -15,6 +15,7 @@ import org.junit.jupiter.params.provider.MethodSource
 import org.mockito.Mockito
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.`when`
+import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
@@ -32,11 +33,14 @@ import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.mo
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.Order
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.OrderParameters
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.OrderVersion
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.auth.Cohort
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.auth.UserCohort
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.dto.UpdateFileRequiredDto
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.dto.UpdateHavePhotoDto
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.DataDictionaryVersion
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.DocumentType
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.OrderStatus
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.Prison
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.RequestType
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.repository.OrderRepository
 import java.io.ByteArrayInputStream
@@ -48,7 +52,7 @@ import kotlin.collections.plus
 class AdditionalDocumentServiceTest : OrderSectionServiceTestBase() {
   private lateinit var service: AdditionalDocumentService
   private lateinit var client: DocumentApiClient
-
+  private lateinit var userCohortService: UserCohortService
   val username: String = "username"
   val mockOrderId = UUID.randomUUID()
   val mockVersionId = UUID.randomUUID()
@@ -65,6 +69,8 @@ class AdditionalDocumentServiceTest : OrderSectionServiceTestBase() {
     client = mock(DocumentApiClient::class.java)
     service = AdditionalDocumentService(client)
     service.orderRepo = repo
+    userCohortService = mock()
+    service.userCohortService = userCohortService
   }
 
   @Nested
@@ -161,6 +167,50 @@ class AdditionalDocumentServiceTest : OrderSectionServiceTestBase() {
                   doc,
                 ),
                 dataDictionaryVersion = mockDictionaryVersion,
+              ),
+            ),
+          ),
+        ),
+      )
+
+      // Mock the document api response
+      `when`(client.getDocument(mockOrderId.toString())).thenReturn(
+        ResponseEntity.ok().body(
+          Flux.just(InputStreamResource(ByteArrayInputStream("".toByteArray()))),
+        ),
+      )
+
+      // Get the document
+      val result = service.getDocument(mockOrderId, username, docType)
+
+      // Verify the document api was called
+      verify(client, times(1)).getDocument(doc.documentId.toString())
+    }
+
+    @Test
+    fun `it should return the object blob for draft order in the same cohort`() {
+      whenever(
+        userCohortService.getUserCohort(any()),
+      ).thenReturn(UserCohort(Cohort.PRISON, activeCaseLoadId = Prison.BEDFORD_PRISON.ids.first()))
+      // Mock an order with a single document
+      whenever(
+        repo.findById(mockOrderId),
+      ).thenReturn(
+        Optional.of(
+          Order(
+            id = mockOrderId,
+            versions = mutableListOf(
+              OrderVersion(
+                id = mockVersionId,
+                status = OrderStatus.IN_PROGRESS,
+                type = RequestType.REQUEST,
+                username = username + "Not",
+                orderId = mockOrderId,
+                additionalDocuments = mutableListOf(
+                  doc,
+                ),
+                dataDictionaryVersion = mockDictionaryVersion,
+                ownerCohort = Prison.BEDFORD_PRISON.name,
               ),
             ),
           ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/AdditionalDocumentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/AdditionalDocumentServiceTest.kt
@@ -145,7 +145,7 @@ class AdditionalDocumentServiceTest : OrderSectionServiceTestBase() {
     fun `it should return the object blob for submitted order`() {
       // Mock an order with a single document
       whenever(
-        orderRepo.findById(mockOrderId),
+        repo.findById(mockOrderId),
       ).thenReturn(
         Optional.of(
           Order(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/AdditionalDocumentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/AdditionalDocumentServiceTest.kt
@@ -140,6 +140,46 @@ class AdditionalDocumentServiceTest {
       // Verify the document api was called
       verify(client, times(1)).getDocument(doc.documentId.toString())
     }
+
+    @Test
+    fun `it should return the object blob for submitted order`() {
+      // Mock an order with a single document
+      whenever(
+        orderRepo.findById(mockOrderId),
+      ).thenReturn(
+        Optional.of(
+          Order(
+            id = mockOrderId,
+            versions = mutableListOf(
+              OrderVersion(
+                id = mockVersionId,
+                status = OrderStatus.SUBMITTED,
+                type = RequestType.REQUEST,
+                username = username,
+                orderId = mockOrderId,
+                additionalDocuments = mutableListOf(
+                  doc,
+                ),
+                dataDictionaryVersion = mockDictionaryVersion,
+              ),
+            ),
+          ),
+        ),
+      )
+
+      // Mock the document api response
+      `when`(client.getDocument(mockOrderId.toString())).thenReturn(
+        ResponseEntity.ok().body(
+          Flux.just(InputStreamResource(ByteArrayInputStream("".toByteArray()))),
+        ),
+      )
+
+      // Get the document
+      val result = service.getDocument(mockOrderId, username, docType)
+
+      // Verify the document api was called
+      verify(client, times(1)).getDocument(doc.documentId.toString())
+    }
   }
 
   @Nested

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/OrderServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/OrderServiceTest.kt
@@ -82,7 +82,7 @@ class OrderServiceTest {
     userCohortService = mock()
     val featureFlags = FeatureFlags(ddV6CourtMappings = true, dataDictionaryVersion = DataDictionaryVersion.DDV4)
 
-    service = OrderService(fmsService, featureFlags, userCohortService)
+    service = OrderService(fmsService, featureFlags)
     service.orderRepo = repo
     authentication = mock(AuthAwareAuthenticationToken::class.java)
     whenever(authentication.name).thenReturn("mockUser")
@@ -91,6 +91,7 @@ class OrderServiceTest {
     context.authentication = authentication
     SecurityContextHolder.setContext(context)
     whenever(repo.save(any<Order>())).thenReturn(TestUtilities.createReadyToSubmitOrder())
+    service.userCohortService = userCohortService
   }
 
   @Nested
@@ -724,7 +725,8 @@ class OrderServiceTest {
     @BeforeEach
     fun setup() {
       val featureFlags = FeatureFlags(ddV6CourtMappings = true, dataDictionaryVersion = DataDictionaryVersion.DDV5)
-      service = OrderService(fmsService, featureFlags, userCohortService)
+      service = OrderService(fmsService, featureFlags)
+      service.userCohortService = userCohortService
       service.orderRepo = repo
       whenever(repo.findById(order.id)).thenReturn(Optional.of(order))
       whenever(repo.save(order)).thenReturn(order)
@@ -1211,8 +1213,9 @@ class OrderServiceTest {
       @BeforeEach
       fun setup() {
         val featureFlags = FeatureFlags(ddV6CourtMappings = true, dataDictionaryVersion = DataDictionaryVersion.DDV5)
-        service = OrderService(fmsService, featureFlags, userCohortService)
+        service = OrderService(fmsService, featureFlags)
         service.orderRepo = repo
+        service.userCohortService = userCohortService
         whenever(repo.findById(orderInPast.id)).thenReturn(Optional.of(orderInPast))
         whenever(repo.save(orderInPast)).thenReturn(orderInPast)
       }


### PR DESCRIPTION
### Context

Ticket: https://dsdmoj.atlassian.net/browse/ELM-4966

Refactor to allow getDocument for submitted order


# Backend PR Checklist

These are items (excluding GitHub Checks) which should be confirmed before a branch is ready to merge.

- [x] Ensure backwards compatibility (did not remove existing code, only added new)
- [x] Did not remove/edit existing enum values
- [x] Added relevant automation tests (updated or new)
- [ ] Verified Serco Mapping changes are safe for production (e.g Postman)
- [ ] Relevant documentation is updated and linked
- [x] PR has been self-reviewed by the author
- [x] Reused existing components before creating new ones
- [x] Code refined to the best of your knowledge
- [x] Ticket number included in the description
- [ ] (If applicable) Ran frontend scenario tests against backend changes