### PR TITLE
ELM-5019: Allow YOUTH_CUSTODY_SERVICE to look up by nomis number

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/DeviceWearerDetailsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/DeviceWearerDetailsService.kt
@@ -38,7 +38,8 @@ class DeviceWearerDetailsService(private val webClient: CorePersonRecordApi) : O
   }
 
   private fun fetchPersonRecord(notifyingOrganisation: String?, organisationSearchId: String, versionId: UUID) = when {
-    notifyingOrganisation == NotifyingOrganisationDDv5.PRISON.name ->
+    notifyingOrganisation == NotifyingOrganisationDDv5.PRISON.name ||
+      notifyingOrganisation == NotifyingOrganisationDDv5.YOUTH_CUSTODY_SERVICE.name ->
       webClient.getPersonByPrisonNumber(organisationSearchId, versionId)
     notifyingOrganisation == NotifyingOrganisationDDv5.PROBATION.name ->
       webClient.getPersonByCrn(organisationSearchId, versionId)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/DeviceWearerDetailsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringcreateanorderapi/service/DeviceWearerDetailsServiceTest.kt
@@ -8,10 +8,13 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import org.springframework.http.HttpStatus
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.client.CorePersonRecordApi
+import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.exception.BadRequestException
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.exception.CorePersonRecordDependencyException
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.exception.CorePersonRecordNotFoundException
 import uk.gov.justice.digital.hmpps.hmppselectronicmonitoringcreateanorderapi.models.Address
@@ -321,13 +324,21 @@ class DeviceWearerDetailsServiceTest {
       }.hasMessageContaining("unsupported")
     }
 
-    @Test
-    fun `throws bad request when notifying organisation is unsupported`() {
-      mockOrder.interestedParties!!.notifyingOrganisation = NotifyingOrganisationDDv5.HOME_OFFICE.name
+    @ParameterizedTest
+    @EnumSource(
+      value = NotifyingOrganisationDDv5::class,
+      names = ["PRISON", "YOUTH_CUSTODY_SERVICE", "PROBATION"],
+      mode = EnumSource.Mode.EXCLUDE,
+    )
+    fun `throws bad request when notifying organisation is unsupported`(
+      notifyingOrganisation: NotifyingOrganisationDDv5,
+    ) {
+      mockOrder.interestedParties!!.notifyingOrganisation = notifyingOrganisation.name
 
       assertThatThrownBy {
         service.storeDetails("value", mockOrderId, mockUsername)
-      }.hasMessageContaining("unsupported")
+      }.isInstanceOf(BadRequestException::class.java)
+        .hasMessageContaining("unsupported")
     }
 
     @Test


### PR DESCRIPTION
### Context

Ticket: https://dsdmoj.atlassian.net/browse/ELM-5019

[Why are we making this change?]

### Changes proposed in this pull request

Allow YOUTH_CUSTODY_SERVICE to look up by nomis number


# Backend PR Checklist

These are items (excluding GitHub Checks) which should be confirmed before a branch is ready to merge.

- [ ] Ensure backwards compatibility (did not remove existing code, only added new)
- [ ] Did not remove/edit existing enum values
- [ ] Added relevant automation tests (updated or new)
- [ ] Verified Serco Mapping changes are safe for production (e.g Postman)
- [ ] Relevant documentation is updated and linked
- [ ] PR has been self-reviewed by the author
- [ ] Reused existing components before creating new ones
- [ ] Code refined to the best of your knowledge
- [ ] Ticket number included in the description
- [ ] (If applicable) Ran frontend scenario tests against backend changes