### PR TITLE
ELM-4495:Set default data dictionary version to DDV7 in prod

### DIFF
--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -13,7 +13,7 @@ generic-service:
     CP_FMS_INTEGRATION_ENABLED: false
     TAG_AT_SOURCE_ENABLED: false
     DDV6_COURT_MAPPINGS: true
-    SETTINGS_DATA_DICTIONARY_VERSION: DDV6
+    SETTINGS_DATA_DICTIONARY_VERSION: DDV7
     MANAGE_USER_URL: "https://manage-users-api.hmpps.service.justice.gov.uk/"
 
 


### PR DESCRIPTION
### Context

Ticket: https://dsdmoj.atlassian.net/browse/ELM-4495

[Why are we making this change?]

Set default data dictionary version to DDV7 in prod ready for DDV7 release

# Backend PR Checklist

These are items (excluding GitHub Checks) which should be confirmed before a branch is ready to merge.

- [ ] Ensure backwards compatibility (did not remove existing code, only added new)
- [ ] Did not remove/edit existing enum values
- [ ] Added relevant automation tests (updated or new)
- [ ] Verified Serco Mapping changes are safe for production (e.g Postman)
- [ ] Relevant documentation is updated and linked
- [ ] PR has been self-reviewed by the author
- [ ] Reused existing components before creating new ones
- [ ] Code refined to the best of your knowledge
- [ ] Ticket number included in the description
- [ ] (If applicable) Ran frontend scenario tests against backend changes