### PR TITLE
ELM-4992: Search optimisation

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/dto/OrderSearchResultDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/models/dto/OrderSearchResultDto.kt
@@ -1,0 +1,40 @@
+package uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.dto
+
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.AddressType
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.OrderStatus
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.RequestType
+import java.time.OffsetDateTime
+import java.time.ZonedDateTime
+import java.util.UUID
+
+data class OrderSearchResultDeviceWearerDto(
+  val firstName: String? = null,
+  val lastName: String? = null,
+  val dateOfBirth: ZonedDateTime? = null,
+  val adultAtTimeOfInstallation: Boolean? = null,
+  val nomisId: String? = null,
+  val pncId: String? = null,
+  val deliusId: String? = null,
+  val prisonNumber: String? = null,
+  val homeOfficeReferenceNumber: String? = null,
+  val complianceAndEnforcementPersonReference: String? = null,
+  val courtCaseReferenceNumber: String? = null,
+)
+
+data class OrderSearchResultAddressDto(val addressType: AddressType, val addressLine3: String)
+
+data class OrderSearchResultMonitoringConditionsDto(
+  val startDate: ZonedDateTime? = null,
+  val endDate: ZonedDateTime? = null,
+)
+
+// Slimmer representation of Order
+data class OrderSearchResultDto(
+  val id: UUID,
+  val status: OrderStatus,
+  val type: RequestType,
+  val fmsResultDate: OffsetDateTime? = null,
+  val deviceWearer: OrderSearchResultDeviceWearerDto,
+  val addresses: List<OrderSearchResultAddressDto>,
+  val monitoringConditions: OrderSearchResultMonitoringConditionsDto,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/repository/OrderRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/repository/OrderRepository.kt
@@ -14,7 +14,8 @@ import java.util.*
 interface OrderRepository :
   PagingAndSortingRepository<Order, UUID>,
   JpaSpecificationExecutor<Order>,
-  JpaRepository<Order, UUID> {
+  JpaRepository<Order, UUID>,
+  OrderSearchRepository {
 
   @Query(
     """

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/repository/OrderSearchRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/repository/OrderSearchRepository.kt
@@ -1,0 +1,8 @@
+package uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.repository
+
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.criteria.OrderSearchCriteria
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.dto.OrderSearchResultDto
+
+interface OrderSearchRepository {
+  fun searchOrders(criteria: OrderSearchCriteria): List<OrderSearchResultDto>
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/repository/OrderSearchRepositoryImpl.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/repository/OrderSearchRepositoryImpl.kt
@@ -1,0 +1,175 @@
+package uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.repository
+
+import jakarta.persistence.EntityManager
+import jakarta.persistence.PersistenceContext
+import jakarta.persistence.Tuple
+import jakarta.persistence.criteria.CriteriaBuilder
+import jakarta.persistence.criteria.Join
+import jakarta.persistence.criteria.JoinType
+import jakarta.persistence.criteria.Predicate
+import jakarta.persistence.criteria.Root
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.Address
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.DeviceWearer
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.MonitoringConditions
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.OrderVersion
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.criteria.OrderSearchCriteria
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.dto.OrderSearchResultAddressDto
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.dto.OrderSearchResultDeviceWearerDto
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.dto.OrderSearchResultDto
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.dto.OrderSearchResultMonitoringConditionsDto
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.AddressType
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.OrderStatus
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.RequestType
+import java.time.OffsetDateTime
+import java.time.ZonedDateTime
+import java.util.UUID
+
+class OrderSearchRepositoryImpl(@PersistenceContext private val entityManager: EntityManager) : OrderSearchRepository {
+
+  override fun searchOrders(criteria: OrderSearchCriteria): List<OrderSearchResultDto> {
+    val cb = entityManager.criteriaBuilder
+    val query = cb.createTupleQuery()
+
+    val version = query.from(OrderVersion::class.java)
+    val deviceWearer: Join<OrderVersion, DeviceWearer> = version.join("deviceWearer", JoinType.LEFT)
+    val monitoringConditions: Join<OrderVersion, MonitoringConditions> =
+      version.join("monitoringConditions", JoinType.LEFT)
+    val primaryAddress: Join<OrderVersion, Address> = version.join("addresses", JoinType.LEFT)
+    primaryAddress.on(cb.equal(primaryAddress.get<AddressType>("addressType"), AddressType.PRIMARY))
+
+    query.multiselect(
+      version.get<UUID>("orderId").alias("orderId"),
+      version.get<OrderStatus>("status").alias("status"),
+      version.get<RequestType>("type").alias("type"),
+      version.get<OffsetDateTime>("fmsResultDate").alias("fmsResultDate"),
+      deviceWearer.get<String>("firstName").alias("firstName"),
+      deviceWearer.get<String>("lastName").alias("lastName"),
+      deviceWearer.get<ZonedDateTime>("dateOfBirth").alias("dateOfBirth"),
+      deviceWearer.get<Boolean>("adultAtTimeOfInstallation").alias("adultAtTimeOfInstallation"),
+      deviceWearer.get<String>("nomisId").alias("nomisId"),
+      deviceWearer.get<String>("pncId").alias("pncId"),
+      deviceWearer.get<String>("deliusId").alias("deliusId"),
+      deviceWearer.get<String>("prisonNumber").alias("prisonNumber"),
+      deviceWearer.get<String>("homeOfficeReferenceNumber").alias("homeOfficeReferenceNumber"),
+      deviceWearer.get<String>("complianceAndEnforcementPersonReference")
+        .alias("complianceAndEnforcementPersonReference"),
+      deviceWearer.get<String>("courtCaseReferenceNumber").alias("courtCaseReferenceNumber"),
+      primaryAddress.get<String>("addressLine3").alias("addressLine3"),
+      monitoringConditions.get<ZonedDateTime>("startDate").alias("startDate"),
+      monitoringConditions.get<ZonedDateTime>("endDate").alias("endDate"),
+    )
+
+    query.where(*buildPredicates(criteria, cb, query, version, deviceWearer).toTypedArray())
+
+    return entityManager.createQuery(query).resultList.map { it.toDto() }
+  }
+
+  private fun buildPredicates(
+    criteria: OrderSearchCriteria,
+    cb: CriteriaBuilder,
+    query: jakarta.persistence.criteria.CriteriaQuery<Tuple>,
+    version: Root<OrderVersion>,
+    deviceWearer: Join<OrderVersion, DeviceWearer>,
+  ): List<Predicate> {
+    val predicates = mutableListOf<Predicate>()
+
+    val latestVersion = query.subquery(Int::class.java)
+    val subqueryRoot = latestVersion.from(OrderVersion::class.java)
+    latestVersion.select(cb.max(subqueryRoot.get("versionId")))
+    latestVersion.where(cb.equal(subqueryRoot.get<UUID>("orderId"), version.get<UUID>("orderId")))
+    predicates.add(cb.equal(version.get<Int>("versionId"), latestVersion))
+
+    predicates.add(
+      cb.or(
+        cb.equal(version.get<OrderStatus>("status"), OrderStatus.SUBMITTED),
+        cb.equal(version.get<OrderStatus>("status"), OrderStatus.IN_PROGRESS),
+      ),
+    )
+
+    val normalizedKeyword = criteria.searchTerm.trim().replace(Regex("\\s+"), " ").lowercase()
+    if (normalizedKeyword.isNotEmpty()) {
+      val searchTermPredicates = normalizedKeyword.split(" ").map { keywordPart ->
+        isMatch(deviceWearer, cb, keywordPart)
+      }
+      predicates.add(cb.and(*searchTermPredicates.toTypedArray()))
+    }
+
+    val filter = criteria.tagFilter
+    if (filter.tagGroups.isNotEmpty()) {
+      val groupPredicates = filter.tagGroups.map { group ->
+        val groupRequirement = group.map { tag -> hasTag(cb, version, tag) }
+        cb.and(*groupRequirement.toTypedArray())
+      }
+      if (criteria.ownerCohort != null) {
+        val ownerCohortQuery = cb.equal(
+          cb.lower(version.get("ownerCohort")),
+          criteria.ownerCohort.lowercase(),
+        )
+        predicates.add(cb.or(cb.or(*groupPredicates.toTypedArray()), ownerCohortQuery))
+      } else {
+        predicates.add(cb.or(*groupPredicates.toTypedArray()))
+      }
+    }
+
+    if (filter.exclude.isNotEmpty()) {
+      val excludeTagPredicates = filter.exclude.map { tag -> cb.not(hasTag(cb, version, tag)) }
+      val notMatches = cb.and(*excludeTagPredicates.toTypedArray())
+      predicates.add(cb.or(notMatches, cb.isNull(version.get<String>("tags"))))
+    }
+
+    return predicates
+  }
+
+  private fun isMatch(
+    deviceWearer: Join<OrderVersion, DeviceWearer>,
+    cb: CriteriaBuilder,
+    keyword: String,
+  ): Predicate {
+    val searchableFields = listOf(
+      DeviceWearer::firstName.name,
+      DeviceWearer::lastName.name,
+      DeviceWearer::nomisId.name,
+      DeviceWearer::pncId.name,
+      DeviceWearer::deliusId.name,
+      DeviceWearer::prisonNumber.name,
+      DeviceWearer::homeOfficeReferenceNumber.name,
+      DeviceWearer::complianceAndEnforcementPersonReference.name,
+      DeviceWearer::courtCaseReferenceNumber.name,
+    )
+    return cb.or(
+      *searchableFields.map { field -> cb.like(cb.lower(deviceWearer.get(field)), keyword) }.toTypedArray(),
+    )
+  }
+
+  private fun hasTag(cb: CriteriaBuilder, version: Root<OrderVersion>, tag: String): Predicate {
+    val paddedTags = cb.concat(cb.concat(",", version.get("tags")), ",")
+    return cb.like(cb.lower(paddedTags), "%,${tag.lowercase()},%")
+  }
+
+  private fun Tuple.toDto(): OrderSearchResultDto = OrderSearchResultDto(
+    id = get("orderId", UUID::class.java),
+    status = get("status", OrderStatus::class.java),
+    type = get("type", RequestType::class.java),
+    fmsResultDate = get("fmsResultDate", OffsetDateTime::class.java),
+    deviceWearer = OrderSearchResultDeviceWearerDto(
+      firstName = get("firstName", String::class.java),
+      lastName = get("lastName", String::class.java),
+      dateOfBirth = get("dateOfBirth", ZonedDateTime::class.java),
+      adultAtTimeOfInstallation = get("adultAtTimeOfInstallation", Boolean::class.javaObjectType),
+      nomisId = get("nomisId", String::class.java),
+      pncId = get("pncId", String::class.java),
+      deliusId = get("deliusId", String::class.java),
+      prisonNumber = get("prisonNumber", String::class.java),
+      homeOfficeReferenceNumber = get("homeOfficeReferenceNumber", String::class.java),
+      complianceAndEnforcementPersonReference = get("complianceAndEnforcementPersonReference", String::class.java),
+      courtCaseReferenceNumber = get("courtCaseReferenceNumber", String::class.java),
+    ),
+    addresses = get("addressLine3", String::class.java)
+      ?.let { listOf(OrderSearchResultAddressDto(addressType = AddressType.PRIMARY, addressLine3 = it)) }
+      ?: emptyList(),
+    monitoringConditions = OrderSearchResultMonitoringConditionsDto(
+      startDate = get("startDate", ZonedDateTime::class.java),
+      endDate = get("endDate", ZonedDateTime::class.java),
+    ),
+  )
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/resource/OrderController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/resource/OrderController.kt
@@ -21,6 +21,7 @@ import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.mo
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.dto.CreateOrderDto
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.dto.OrderDto
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.dto.OrderInformationDto
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.dto.OrderSearchResultDto
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.dto.UpdateAmendOrderDto
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.dto.VersionInformationDTO
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.OrderListView
@@ -128,10 +129,10 @@ class OrderController(@Autowired val orderService: OrderService) {
   fun searchOrders(
     @RequestParam searchTerm: String = "",
     authentication: Authentication,
-  ): ResponseEntity<List<OrderDto>> {
+  ): ResponseEntity<List<OrderSearchResultDto>> {
     val orders = orderService.searchOrders(searchTerm, authentication as JwtAuthenticationToken)
 
-    return ResponseEntity(orders.map { convertToDto(it) }, HttpStatus.OK)
+    return ResponseEntity(orders, HttpStatus.OK)
   }
 
   @GetMapping("/orders/{orderId}/versions")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/OrderService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/OrderService.kt
@@ -19,6 +19,7 @@ import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.mo
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.criteria.TagFilter
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.dto.CreateOrderDto
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.dto.OrderInformationDto
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.dto.OrderSearchResultDto
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.dto.VersionInformationDTO
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.FmsOrderSource
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.NotifyingOrganisationDDv5
@@ -26,7 +27,6 @@ import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.mo
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.OrderStatus
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.Prison
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.RequestType
-import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.specification.OrderSearchSpecification
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.repository.projections.OrderVersionListInformation
 import java.time.ZonedDateTime
 import java.util.*
@@ -356,16 +356,14 @@ class OrderService(val fmsService: FmsService, private val featureFlags: Feature
     return results.map { it.toListInformationDto() }
   }
 
-  fun searchOrders(searchTerm: String, authentication: JwtAuthenticationToken): List<Order> {
+  fun searchOrders(searchTerm: String, authentication: JwtAuthenticationToken): List<OrderSearchResultDto> {
     val userCohort = userCohortService.getUserCohort(authentication)
 
     val filter = TagFilter.getTagFilterByUserCohort(userCohort)
     val ownerCohort = getOwnerCohort(userCohort)
     val searchCriteria = OrderSearchCriteria(searchTerm, filter, ownerCohort)
 
-    return orderRepo.findAll(
-      OrderSearchSpecification(searchCriteria),
-    )
+    return orderRepo.searchOrders(searchCriteria)
   }
 
   fun updateOrderOwner(orderId: UUID, token: JwtAuthenticationToken, newOwner: String): Order {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/OrderControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/OrderControllerTest.kt
@@ -31,6 +31,7 @@ import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.mo
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.OrderVersion
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.dto.OrderDto
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.dto.OrderInformationDto
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.dto.OrderSearchResultDto
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.dto.VersionInformationDTO
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.DataDictionaryVersion
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.DocumentType
@@ -754,7 +755,7 @@ class OrderControllerTest : IntegrationTestBase() {
         .exchange()
         .expectStatus()
         .isOk
-        .expectBodyList<OrderInformationDto>()
+        .expectBodyList(OrderSearchResultDto::class.java)
         .hasSize(1)
     }
 
@@ -832,7 +833,7 @@ class OrderControllerTest : IntegrationTestBase() {
         .exchange()
         .expectStatus()
         .isOk
-        .expectBodyList(OrderDto::class.java)
+        .expectBodyList(OrderSearchResultDto::class.java)
         .hasSize(1)
     }
 
@@ -846,7 +847,7 @@ class OrderControllerTest : IntegrationTestBase() {
         .exchange()
         .expectStatus()
         .isOk
-        .expectBodyList(OrderDto::class.java)
+        .expectBodyList(OrderSearchResultDto::class.java)
         .hasSize(0)
     }
 
@@ -860,7 +861,7 @@ class OrderControllerTest : IntegrationTestBase() {
         .exchange()
         .expectStatus()
         .isOk
-        .expectBodyList(OrderDto::class.java)
+        .expectBodyList(OrderSearchResultDto::class.java)
         .hasSize(1)
     }
 
@@ -882,7 +883,7 @@ class OrderControllerTest : IntegrationTestBase() {
         .exchange()
         .expectStatus()
         .isOk
-        .expectBodyList(OrderDto::class.java)
+        .expectBodyList(OrderSearchResultDto::class.java)
         .hasSize(0)
     }
 
@@ -896,7 +897,7 @@ class OrderControllerTest : IntegrationTestBase() {
         .exchange()
         .expectStatus()
         .isOk
-        .expectBodyList(OrderDto::class.java)
+        .expectBodyList(OrderSearchResultDto::class.java)
         .hasSize(0)
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/OrderControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/resource/OrderControllerTest.kt
@@ -911,7 +911,7 @@ class OrderControllerTest : IntegrationTestBase() {
         .exchange()
         .expectStatus()
         .isOk
-        .expectBodyList(OrderDto::class.java)
+        .expectBodyList(OrderSearchResultDto::class.java)
         .hasSize(1)
     }
 
@@ -925,7 +925,7 @@ class OrderControllerTest : IntegrationTestBase() {
         .exchange()
         .expectStatus()
         .isOk
-        .expectBodyList(OrderDto::class.java)
+        .expectBodyList(OrderSearchResultDto::class.java)
         .hasSize(0)
     }
 
@@ -940,7 +940,7 @@ class OrderControllerTest : IntegrationTestBase() {
         .exchange()
         .expectStatus()
         .isOk
-        .expectBodyList(OrderDto::class.java)
+        .expectBodyList(OrderSearchResultDto::class.java)
         .hasSize(2)
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/resources/OrderControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/resources/OrderControllerTest.kt
@@ -16,6 +16,9 @@ import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.mo
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.dto.CreateOrderDto
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.dto.OrderDto
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.dto.OrderInformationDto
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.dto.OrderSearchResultDeviceWearerDto
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.dto.OrderSearchResultDto
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.dto.OrderSearchResultMonitoringConditionsDto
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.DataDictionaryVersion
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.OrderListView
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.OrderStatus
@@ -204,118 +207,29 @@ class OrderControllerTest {
   fun `Search for orders given a full name`() {
     val orderId = UUID.randomUUID()
     val orderId2 = UUID.randomUUID()
-    val orderVersion = OrderVersion(
-      orderId = orderId,
-      username = "mockUser",
-      status = OrderStatus.SUBMITTED,
-      type = RequestType.REQUEST,
-      dataDictionaryVersion = mockDictionaryVersion,
-    )
-    val orderVersion2 = OrderVersion(
-      orderId = orderId2,
-      username = "mockUser",
-      status = OrderStatus.SUBMITTED,
-      type = RequestType.REQUEST,
-      dataDictionaryVersion = mockDictionaryVersion,
-    )
-    val orders: List<Order> = listOf(
-      Order(
+    val searchResults = listOf(
+      OrderSearchResultDto(
         id = orderId,
-        versions = mutableListOf(
-          orderVersion,
-        ),
+        status = OrderStatus.SUBMITTED,
+        type = RequestType.REQUEST,
+        deviceWearer = OrderSearchResultDeviceWearerDto(firstName = "Bob", lastName = "Smith"),
+        addresses = emptyList(),
+        monitoringConditions = OrderSearchResultMonitoringConditionsDto(),
       ),
-      Order(
+      OrderSearchResultDto(
         id = orderId2,
-        versions = mutableListOf(
-          orderVersion2,
-        ),
+        status = OrderStatus.SUBMITTED,
+        type = RequestType.REQUEST,
+        deviceWearer = OrderSearchResultDeviceWearerDto(firstName = "Bob", lastName = "Smith"),
+        addresses = emptyList(),
+        monitoringConditions = OrderSearchResultMonitoringConditionsDto(),
       ),
     )
 
-    `when`(orderService.searchOrders("Bob Smith", authentication)).thenReturn(orders)
-    `when`(authentication.name).thenReturn("mockUser")
+    `when`(orderService.searchOrders("Bob Smith", authentication)).thenReturn(searchResults)
 
     val result = controller.searchOrders("Bob Smith", authentication)
-    Assertions.assertThat(result.body).isEqualTo(
-      listOf(
-        OrderDto(
-          id = orderId,
-          additionalDocuments = mutableListOf(),
-          addresses = mutableListOf(),
-          contactDetails = null,
-          curfewConditions = null,
-          curfewReleaseDateConditions = null,
-          curfewTimeTable = mutableListOf(),
-          deviceWearer = null,
-          deviceWearerResponsibleAdult = null,
-          enforcementZoneConditions = mutableListOf(),
-          fmsResultId = null,
-          fmsResultDate = null,
-          installationAndRisk = null,
-          dapoClauses = mutableListOf(),
-          offences = mutableListOf(),
-          offenceAdditionalDetails = null,
-          interestedParties = null,
-          isValid = false,
-          mandatoryAttendanceConditions = mutableListOf(),
-          monitoringConditions = null,
-          monitoringConditionsAlcohol = null,
-          monitoringConditionsTrail = null,
-          status = OrderStatus.SUBMITTED,
-          type = RequestType.REQUEST,
-          username = "mockUser",
-          submittedBy = null,
-          variationDetails = null,
-          probationDeliveryUnit = null,
-          installationLocation = null,
-          installationAppointment = null,
-          mappa = null,
-          detailsOfInstallation = null,
-          dataDictionaryVersion = mockDictionaryVersion,
-          orderParameters = null,
-          versionId = orderVersion.id,
-          isOwner = true,
-        ),
-        OrderDto(
-          id = orderId2,
-          additionalDocuments = mutableListOf(),
-          addresses = mutableListOf(),
-          contactDetails = null,
-          curfewConditions = null,
-          curfewReleaseDateConditions = null,
-          curfewTimeTable = mutableListOf(),
-          deviceWearer = null,
-          deviceWearerResponsibleAdult = null,
-          enforcementZoneConditions = mutableListOf(),
-          fmsResultId = null,
-          fmsResultDate = null,
-          installationAndRisk = null,
-          dapoClauses = mutableListOf(),
-          offences = mutableListOf(),
-          offenceAdditionalDetails = null,
-          interestedParties = null,
-          isValid = false,
-          mandatoryAttendanceConditions = mutableListOf(),
-          monitoringConditions = null,
-          monitoringConditionsAlcohol = null,
-          monitoringConditionsTrail = null,
-          status = OrderStatus.SUBMITTED,
-          type = RequestType.REQUEST,
-          username = "mockUser",
-          submittedBy = null,
-          variationDetails = null,
-          probationDeliveryUnit = null,
-          installationLocation = null,
-          installationAppointment = null,
-          mappa = null,
-          detailsOfInstallation = null,
-          dataDictionaryVersion = mockDictionaryVersion,
-          orderParameters = null,
-          versionId = orderVersion2.id,
-          isOwner = true,
-        ),
-      ),
-    )
+
+    Assertions.assertThat(result.body).isEqualTo(searchResults)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/OrderServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/OrderServiceTest.kt
@@ -12,7 +12,6 @@ import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
-import org.mockito.ArgumentMatchers
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.never
 import org.mockito.Mockito.reset
@@ -58,7 +57,6 @@ import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.mo
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.fms.FmsMonitoringOrderSubmissionResult
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.fms.FmsSubmissionResult
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.fms.FmsSubmissionStrategyKind
-import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.specification.OrderSearchSpecification
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.repository.OrderRepository
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.repository.projections.OrderVersionListInformation
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.utilities.TestUtilities
@@ -675,17 +673,24 @@ class OrderServiceTest {
 
   @Test
   fun `Should be able to search for orders`() {
-    val mockOrder = TestUtilities.createReadyToSubmitOrder(startDate = mockStartDate, endDate = mockEndDate)
+    val mockResult = OrderSearchResultDto(
+      id = UUID.randomUUID(),
+      status = OrderStatus.IN_PROGRESS,
+      type = RequestType.REQUEST,
+      deviceWearer = OrderSearchResultDeviceWearerDto(firstName = "Bob", lastName = "Smith"),
+      addresses = emptyList(),
+      monitoringConditions = OrderSearchResultMonitoringConditionsDto(),
+    )
 
     val authentication = mock(JwtAuthenticationToken::class.java)
     whenever(userCohortService.getUserCohort(authentication)).thenReturn(
       UserCohort(Cohort.PRISON),
     )
-    whenever(repo.findAll(ArgumentMatchers.any(OrderSearchSpecification::class.java))).thenReturn(listOf(mockOrder))
+    whenever(repo.searchOrders(any())).thenReturn(listOf(mockResult))
 
     val result = service.searchOrders("Bob Smith", authentication)
 
-    assertThat(result).isEqualTo(listOf(mockOrder))
+    assertThat(result).isEqualTo(listOf(mockResult))
   }
 
   @Nested

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/OrderServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/OrderServiceTest.kt
@@ -40,6 +40,9 @@ import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.mo
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.auth.Cohort
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.auth.UserCohort
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.dto.CreateOrderDto
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.dto.OrderSearchResultDeviceWearerDto
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.dto.OrderSearchResultDto
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.dto.OrderSearchResultMonitoringConditionsDto
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.DataDictionaryVersion
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.DocumentType
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.FmsOrderSource
@@ -1428,6 +1431,28 @@ class OrderServiceTest {
       val result = service.getFmsMonitoringOrderPayload(mockOrder.id, mockOrder.versions.first().id)
 
       assertThat(result).isEqualTo("mockPayload")
+    }
+
+    @Test
+    fun `Should be able to search for orders`() {
+      val mockResult = OrderSearchResultDto(
+        id = UUID.randomUUID(),
+        status = OrderStatus.IN_PROGRESS,
+        type = RequestType.REQUEST,
+        deviceWearer = OrderSearchResultDeviceWearerDto(firstName = "Bob", lastName = "Smith"),
+        addresses = emptyList(),
+        monitoringConditions = OrderSearchResultMonitoringConditionsDto(),
+      )
+
+      val authentication = mock(JwtAuthenticationToken::class.java)
+      whenever(userCohortService.getUserCohort(authentication)).thenReturn(
+        UserCohort(Cohort.PRISON),
+      )
+      whenever(repo.searchOrders(any())).thenReturn(listOf(mockResult))
+
+      val result = service.searchOrders("Bob Smith", authentication)
+
+      assertThat(result).isEqualTo(listOf(mockResult))
     }
   }
 


### PR DESCRIPTION
### Context

Ticket: https://dsdmoj.atlassian.net/browse/ELM-XXXX

[Why are we making this change?]

Lisa reported search being slow
After taking a look, it was getting full orders when we only needed about 15 fields to satisfy the UI and the order retrieval query was using the Lazy strategy meaning we were battering the database with queries per association - e.g 50 expected orders = 1 + (50 x 28(assoc fields number was around this)), so around 1k db queries

### Changes proposed in this pull request

[What has been changed?]


# Backend PR Checklist

These are items (excluding GitHub Checks) which should be confirmed before a branch is ready to merge.

- [ ] Ensure backwards compatibility (did not remove existing code, only added new)
- [ ] Did not remove/edit existing enum values
- [ ] Added relevant automation tests (updated or new)
- [ ] Verified Serco Mapping changes are safe for production (e.g Postman)
- [ ] Relevant documentation is updated and linked
- [ ] PR has been self-reviewed by the author
- [ ] Reused existing components before creating new ones
- [ ] Code refined to the best of your knowledge
- [ ] Ticket number included in the description
- [ ] (If applicable) Ran frontend scenario tests against backend changes