### PR TITLE
route common platform orders to correct uri

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/client/FmsClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/client/FmsClient.kt
@@ -12,6 +12,7 @@ import org.springframework.web.reactive.function.client.bodyToMono
 import reactor.core.publisher.Mono
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.exception.CreateSercoEntityException
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.CaseState
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.FmsOrderSource
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.RequestType
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.fms.FmsAttachmentResponse
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.fms.FmsErrorResponse
@@ -22,12 +23,15 @@ import java.util.*
 class FmsClient(@Value("\${services.serco.url}") url: String, private val fmsAuthClient: FmsAuthClient) {
   private val webClient: WebClient = WebClient.builder().baseUrl(url).build()
 
-  fun createDeviceWearer(deviceWearerPayload: String, orderId: UUID): FmsResponse {
+  private fun resolvePath(orderSource: FmsOrderSource, cemoPath: String, commonPlatformPath: String): String =
+    if (orderSource == FmsOrderSource.CEMO) cemoPath else commonPlatformPath
+
+  private fun postFmsRequest(path: String, payload: String, orderId: UUID, errorContext: String): FmsResponse {
     val token = fmsAuthClient.getClientToken()
-    val result = webClient.post().uri("/x_seem_cemo/device_wearer/createDW")
+    return webClient.post().uri(path)
       .header(HttpHeaders.AUTHORIZATION, "Bearer $token")
       .contentType(MediaType.APPLICATION_JSON)
-      .bodyValue(deviceWearerPayload)
+      .bodyValue(payload)
       .retrieve()
       .onStatus(
         { t -> t.isError },
@@ -35,7 +39,7 @@ class FmsClient(@Value("\${services.serco.url}") url: String, private val fmsAut
           it.bodyToMono(FmsErrorResponse::class.java).flatMap { error ->
             Mono.error(
               CreateSercoEntityException(
-                "Error creating FMS Device Wearer for order: $orderId with error: ${error?.error?.detail}",
+                "Error $errorContext for order: $orderId with error: ${error?.error?.detail}",
               ),
             )
           }
@@ -44,82 +48,66 @@ class FmsClient(@Value("\${services.serco.url}") url: String, private val fmsAut
       .bodyToMono(FmsResponse::class.java)
       .onErrorResume(WebClientResponseException::class.java) { Mono.empty() }
       .block()!!
-    return result
   }
 
-  fun createMonitoringOrder(orderPayload: String, orderId: UUID): FmsResponse {
-    val token = fmsAuthClient.getClientToken()
-    val result = webClient.post().uri("/x_seem_cemo/monitoring_order/createMO")
-      .header(HttpHeaders.AUTHORIZATION, "Bearer $token")
-      .contentType(MediaType.APPLICATION_JSON)
-      .bodyValue(orderPayload)
-      .retrieve()
-      .onStatus(
-        { t -> t.isError },
-        {
-          it.bodyToMono(FmsErrorResponse::class.java).flatMap { error ->
-            Mono.error(
-              CreateSercoEntityException(
-                "Error creating FMS Monitoring Order for order: $orderId with error: ${error?.error?.detail}",
-              ),
-            )
-          }
-        },
-      )
-      .bodyToMono(FmsResponse::class.java)
-      .onErrorResume(WebClientResponseException::class.java) { Mono.empty() }
-      .block()!!
-    return result
+  fun createDeviceWearer(deviceWearerPayload: String, orderId: UUID, orderSource: FmsOrderSource): FmsResponse {
+    val path = resolvePath(
+      orderSource,
+      cemoPath = "/x_seem_cemo/device_wearer/createDW",
+      commonPlatformPath = "/x_seem_cemo/device_wearer/createCPDW",
+    )
+
+    return postFmsRequest(
+      path,
+      deviceWearerPayload,
+      orderId,
+      "creating FMS Device Wearer",
+    )
   }
 
-  fun updateDeviceWearer(deviceWearerPayload: String, orderId: UUID): FmsResponse {
-    val token = fmsAuthClient.getClientToken()
-    val result = webClient.post().uri("/x_seem_cemo/device_wearer/updateDW")
-      .header(HttpHeaders.AUTHORIZATION, "Bearer $token")
-      .contentType(MediaType.APPLICATION_JSON)
-      .bodyValue(deviceWearerPayload)
-      .retrieve()
-      .onStatus(
-        { t -> t.isError },
-        {
-          it.bodyToMono(FmsErrorResponse::class.java).flatMap { error ->
-            Mono.error(
-              CreateSercoEntityException(
-                "Error updating FMS Device Wearer for order: $orderId with error: ${error?.error?.detail}",
-              ),
-            )
-          }
-        },
-      )
-      .bodyToMono(FmsResponse::class.java)
-      .onErrorResume(WebClientResponseException::class.java) { Mono.empty() }
-      .block()!!
-    return result
+  fun createMonitoringOrder(orderPayload: String, orderId: UUID, orderSource: FmsOrderSource): FmsResponse {
+    val path = resolvePath(
+      orderSource,
+      cemoPath = "/x_seem_cemo/monitoring_order/createMO",
+      commonPlatformPath = "/x_seem_cemo/monitoring_order/createCPMO",
+    )
+
+    return postFmsRequest(
+      path,
+      orderPayload,
+      orderId,
+      errorContext = "creating FMS Monitoring Order",
+    )
   }
 
-  fun updateMonitoringOrder(orderPayload: String, orderId: UUID): FmsResponse {
-    val token = fmsAuthClient.getClientToken()
-    val result = webClient.post().uri("/x_seem_cemo/monitoring_order/updateMO")
-      .header(HttpHeaders.AUTHORIZATION, "Bearer $token")
-      .contentType(MediaType.APPLICATION_JSON)
-      .bodyValue(orderPayload)
-      .retrieve()
-      .onStatus(
-        { t -> t.isError },
-        {
-          it.bodyToMono(FmsErrorResponse::class.java).flatMap { error ->
-            Mono.error(
-              CreateSercoEntityException(
-                "Error updating FMS Monitoring Order for order: $orderId with error: ${error?.error?.detail}",
-              ),
-            )
-          }
-        },
-      )
-      .bodyToMono(FmsResponse::class.java)
-      .onErrorResume(WebClientResponseException::class.java) { Mono.empty() }
-      .block()!!
-    return result
+  fun updateDeviceWearer(deviceWearerPayload: String, orderId: UUID, orderSource: FmsOrderSource): FmsResponse {
+    val path = resolvePath(
+      orderSource,
+      cemoPath = "/x_seem_cemo/device_wearer/updateDW",
+      commonPlatformPath = "/x_seem_cemo/device_wearer/updateCPDW",
+    )
+
+    return postFmsRequest(
+      path,
+      deviceWearerPayload,
+      orderId,
+      errorContext = "updating FMS Device Wearer",
+    )
+  }
+
+  fun updateMonitoringOrder(orderPayload: String, orderId: UUID, orderSource: FmsOrderSource): FmsResponse {
+    val path = resolvePath(
+      orderSource,
+      cemoPath = "/x_seem_cemo/monitoring_order/updateMO",
+      commonPlatformPath = "/x_seem_cemo/monitoring_order/updateCPMO",
+    )
+
+    return postFmsRequest(
+      path,
+      orderPayload,
+      orderId,
+      errorContext = "updating FMS Monitoring Order",
+    )
   }
 
   fun createAttachment(
@@ -176,6 +164,7 @@ class FmsClient(@Value("\${services.serco.url}") url: String, private val fmsAut
           response.statusCode().isError -> {
             Mono.just(CaseState.UNKNOWN)
           }
+
           else -> {
             response.bodyToMono<FmsStateResponse>()
               .map { res ->

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/strategy/FmsOrderSubmissionStrategy.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/strategy/FmsOrderSubmissionStrategy.kt
@@ -25,10 +25,14 @@ class FmsOrderSubmissionStrategy(
   private val featureFlags: FeatureFlags,
 ) : FmsSubmissionStrategyBase(objectMapper, featureFlags) {
 
-  private fun submitCreateDeviceWearerRequest(deviceWearerPayload: String, orderId: UUID): Result<String> = try {
+  private fun submitCreateDeviceWearerRequest(
+    deviceWearerPayload: String,
+    orderId: UUID,
+    orderSource: FmsOrderSource,
+  ): Result<String> = try {
     Result(
       success = true,
-      data = fmsClient.createDeviceWearer(deviceWearerPayload, orderId).result.first().id,
+      data = fmsClient.createDeviceWearer(deviceWearerPayload, orderId, orderSource).result.first().id,
     )
   } catch (e: Exception) {
     Result(
@@ -37,10 +41,14 @@ class FmsOrderSubmissionStrategy(
     )
   }
 
-  private fun submitCreateMonitoringOrderRequest(monitoringOrderPayload: String, orderId: UUID): Result<String> = try {
+  private fun submitCreateMonitoringOrderRequest(
+    monitoringOrderPayload: String,
+    orderId: UUID,
+    orderSource: FmsOrderSource,
+  ): Result<String> = try {
     Result(
       success = true,
-      data = fmsClient.createMonitoringOrder(monitoringOrderPayload, orderId).result.first().id,
+      data = fmsClient.createMonitoringOrder(monitoringOrderPayload, orderId, orderSource).result.first().id,
     )
   } catch (e: Exception) {
     Result(
@@ -125,7 +133,7 @@ class FmsOrderSubmissionStrategy(
       )
     }
 
-    val submissionResult = this.submitCreateDeviceWearerRequest(serialiseResult.data!!, order.id)
+    val submissionResult = this.submitCreateDeviceWearerRequest(serialiseResult.data!!, order.id, orderSource)
 
     if (!submissionResult.success) {
       return FmsDeviceWearerSubmissionResult(
@@ -166,7 +174,11 @@ class FmsOrderSubmissionStrategy(
       )
     }
 
-    val submissionResult = this.submitCreateMonitoringOrderRequest(serialiseResult.data!!, order.id)
+    val submissionResult = this.submitCreateMonitoringOrderRequest(
+      serialiseResult.data!!,
+      order.id,
+      orderSource,
+    )
 
     if (!submissionResult.success) {
       return FmsMonitoringOrderSubmissionResult(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/strategy/FmsVariationSubmissionStrategy.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/strategy/FmsVariationSubmissionStrategy.kt
@@ -33,10 +33,14 @@ class FmsVariationSubmissionStrategy(
   val repo: FmsSubmissionResultRepository,
 ) : FmsSubmissionStrategyBase(objectMapper, featureFlags) {
 
-  private fun submitUpdateDeviceWearerRequest(deviceWearerPayload: String, orderId: UUID): Result<String> = try {
+  private fun submitUpdateDeviceWearerRequest(
+    deviceWearerPayload: String,
+    orderId: UUID,
+    orderSource: FmsOrderSource,
+  ): Result<String> = try {
     Result(
       success = true,
-      data = fmsClient.updateDeviceWearer(deviceWearerPayload, orderId).result.first().id,
+      data = fmsClient.updateDeviceWearer(deviceWearerPayload, orderId, orderSource).result.first().id,
     )
   } catch (e: Exception) {
     Result(
@@ -45,10 +49,14 @@ class FmsVariationSubmissionStrategy(
     )
   }
 
-  private fun submitUpdateMonitoringOrderRequest(monitoringOrderPayload: String, orderId: UUID): Result<String> = try {
+  private fun submitUpdateMonitoringOrderRequest(
+    monitoringOrderPayload: String,
+    orderId: UUID,
+    orderSource: FmsOrderSource,
+  ): Result<String> = try {
     Result(
       success = true,
-      data = fmsClient.updateMonitoringOrder(monitoringOrderPayload, orderId).result.first().id,
+      data = fmsClient.updateMonitoringOrder(monitoringOrderPayload, orderId, orderSource).result.first().id,
     )
   } catch (e: Exception) {
     Result(
@@ -127,7 +135,7 @@ class FmsVariationSubmissionStrategy(
       )
     }
 
-    val submissionResult = this.submitUpdateDeviceWearerRequest(serialiseResult.data!!, order.id)
+    val submissionResult = this.submitUpdateDeviceWearerRequest(serialiseResult.data!!, order.id, orderSource)
 
     if (!submissionResult.success) {
       return FmsDeviceWearerSubmissionResult(
@@ -179,7 +187,7 @@ class FmsVariationSubmissionStrategy(
       )
     }
 
-    val submissionResult = this.submitUpdateMonitoringOrderRequest(serialiseResult.data!!, order.id)
+    val submissionResult = this.submitUpdateMonitoringOrderRequest(serialiseResult.data!!, order.id, orderSource)
 
     if (!submissionResult.success) {
       return FmsMonitoringOrderSubmissionResult(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/client/FmsClientTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/client/FmsClientTest.kt
@@ -18,6 +18,7 @@ import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.in
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.integration.wiremock.SercoAuthMockServerExtension.Companion.sercoAuthApi
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.integration.wiremock.SercoMockApiExtension.Companion.sercoApi
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.CaseState
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.FmsOrderSource
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.enums.RequestType
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.fms.DeviceWearer
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.fms.ErrorResponse
@@ -25,6 +26,7 @@ import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.mo
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.fms.FmsAttachmentResult
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.fms.FmsErrorResponse
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.fms.FmsResponse
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.fms.FmsResult
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.fms.MonitoringOrder
 import java.io.ByteArrayInputStream
 import java.util.*
@@ -56,7 +58,7 @@ class FmsClientTest : IntegrationTestBase() {
 
       // When
       val exception = assertThrows<CreateSercoEntityException> {
-        fmsClient.createDeviceWearer(mockDeviceWearerPayload(), orderId)
+        fmsClient.createDeviceWearer(mockDeviceWearerPayload(), orderId, FmsOrderSource.CEMO)
       }
 
       // Then
@@ -80,13 +82,27 @@ class FmsClientTest : IntegrationTestBase() {
 
       // When
       val exception = assertThrows<CreateSercoEntityException> {
-        fmsClient.createDeviceWearer(mockDeviceWearerPayload(), orderId)
+        fmsClient.createDeviceWearer(mockDeviceWearerPayload(), orderId, FmsOrderSource.CEMO)
       }
 
       // Then
       assertThat(
         exception.message,
       ).isEqualTo("Error creating FMS Device Wearer for order: $orderId with error: Error detail")
+    }
+
+    @Test
+    fun `it should call the common platform endpoint when orderSource is COMMON_PLATFORM`() {
+      val orderId = UUID.randomUUID()
+      sercoAuthApi.stubGrantToken()
+      sercoApi.stubCreateCommonPlatformDeviceWearer(
+        status = HttpStatus.OK,
+        result = FmsResponse(result = listOf(FmsResult(message = "mock response", id = "1")), status = "200"),
+      )
+
+      val result = fmsClient.createDeviceWearer(mockDeviceWearerPayload(), orderId, FmsOrderSource.COMMON_PLATFORM)
+
+      assertThat(result.result.first().id).isEqualTo("1")
     }
   }
 
@@ -108,7 +124,7 @@ class FmsClientTest : IntegrationTestBase() {
 
       // When
       val exception = assertThrows<CreateSercoEntityException> {
-        fmsClient.createMonitoringOrder(mockMonitoringOrderPayload(), orderId)
+        fmsClient.createMonitoringOrder(mockMonitoringOrderPayload(), orderId, FmsOrderSource.CEMO)
       }
 
       // Then
@@ -132,13 +148,31 @@ class FmsClientTest : IntegrationTestBase() {
 
       // When
       val exception = assertThrows<CreateSercoEntityException> {
-        fmsClient.createMonitoringOrder(mockMonitoringOrderPayload(), orderId)
+        fmsClient.createMonitoringOrder(mockMonitoringOrderPayload(), orderId, FmsOrderSource.CEMO)
       }
 
       // Then
       assertThat(
         exception.message,
       ).isEqualTo("Error creating FMS Monitoring Order for order: $orderId with error: Error detail")
+    }
+
+    @Test
+    fun `it should call the common platform endpoint when orderSource is COMMON_PLATFORM`() {
+      val orderId = UUID.randomUUID()
+      sercoAuthApi.stubGrantToken()
+      sercoApi.stubCreateCommonPlatformMonitoringOrder(
+        status = HttpStatus.OK,
+        result = FmsResponse(result = listOf(FmsResult(message = "mock response", id = "1")), status = "200"),
+      )
+
+      val result = fmsClient.createMonitoringOrder(
+        mockMonitoringOrderPayload(),
+        orderId,
+        FmsOrderSource.COMMON_PLATFORM,
+      )
+
+      assertThat(result.result.first().id).isEqualTo("1")
     }
   }
 
@@ -160,7 +194,7 @@ class FmsClientTest : IntegrationTestBase() {
 
       // When
       val exception = assertThrows<CreateSercoEntityException> {
-        fmsClient.updateDeviceWearer(mockDeviceWearerPayload(), orderId)
+        fmsClient.updateDeviceWearer(mockDeviceWearerPayload(), orderId, FmsOrderSource.CEMO)
       }
 
       // Then
@@ -184,13 +218,27 @@ class FmsClientTest : IntegrationTestBase() {
 
       // When
       val exception = assertThrows<CreateSercoEntityException> {
-        fmsClient.updateDeviceWearer(mockDeviceWearerPayload(), orderId)
+        fmsClient.updateDeviceWearer(mockDeviceWearerPayload(), orderId, FmsOrderSource.CEMO)
       }
 
       // Then
       assertThat(
         exception.message,
       ).isEqualTo("Error updating FMS Device Wearer for order: $orderId with error: Error detail")
+    }
+
+    @Test
+    fun `it should call the common platform endpoint when orderSource is COMMON_PLATFORM`() {
+      val orderId = UUID.randomUUID()
+      sercoAuthApi.stubGrantToken()
+      sercoApi.stubUpdateCommonPlatformDeviceWearer(
+        status = HttpStatus.OK,
+        result = FmsResponse(result = listOf(FmsResult(message = "mock response", id = "1")), status = "200"),
+      )
+
+      val result = fmsClient.updateDeviceWearer(mockDeviceWearerPayload(), orderId, FmsOrderSource.COMMON_PLATFORM)
+
+      assertThat(result.result.first().id).isEqualTo("1")
     }
   }
 
@@ -212,7 +260,7 @@ class FmsClientTest : IntegrationTestBase() {
 
       // When
       val exception = assertThrows<CreateSercoEntityException> {
-        fmsClient.updateMonitoringOrder(mockMonitoringOrderPayload(), orderId)
+        fmsClient.updateMonitoringOrder(mockMonitoringOrderPayload(), orderId, FmsOrderSource.CEMO)
       }
 
       // Then
@@ -236,13 +284,31 @@ class FmsClientTest : IntegrationTestBase() {
 
       // When
       val exception = assertThrows<CreateSercoEntityException> {
-        fmsClient.updateMonitoringOrder(mockMonitoringOrderPayload(), orderId)
+        fmsClient.updateMonitoringOrder(mockMonitoringOrderPayload(), orderId, FmsOrderSource.CEMO)
       }
 
       // Then
       assertThat(
         exception.message,
       ).isEqualTo("Error updating FMS Monitoring Order for order: $orderId with error: Error detail")
+    }
+
+    @Test
+    fun `it should call the common platform endpoint when orderSource is COMMON_PLATFORM`() {
+      val orderId = UUID.randomUUID()
+      sercoAuthApi.stubGrantToken()
+      sercoApi.stubUpdateCommonPlatformMonitoringOrder(
+        status = HttpStatus.OK,
+        result = FmsResponse(result = listOf(FmsResult(message = "mock response", id = "1")), status = "200"),
+      )
+
+      val result = fmsClient.updateMonitoringOrder(
+        mockMonitoringOrderPayload(),
+        orderId,
+        FmsOrderSource.COMMON_PLATFORM,
+      )
+
+      assertThat(result.result.first().id).isEqualTo("1")
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/listener/CourtHearingEventListenerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/listener/CourtHearingEventListenerTest.kt
@@ -126,11 +126,11 @@ class CourtHearingEventListenerTest : IntegrationTestBase() {
   fun `Will process a valid payload with em details`() {
     val rootFilePath = "src/test/resources/json/SUSPS_community_order_inclusion"
     val rawMessage = generateRawHearingEventMessage("$rootFilePath/cp_payload.json")
-    sercoApi.stubCreateDeviceWearer(
+    sercoApi.stubCreateCommonPlatformDeviceWearer(
       HttpStatus.OK,
       FmsResponse(result = listOf(FmsResult(message = "", id = "MockDeviceWearerId"))),
     )
-    sercoApi.stubCreateMonitoringOrder(
+    sercoApi.stubCreateCommonPlatformMonitoringOrder(
       HttpStatus.OK,
       FmsResponse(result = listOf(FmsResult(message = "", id = "MockMonitoringOrderId"))),
     )
@@ -138,8 +138,6 @@ class CourtHearingEventListenerTest : IntegrationTestBase() {
     await().until { getNumberOfMessagesCurrentlyOnEventQueue() == 0 }
     assertThat(fmsSubmissionRepo.count().toInt()).isNotEqualTo(0)
   }
-
-  fun String.removeWhitespaceAndNewlines(): String = this.replace("(\"[^\"]*\")|\\s".toRegex(), "\$1")
 
   companion object {
     @JvmStatic
@@ -210,11 +208,11 @@ class CourtHearingEventListenerTest : IntegrationTestBase() {
       rawMessage = generateRawHearingEventMessage("$rootFilePath/cp_payload.json")
     }
 
-    sercoApi.stubCreateDeviceWearer(
+    sercoApi.stubCreateCommonPlatformDeviceWearer(
       HttpStatus.OK,
       FmsResponse(result = listOf(FmsResult(message = "", id = "MockDeviceWearerId"))),
     )
-    sercoApi.stubCreateMonitoringOrder(
+    sercoApi.stubCreateCommonPlatformMonitoringOrder(
       HttpStatus.OK,
       FmsResponse(result = listOf(FmsResult(message = "", id = "MockMonitoringOrderId"))),
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/wiremock/SercoMockApi.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/integration/wiremock/SercoMockApi.kt
@@ -46,15 +46,13 @@ class SercoMockApiServer : WireMockServer(WIREMOCK_PORT) {
   }
 
   private val objectMapper: ObjectMapper = ObjectMapper()
-  fun stubCreateDeviceWearer(status: HttpStatus, result: FmsResponse, errorResponse: FmsErrorResponse? = null) {
-    val body: String
-    if (errorResponse != null) {
-      body = objectMapper.writeValueAsString(errorResponse)
-    } else {
-      body = objectMapper.writeValueAsString(result)
-    }
+
+  private fun responseBody(result: Any, errorResponse: FmsErrorResponse?): String =
+    objectMapper.writeValueAsString(errorResponse ?: result)
+
+  private fun stubPostResponse(path: String, status: HttpStatus, body: String) {
     stubFor(
-      post(urlPathTemplate("/x_seem_cemo/device_wearer/createDW"))
+      post(urlPathTemplate(path))
         .willReturn(
           aResponse()
             .withHeader("Content-Type", "application/json")
@@ -66,74 +64,56 @@ class SercoMockApiServer : WireMockServer(WIREMOCK_PORT) {
     )
   }
 
-  fun stubCreateMonitoringOrder(status: HttpStatus, result: FmsResponse, errorResponse: FmsErrorResponse? = null) {
-    val body: String
-    if (errorResponse != null) {
-      body = objectMapper.writeValueAsString(errorResponse)
-    } else {
-      body = objectMapper.writeValueAsString(result)
-    }
-    stubFor(
-      post(urlPathTemplate("/x_seem_cemo/monitoring_order/createMO"))
-        .willReturn(
-          aResponse()
-            .withHeader("Content-Type", "application/json")
-            .withBody(
-              body,
-            )
-            .withStatus(status.value()),
-        ),
-    )
+  fun stubCreateDeviceWearer(status: HttpStatus, result: FmsResponse, errorResponse: FmsErrorResponse? = null) {
+    stubPostResponse("/x_seem_cemo/device_wearer/createDW", status, responseBody(result, errorResponse))
   }
 
   fun stubUpdateDeviceWearer(status: HttpStatus, result: FmsResponse, errorResponse: FmsErrorResponse? = null) {
-    val body: String
-    if (errorResponse != null) {
-      body = objectMapper.writeValueAsString(errorResponse)
-    } else {
-      body = objectMapper.writeValueAsString(result)
-    }
-    stubFor(
-      post(urlPathTemplate("/x_seem_cemo/device_wearer/updateDW"))
-        .willReturn(
-          aResponse()
-            .withHeader("Content-Type", "application/json")
-            .withBody(
-              body,
-            )
-            .withStatus(status.value()),
-        ),
-    )
+    stubPostResponse("/x_seem_cemo/device_wearer/updateDW", status, responseBody(result, errorResponse))
+  }
+
+  fun stubCreateMonitoringOrder(status: HttpStatus, result: FmsResponse, errorResponse: FmsErrorResponse? = null) {
+    stubPostResponse("/x_seem_cemo/monitoring_order/createMO", status, responseBody(result, errorResponse))
   }
 
   fun stubUpdateMonitoringOrder(status: HttpStatus, result: FmsResponse, errorResponse: FmsErrorResponse? = null) {
-    val body: String
-    if (errorResponse != null) {
-      body = objectMapper.writeValueAsString(errorResponse)
-    } else {
-      body = objectMapper.writeValueAsString(result)
-    }
-    stubFor(
-      post(urlPathTemplate("/x_seem_cemo/monitoring_order/updateMO"))
-        .willReturn(
-          aResponse()
-            .withHeader("Content-Type", "application/json")
-            .withBody(
-              body,
-            )
-            .withStatus(status.value()),
-        ),
-    )
+    stubPostResponse("/x_seem_cemo/monitoring_order/updateMO", status, responseBody(result, errorResponse))
+  }
+
+  fun stubCreateCommonPlatformDeviceWearer(
+    status: HttpStatus,
+    result: FmsResponse,
+    errorResponse: FmsErrorResponse? = null,
+  ) {
+    stubPostResponse("/x_seem_cemo/device_wearer/createCPDW", status, responseBody(result, errorResponse))
+  }
+
+  fun stubCreateCommonPlatformMonitoringOrder(
+    status: HttpStatus,
+    result: FmsResponse,
+    errorResponse: FmsErrorResponse? = null,
+  ) {
+    stubPostResponse("/x_seem_cemo/monitoring_order/createCPMO", status, responseBody(result, errorResponse))
+  }
+
+  fun stubUpdateCommonPlatformDeviceWearer(
+    status: HttpStatus,
+    result: FmsResponse,
+    errorResponse: FmsErrorResponse? = null,
+  ) {
+    stubPostResponse("/x_seem_cemo/device_wearer/updateCPDW", status, responseBody(result, errorResponse))
+  }
+
+  fun stubUpdateCommonPlatformMonitoringOrder(
+    status: HttpStatus,
+    result: FmsResponse,
+    errorResponse: FmsErrorResponse? = null,
+  ) {
+    stubPostResponse("/x_seem_cemo/monitoring_order/updateCPMO", status, responseBody(result, errorResponse))
   }
 
   fun stubSubmitAttachment(status: HttpStatus, result: FmsAttachmentResponse, errorResponse: FmsErrorResponse? = null) {
-    val body: String
-
-    if (errorResponse != null) {
-      body = objectMapper.writeValueAsString(errorResponse)
-    } else {
-      body = objectMapper.writeValueAsString(result)
-    }
+    val body = responseBody(result, errorResponse)
 
     stubFor(
       post(urlPathTemplate("/now/v1/attachment_csm/file"))
@@ -157,11 +137,7 @@ class SercoMockApiServer : WireMockServer(WIREMOCK_PORT) {
     result: FmsStateResponse,
     errorResponse: FmsErrorResponse? = null,
   ) {
-    val body = if (errorResponse != null) {
-      objectMapper.writeValueAsString(errorResponse)
-    } else {
-      objectMapper.writeValueAsString(result)
-    }
+    val body = responseBody(result, errorResponse)
     stubFor(
       get(urlEqualTo("/now/table/x_serg2_ems_csm_case/$caseId?sysparm_fields=state"))
         .willReturn(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/FmsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/FmsServiceTest.kt
@@ -139,8 +139,16 @@ class FmsServiceTest {
     val mockOrder = TestUtilities.createReadyToSubmitOrder()
 
     val mockFmsResponse = FmsResponse(result = listOf(FmsResult(id = mockOrder.id.toString())))
-    whenever(mockClient.createDeviceWearer(any(), eq(mockOrder.id))).thenReturn(mockFmsResponse)
-    whenever(mockClient.createMonitoringOrder(any(), eq(mockOrder.id))).thenReturn(mockFmsResponse)
+    whenever(
+      mockClient.createDeviceWearer(
+        any(),
+        eq(mockOrder.id),
+        eq(FmsOrderSource.CEMO),
+      ),
+    ).thenReturn(mockFmsResponse)
+    whenever(mockClient.createMonitoringOrder(any(), eq(mockOrder.id), eq(FmsOrderSource.CEMO))).thenReturn(
+      mockFmsResponse,
+    )
 
     service = FmsService(
       mockClient,
@@ -161,7 +169,7 @@ class FmsServiceTest {
     val payloadCaptor = argumentCaptor<String>()
     val orderIdCaptor = argumentCaptor<UUID>()
 
-    verify(mockClient).createDeviceWearer(payloadCaptor.capture(), orderIdCaptor.capture())
+    verify(mockClient).createDeviceWearer(payloadCaptor.capture(), orderIdCaptor.capture(), eq(FmsOrderSource.CEMO))
 
     assertThat(orderIdCaptor.firstValue).isEqualTo(mockOrder.id)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/strategy/FmsVariationSubmissionStrategyTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/strategy/FmsVariationSubmissionStrategyTest.kt
@@ -55,7 +55,7 @@ class FmsVariationSubmissionStrategyTest {
     objectMapper = jacksonObjectMapper()
     repo = mock(FmsSubmissionResultRepository::class.java)
 
-    whenever(mockClient.updateDeviceWearer(any(), any())).thenReturn(
+    whenever(mockClient.updateDeviceWearer(any(), any(), any())).thenReturn(
       FmsResponse(
         result = listOf(
           FmsResult(message = "mock response", id = "3"),
@@ -63,7 +63,7 @@ class FmsVariationSubmissionStrategyTest {
         status = "200",
       ),
     )
-    whenever(mockClient.updateMonitoringOrder(any(), any())).thenReturn(
+    whenever(mockClient.updateMonitoringOrder(any(), any(), any())).thenReturn(
       FmsResponse(
         result = listOf(
           FmsResult(message = "mock response", id = "1"),


### PR DESCRIPTION
### Context

Ticket: https://dsdmoj.atlassian.net/browse/ELM-4991

UP3/Serco is creating new set of createDW, createMO, updateDW and updateMO endpoint in aim to remove mandatory checks for common platform payload. We will need to call those endpoints for common platform generated EM order


# Backend PR Checklist

These are items (excluding GitHub Checks) which should be confirmed before a branch is ready to merge.

- [x] Ensure backwards compatibility (did not remove existing code, only added new)
- [x] Did not remove/edit existing enum values
- [x] Added relevant automation tests (updated or new)
- [x] Verified Serco Mapping changes are safe for production (e.g Postman)
- [x] Relevant documentation is updated and linked
- [x] PR has been self-reviewed by the author
- [x] Reused existing components before creating new ones
- [x] Code refined to the best of your knowledge
- [x] Ticket number included in the description
- [ ] (If applicable) Ran frontend scenario tests against backend changes